### PR TITLE
Replace up- and downward arrow symbols in help

### DIFF
--- a/src/help_content.rs
+++ b/src/help_content.rs
@@ -18,7 +18,7 @@ See *https://dystroy.org/broot* for a complete guide.
 `<esc>` gets you back to the previous state.
 Typing some letters searches the tree and selects the most relevant file.
 To use a regular expression, use a slash at start or end eg `/j(ava|s)$`.
-The **🡑** and **🡓** arrow keys can be used to change selection.
+The **↑** and **↓** arrow keys can be used to change selection.
 The mouse can be used to select (on click) or open (on double-click).
 
 ## Verbs


### PR DESCRIPTION
The proposed symbols probably have much better font coverage (Unicode block in Basic Plane rather than in Supplementary one), at least on my systems.