### PR TITLE
bash: replace `cat` invocation with built-in

### DIFF
--- a/src/shell_bash.rs
+++ b/src/shell_bash.rs
@@ -33,7 +33,7 @@ function br {
     if [ "$code" != 0 ]; then
 	return "$code"
     fi
-    d=$(cat "$f")
+    d=$(<"$f")
     rm -f "$f"
     eval "$d"
 }


### PR DESCRIPTION
In bash and zsh, `$(<x)` expands to the contents of the file `x` without needing to invoke a subprocess.

Shellcheck passes for bash. I don't have a zsh shellcheck, but I did confirm that it works and it is a documented feature.

Shellcheck warns this is undefined for POSIX sh and unsupported by dash, but the script doesn't claim to be supported by those as it is.

I'm not a fish user, but I don't see a similar operator for fish while skimming its manual.