### PR TITLE
Detailed error message on invalid regex

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,7 +19,9 @@ custom_error! {pub ProgramError
 }
 
 custom_error! {pub RegexError
-    Parsing {source: regex::Error} = "Invalid Regular Expression",
+    Parsing {source: regex::Error} = @{
+        format!("Invalid Regular Expression: {}", source.to_string().lines().last().unwrap_or(""))
+    },
     UnknownFlag {bad: char} = "Unknown regular expression flag: {:?}",
 }
 


### PR DESCRIPTION
I also opened https://github.com/rust-lang/regex/issues/562 in the hope in will help avoid string manipulations on error messages in the future