### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Broot (pronounce "b-root")
+# Broot (pronounced "b-root")
 
 [![Build Status](https://travis-ci.org/Canop/broot.svg?branch=master)](https://travis-ci.org/Canop/broot)
 [![Chat on Miaou](https://miaou.dystroy.org/static/shields/room-en.svg?v=1)](https://miaou.dystroy.org/3?Code_et_Croissants)
@@ -27,7 +27,7 @@ Most useful keys for this:
 * the letters of what you're looking for
 * `<enter>` to select a directory (staying in broot)
 * `<esc>` to get back to the previous state or clear your search
-* `:c` to get back to the shell having cd to the selected directory ([see below](#use-broot-for-navigation))
+* `:c` to get back to the shell having `cd` to the selected directory ([see below](#use-broot-for-navigation))
 * `:q` if you just want to quit (`<esc>` works too)
 
 ### Never lose track of file hierarchy while you fuzzy search:
@@ -50,11 +50,11 @@ And if you look for a filename *ending* in `"abc"` then you may anchor the regex
 
 To toggle size display, you usually hit `:s`. Sizes are computed in the background, you don't have to wait for them when you navigate.
 
-### Apply a personal shorcut to a file:
+### Apply a personal shortcut to a file:
 
 ![size](img/20190128-edit.png)
 
-Just find the file you want to edit with a few keystrokes, type `:e`, then `<enter>` (you should define your prefered editor, see [documentation](documentation.md#verbs)).
+Just find the file you want to edit with a few keystrokes, type `:e`, then `<enter>` (you should define your preferred editor, see [documentation](documentation.md#verbs)).
 
 ### More...
 
@@ -110,7 +110,7 @@ But broot needs a companion function in the shell in order to be able to change 
 
 (you'll have to source the file or open a new terminal)
 
-With this addition, you can do just `br` to lauch broot, and typing `:c` then *enter* will cd for you. You can search and change directory in one command: `mylosthing:c`.
+With this addition, you can do just `br` to launch broot, and typing `:c` then *enter* will cd for you. You can search and change directory in one command: `mylosthing:c`.
 
 
 ## Development

--- a/documentation.md
+++ b/documentation.md
@@ -23,7 +23,7 @@ When you hit `<enter>`:
 * if there's none, and a directory is selected, this directory becomes the new root and the pattern is cleared
 * if there's no verb and a file is selected, `xdg-open` is called on the file
 
-Hitting ̀ <esc>` clears the current pattern, or brings you back to the previous root. If there was none, it quits broot.
+Hitting `<esc>` clears the current pattern, or brings you back to the previous root. If there was none, it quits broot.
 
 Hitting `?` brings you to the help screen.
 
@@ -56,7 +56,7 @@ Most verbs aren't based on an external application but calls internal functions:
 
 ### `:back` : get back to the previous state of the tree
 
-This is normally achieved with the ̀ esc` key but you might want to remap it.
+This is normally achieved with the `esc` key but you might want to remap it.
 
 ### `:cd` : cd to a directory
 
@@ -68,7 +68,7 @@ In the default configuration it's mapped to `c`.
 
 `:focus` makes the selected directory become the new displayed root.
 
-The difference with ̀just using `<enter>` is that the current filtering pattern is kept.
+The difference with just using `<enter>` is that the current filtering pattern is kept.
 
 In the default configuration, it's mapped to `g`.
 
@@ -136,7 +136,7 @@ In the default configuration, it's mapped to `s` and can be activated at launch 
 
 When broot starts, it checks for a configuration file in the standard location defined by your OS and creates one if there's none.
 
-You can see this location by opening the help with ̀`?`. You can also open it directly from the help screen by typing `:o`.
+You can see this location by opening the help with `?`. You can also open it directly from the help screen by typing `:o`.
 
 ## Passing commands as program argument
 


### PR DESCRIPTION
I fixed some typos and easy misspellings in the README.md and documentation.md files.