### PR TITLE
Numerous minor refactorings

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,4 +1,3 @@
-
 use crate::{
     app_context::AppContext,
     browser_states::BrowserState,
@@ -19,7 +18,7 @@ pub enum AppStateCmdResult {
     NewState(Box<dyn AppState>, Command),
     PopStateAndReapply, // the state asks the command be executed on a previous state
     PopState,
-    RefreshState{clear_cache: bool},
+    RefreshState { clear_cache: bool },
 }
 
 impl AppStateCmdResult {
@@ -47,7 +46,6 @@ impl From<Launchable> for AppStateCmdResult {
 /// a whole application state, stackable to allow reverting
 ///  to a previous one
 pub trait AppState {
-
     fn apply(
         &mut self,
         cmd: &mut Command,
@@ -55,28 +53,16 @@ pub trait AppState {
         con: &AppContext,
     ) -> Result<AppStateCmdResult, ProgramError>;
 
-    fn can_execute(
-        &self,
-        verb_index: usize,
-        con: &AppContext,
-    ) -> bool;
+    fn can_execute(&self, verb_index: usize, con: &AppContext) -> bool;
 
     fn refresh(&mut self, screen: &Screen, con: &AppContext) -> Command;
 
-    fn do_pending_task(
-        &mut self,
-        screen: &mut Screen,
-        tl: &TaskLifetime
-    );
+    fn do_pending_task(&mut self, screen: &mut Screen, tl: &TaskLifetime);
 
     fn has_pending_task(&self) -> bool;
 
-    fn display(
-        &mut self,
-        w: &mut W,
-        screen: &Screen,
-        con: &AppContext
-    ) -> Result<(), ProgramError>;
+    fn display(&mut self, w: &mut W, screen: &Screen, con: &AppContext)
+        -> Result<(), ProgramError>;
 
     fn write_flags(
         &self,
@@ -92,5 +78,4 @@ pub trait AppState {
         screen: &Screen,
         con: &AppContext,
     ) -> Result<(), ProgramError>;
-
 }

--- a/src/browser_verbs.rs
+++ b/src/browser_verbs.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        app_state::{AppStateCmdResult},
         app_context::AppContext,
+        app_state::AppStateCmdResult,
         browser_states::BrowserState,
         commands::Command,
         errors::ProgramError,
@@ -26,7 +26,7 @@ fn focus_path(path: PathBuf, screen: &mut Screen, tree: &Tree) -> AppStateCmdRes
             screen,
             &TaskLifetime::unlimited(),
         ),
-        Command::from_pattern(&tree.options.pattern),
+        Command::from(&tree.options.pattern),
     )
 }
 
@@ -55,7 +55,7 @@ impl VerbExecutor for BrowserState {
             }
             ":focus_root" => focus_path(PathBuf::from("/"), screen, self.displayed_tree()),
             ":up_tree" => match self.displayed_tree().root().parent() {
-                Some(path) => focus_path(path.to_path_buf(), screen,self.displayed_tree()),
+                Some(path) => focus_path(path.to_path_buf(), screen, self.displayed_tree()),
                 None => AppStateCmdResult::DisplayError("no parent found".to_string()),
             },
             ":focus_user_home" => match UserDirs::new() {
@@ -105,7 +105,7 @@ impl VerbExecutor for BrowserState {
                 external::print_path(&self.displayed_tree().selected_line().target(), con)?
             }
             ":print_tree" => external::print_tree(&self.displayed_tree(), screen, con)?,
-            ":refresh" => AppStateCmdResult::RefreshState{clear_cache: true},
+            ":refresh" => AppStateCmdResult::RefreshState { clear_cache: true },
             ":select_first" => {
                 self.displayed_tree_mut().try_select_first();
                 AppStateCmdResult::Keep
@@ -138,14 +138,18 @@ impl VerbExecutor for BrowserState {
             ":total_search" => {
                 if let Some(tree) = &self.filtered_tree {
                     if tree.total_search {
-                        AppStateCmdResult::DisplayError("search was already total - all children have been rated".to_owned())
+                        AppStateCmdResult::DisplayError(
+                            "search was already total - all children have been rated".to_owned(),
+                        )
                     } else {
                         self.pending_pattern = tree.options.pattern.clone();
                         self.total_search_required = true;
                         AppStateCmdResult::Keep
                     }
                 } else {
-                    AppStateCmdResult::DisplayError("this verb can be used only after a search".to_owned())
+                    AppStateCmdResult::DisplayError(
+                        "this verb can be used only after a search".to_owned(),
+                    )
                 }
             }
             ":quit" => AppStateCmdResult::Quit,
@@ -158,4 +162,3 @@ impl VerbExecutor for BrowserState {
         })
     }
 }
-

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -5,11 +5,7 @@
 
 use std::{fmt, mem};
 
-use crate::{
-    errors::RegexError,
-    fuzzy_patterns::FuzzyPattern,
-    regex_patterns::RegexPattern,
-};
+use crate::{errors::RegexError, fuzzy_patterns::FuzzyPattern, regex_patterns::RegexPattern};
 
 #[derive(Debug, Clone)]
 pub enum Pattern {
@@ -78,10 +74,8 @@ impl Pattern {
 }
 
 /// A Match is a positive result of pattern matching
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Match {
     pub score: i32, // score of the match, guaranteed strictly positive, bigger is better
     pub pos: Vec<usize>, // positions of the matching chars
 }
-
-

--- a/src/task_sync.rs
+++ b/src/task_sync.rs
@@ -3,9 +3,12 @@ use std::sync::{
     Arc,
 };
 
+use lazy_static::lazy_static;
+
 /// a TL initialized from an Arc<AtomicUsize> stays
 ///  alive as long as the passed arc doesn't change.
 /// When it changes, is_expired returns true
+#[derive(Debug, Clone)]
 pub struct TaskLifetime {
     initial_value: usize,
     external_value: Arc<AtomicUsize>,
@@ -18,16 +21,16 @@ impl TaskLifetime {
             external_value,
         }
     }
-    pub fn clone(&self) -> TaskLifetime {
-        TaskLifetime {
-            initial_value: self.initial_value,
-            external_value: Arc::clone(&self.external_value),
-        }
-    }
     pub fn unlimited() -> TaskLifetime {
+        // Use a global static Arc<AtomicUsize> so that we don't have to
+        // allocate more than once
+        lazy_static! {
+            static ref ZERO: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        }
+
         TaskLifetime {
             initial_value: 0,
-            external_value: Arc::new(AtomicUsize::new(0)),
+            external_value: ZERO.clone(),
         }
     }
     pub fn is_expired(&self) -> bool {


### PR DESCRIPTION
- Fixed many unidomatic uses of "if let Some(x) = thing"
- Added standard trait implementations and other interface refactorings (for instance, moving "from(thing)" to From<Thing>. All of these do not affect the use of these interfaces.
- Replaced &Box<dyn Trait> with &dyn Trait, where relevant.
- App::run and App::end now take App by value, to enforce that they should only be called once.
- Replaced `loop` with `for event in rx_events` in App::run.
- Touched files were rustfmt'd