### PR TITLE
Use local variables in br shell function.

### DIFF
--- a/src/shell_install/bash.rs
+++ b/src/shell_install/bash.rs
@@ -44,23 +44,23 @@ const BASH_FUNC: &str = r#"
 # It's needed because some shell commands, like `cd`,
 # have no useful effect if executed in a subshell.
 function br {
-    f=$(mktemp)
+    local command_file=$(mktemp)
     (
 	set +e
-	broot --outcmd "$f" "$@"
-	code=$?
-	if [ "$code" != 0 ]; then
-	    rm -f "$f"
-	    exit "$code"
+	broot --outcmd "${command_file}" "${@}"
+	local error_code=$?
+	if [ "${error_code}" -ne 0 ]; then
+	    rm -f "${command_file}"
+	    exit "${error_code}"
 	fi
     )
-    code=$?
-    if [ "$code" != 0 ]; then
-	return "$code"
+    local error_code=$?
+    if [ "${error_code}" -ne 0 ]; then
+	return "${error_code}"
     fi
-    d=$(<"$f")
-    rm -f "$f"
-    eval "$d"
+    local command_str=$(<"${command_file}")
+    rm -f "${command_file}"
+    eval "${command_str}"
 }
 "#;
 

--- a/src/shell_install/fish.rs
+++ b/src/shell_install/fish.rs
@@ -35,15 +35,15 @@ const FISH_FUNC: &str = r#"
 # It's needed because some shell commands, like `cd`,
 # have no useful effect if executed in a subshell.
 function br
-    set f (mktemp)
-    broot --outcmd $f $argv
+    set -l command_file (mktemp)
+    broot --outcmd $command_file $argv
     if test $status -ne 0
-        rm -f "$f"
-        return "$code"
+        rm -f "$command_file"
+        return "$status"
     end
-    set d (cat "$f")
-    rm -f "$f"
-    eval "$d"
+    set -l command_str (cat "$command_file")
+    rm -f "$command_file"
+    eval "$command_str"
 end
 "#;
 


### PR DESCRIPTION
Improve br shell function:
  - use local variable to prevent accidental overwriting variables
    set by the user in the current shell
  - rename variables to a more descriptive name
  - use $status instead of undefined $code in fish br function