### PR TITLE
Add support for using backtab to select the previous match

### DIFF
--- a/src/browser_states.rs
+++ b/src/browser_states.rs
@@ -244,6 +244,13 @@ impl AppState for BrowserState {
                     tree.make_selection_visible(page_height);
                 }
                 Ok(AppStateCmdResult::Keep)
+            },
+            Action::Previous => {
+                if let Some(tree) = &mut self.filtered_tree {
+                    tree.try_select_previous_match();
+                    tree.make_selection_visible(page_height);
+                }
+                Ok(AppStateCmdResult::Keep)
             }
             _ => Ok(AppStateCmdResult::Keep),
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -34,6 +34,7 @@ pub enum Action {
     RegexEdit(String, String), // a regex being edited (core & flags)
     Back,                      // back to last app state, or clear pattern
     Next,                      // goes to the next matching entry
+    Previous,                  // goes to the previous matching entry
     Refresh,                   // refresh
     Help,                      // goes to help state
     Quit,                      // quit broot
@@ -147,6 +148,9 @@ impl Command {
         match key {
             KeyEvent::Char('\t') => {
                 self.action = Action::Next;
+            }
+            KeyEvent::BackTab => {
+                self.action = Action::Previous;
             }
             KeyEvent::Char('\n') => {
                 self.action = Action::from(&self.parts, true);

--- a/src/flat_tree.rs
+++ b/src/flat_tree.rs
@@ -341,6 +341,20 @@ impl Tree {
         }
         false
     }
+    pub fn try_select_previous_match(&mut self) -> bool {
+        for di in (0..self.lines.len()).rev() {
+            let idx = (self.selection + di) % self.lines.len();
+            let line = &self.lines[idx];
+            if !line.is_selectable() {
+                continue;
+            }
+            if line.score > 0 {
+                self.selection = idx;
+                return true;
+            }
+        }
+        false
+    }
     pub fn has_dir_missing_size(&self) -> bool {
         if !self.options.show_sizes {
             return false;


### PR DESCRIPTION
This PR adds the ability to use backtab (`Shift+Tab`) to select the previous match as requested in [Issue 27](https://github.com/Canop/broot/issues/27).
I tried to implement this a while ago, but couldn't find a way to get the key combination working. I then created a minimal test case for this key combination using crossterm and it still didn't work.
Then I tried another terminal emulator and finally got it working.

To conclude:

- This didn't work in my testing with konsole (may be related to my settings, but I couldn't make the key combination `Shift+Tab` work in konsole). Maybe someone else can test this change with konsole to see if it works with their settings.

- This works in my current terminal emulator alacritty without any further setup required.

This PR also potentially obsoletes [#52 ](https://github.com/Canop/broot/pull/52), as I created that one to have an option for selecting the previous match without arrow keys (they are far away :)) while I was trying to find a way to get backtab working.