### PR TITLE
Add C-n for next and C-p for previous selection

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -140,10 +140,10 @@ impl Command {
             Key::Ctrl('q') => {
                 self.action = Action::Quit;
             }
-            Key::Up => {
+            Key::Up | Key::Ctrl('p') => {
                 self.action = Action::MoveSelection(-1);
             }
-            Key::Down => {
+            Key::Down | Key::Ctrl('n') => {
                 self.action = Action::MoveSelection(1);
             }
             Key::F(5) => {

--- a/website/docs/documentation/usage.md
+++ b/website/docs/documentation/usage.md
@@ -25,7 +25,8 @@ The first line is called the root, and is currently selected.
 
 From here you may navigate using the following keys:
 
-* <kbd class=b>↓</kbd> or <kbd class=b>↑</kbd> : select the next or previous line
+* <kbd class=b>↓</kbd> or <kbd>ctrl</kbd> <kbd>n</kbd> : select the next line
+* <kbd class=b>↑</kbd> or <kbd>ctrl</kbd> <kbd>p</kbd> : select the previous line
 * <kbd class=b>⏎</kbd> on a simple file : leave broot and open the file using xdg-open
 * <kbd class=b>⏎</kbd> on a directory : focus the directory (i.e. make it the new root)
 * <kbd>esc</kbd> gets you back to the previous state (or leave broot if there's none)


### PR DESCRIPTION
This adds additional key bindings for selecting the next and previous lines. The used key bindings are the same as in e.g. [https://github.com/junegunn/fzf](url) and feel vim-like for me.

I also found [https://github.com/Canop/broot/issues/27](url) which requests a key binding to navigate to the previous line by pressing Shift+Tab, but I couldn't get any output from termion when pressing that key combination.