### PR TITLE
docs - add Homebrew to installation instructions

### DIFF
--- a/website/docs/documentation/installation.md
+++ b/website/docs/documentation/installation.md
@@ -35,6 +35,12 @@ Fetch the Canop/broot repository, move to the broot directory, then run
 !!! Note
 	Windows users: broot may need additional rights at first use in order to write its configuration file
 
+# Homebrew
+
+If you're using [homebrew](https://brew.sh/), you can use the `brew install` command:
+
+    brew install broot
+
 # Installation Completion : the `br` shell function
 
 broot is convenient to find a directory then `cd` to it, which is done using `<alt><enter>` or `:cd`.


### PR DESCRIPTION
Just lifted the Homebrew section from the [exa docs](https://github.com/ogham/exa/blob/master/README.md). Feels pretty standard to have instructions per package manager.

Project looks great, btw. 