### PR TITLE
website: add information on installing broot via MacPorts

### DIFF
--- a/website/docs/documentation/installation.md
+++ b/website/docs/documentation/installation.md
@@ -43,6 +43,15 @@ If you're using [homebrew](https://brew.sh/), you can use the `brew install` com
 
 *note: the brew formula is maintained by a third party*
 
+# MacPorts
+
+You can also install broot via [MacPorts](https://www.macports.org):
+
+    sudo port selfupdate
+    sudo port install broot
+
+*note: the MacPorts port for broot is also maintained by a third party.*
+
 # Installation Completion : the `br` shell function
 
 broot is convenient to find a directory then `cd` to it, which is done using `<alt><enter>` or `:cd`.


### PR DESCRIPTION
broot is now present in MacPorts; adding instruction for installing it that way to the website docs.