### PR TITLE
Added write cleanup methods to ensure the terminal is correctly restored

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -35,7 +35,7 @@ use {
     termimad::EventSource,
 };
 
-// Helper function for type inference: queue a Command but return Result<()>
+/// Helper function for type inference: queue a Command but return Result<()>
 #[inline]
 fn just_queue(mut writer: impl Write, command: impl crossterm::Command) -> crossterm::Result<()> {
     writer.queue(command).map(move |_| ())

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,15 +1,13 @@
-use {
-    crate::{
-        app_context::AppContext,
-        browser_states::BrowserState,
-        commands::Command,
-        errors::{ProgramError, TreeBuildError},
-        external::Launchable,
-        screens::Screen,
-        task_sync::TaskLifetime,
-    },
-    std::io::Write,
+use crate::{
+    app_context::AppContext,
+    browser_states::BrowserState,
+    commands::Command,
+    errors::{ProgramError, TreeBuildError},
+    external::Launchable,
+    screens::Screen,
+    task_sync::TaskLifetime,
 };
+use std::io::Write;
 
 /// Result of applying a command to a state
 pub enum AppStateCmdResult {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,12 +1,14 @@
-use crate::{
-    app_context::AppContext,
-    browser_states::BrowserState,
-    commands::Command,
-    errors::{ProgramError, TreeBuildError},
-    external::Launchable,
-    io::W,
-    screens::Screen,
-    task_sync::TaskLifetime,
+use {
+    crate::{
+        app_context::AppContext,
+        browser_states::BrowserState,
+        commands::Command,
+        errors::{ProgramError, TreeBuildError},
+        external::Launchable,
+        screens::Screen,
+        task_sync::TaskLifetime,
+    },
+    std::io::Write,
 };
 
 /// Result of applying a command to a state
@@ -61,19 +63,23 @@ pub trait AppState {
 
     fn has_pending_task(&self) -> bool;
 
-    fn display(&mut self, w: &mut W, screen: &Screen, con: &AppContext)
-        -> Result<(), ProgramError>;
+    fn display(
+        &mut self,
+        w: &mut dyn Write,
+        screen: &Screen,
+        con: &AppContext,
+    ) -> Result<(), ProgramError>;
 
     fn write_flags(
         &self,
-        w: &mut W,
+        w: &mut dyn Write,
         screen: &mut Screen,
         con: &AppContext,
     ) -> Result<(), ProgramError>;
 
     fn write_status(
         &self,
-        w: &mut W,
+        w: &mut dyn Write,
         cmd: &Command,
         screen: &Screen,
         con: &AppContext,

--- a/src/browser_states.rs
+++ b/src/browser_states.rs
@@ -241,9 +241,7 @@ impl AppState for BrowserState {
                 if invocation.name.is_empty() {
                     Status::new(
                         task,
-                        mad_inline!(
-                            "Type a verb then *enter* to execute it (*?* for the list of verbs)"
-                        ),
+                        mad_inline!("Type a verb then *enter* to execute it (*?* for the list of verbs)"),
                         false,
                     )
                     .display(&mut w, screen)

--- a/src/displayable_tree.rs
+++ b/src/displayable_tree.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
-        errors::ProgramError,
         file_sizes::FileSize,
         flat_tree::{LineType, Tree, TreeLine},
+        errors::ProgramError,
         patterns::Pattern,
         skin::Skin,
     },
@@ -18,7 +18,11 @@ use {
 };
 
 #[cfg(unix)]
-use {crate::permissions, std::os::unix::fs::MetadataExt, umask::*};
+use {
+    crate::permissions,
+    std::os::unix::fs::MetadataExt,
+    umask::*,
+};
 
 /// declare a style named `$dst` which is usually a reference to the `$src`
 /// skin but, in case `selected` is true, is a clone with background changed
@@ -38,6 +42,7 @@ macro_rules! cond_bg {
     };
 }
 
+
 /// A tree wrapper which can be used either
 /// - to write on the screen in the application,
 /// - or to write in a file or an exported string.
@@ -55,6 +60,7 @@ pub struct DisplayableTree<'s, 't> {
 }
 
 impl<'s, 't> DisplayableTree<'s, 't> {
+
     pub fn out_of_app(tree: &'t Tree, skin: &'s Skin, width: u16) -> DisplayableTree<'s, 't> {
         DisplayableTree {
             tree,
@@ -202,9 +208,7 @@ impl<'s, 't> DisplayableTree<'s, 't> {
         if idx == 0 {
             style.queue_str(f, &line.path.to_string_lossy())?;
         } else {
-            pattern
-                .style(&line.name, &style, &char_match_style)
-                .write_on(f)?;
+            pattern.style(&line.name, &style, &char_match_style).write_on(f)?;
         }
         match &line.line_type {
             LineType::Dir => {
@@ -281,19 +285,12 @@ impl<'s, 't> DisplayableTree<'s, 't> {
                             self.write_mode(f, line.mode(), selected)?;
                             let owner = permissions::user_name(line.metadata.uid());
                             cond_bg!(owner_style, self, selected, self.skin.owner);
-                            owner_style.queue(
-                                f,
-                                format!(" {:w$}", &owner, w = user_group_max_lengths.0,),
-                            )?;
+                            owner_style.queue(f, format!(" {:w$}", &owner, w = user_group_max_lengths.0,))?;
                             let group = permissions::group_name(line.metadata.gid());
                             cond_bg!(group_style, self, selected, self.skin.group);
-                            group_style.queue(
-                                f,
-                                format!(" {:w$} ", &group, w = user_group_max_lengths.1,),
-                            )?;
+                            group_style.queue(f, format!(" {:w$} ", &group, w = user_group_max_lengths.1,))?;
                         } else {
-                            let length =
-                                9 + 1 + user_group_max_lengths.0 + 1 + user_group_max_lengths.1 + 1;
+                            let length = 9 + 1 +user_group_max_lengths.0 + 1 + user_group_max_lengths.1 + 1;
                             for _ in 0..length {
                                 self.skin.tree.queue_str(f, "─")?;
                             }
@@ -348,3 +345,4 @@ fn user_group_max_lengths(tree: &Tree) -> (usize, usize) {
     }
     (max_user_len, max_group_len)
 }
+

--- a/src/help_states.rs
+++ b/src/help_states.rs
@@ -29,7 +29,7 @@ pub struct HelpState {
 }
 
 impl HelpState {
-    pub fn new(_screen: &Screen, _con: &AppContext) -> HelpState {
+    pub fn new(_screen: &Screen, _con: & AppContext) -> HelpState {
         let area = Area::uninitialized(); // will be fixed at drawing time
         HelpState {
             area,
@@ -40,11 +40,16 @@ impl HelpState {
 }
 
 impl AppState for HelpState {
+
     fn has_pending_task(&self) -> bool {
         false
     }
 
-    fn can_execute(&self, _verb_index: usize, _con: &AppContext) -> bool {
+    fn can_execute(
+        &self,
+        _verb_index: usize,
+        _con: &AppContext,
+    ) -> bool {
         true // we'll probably refine this later
     }
 
@@ -63,7 +68,7 @@ impl AppState for HelpState {
             Action::Resize(w, h) => {
                 screen.set_terminal_size(*w, *h, con);
                 self.dirty = true;
-                AppStateCmdResult::RefreshState { clear_cache: false }
+                AppStateCmdResult::RefreshState{clear_cache: false}
             }
             Action::VerbIndex(index) => {
                 let verb = &con.verb_store.verbs[*index];
@@ -101,11 +106,7 @@ impl AppState for HelpState {
             self.dirty = false;
         }
         let text = help_content::build_text(con);
-        let fmt_text = FmtText::from_text(
-            &screen.help_skin,
-            text,
-            Some((self.area.width - 1) as usize),
-        );
+        let fmt_text = FmtText::from_text(&screen.help_skin, text, Some((self.area.width - 1) as usize));
         let mut text_view = TextView::from(&self.area, &fmt_text);
         self.scroll = text_view.set_scroll(self.scroll);
         Ok(text_view.write_on(&mut w)?)

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,10 @@
-/// This module deals is where is defined whether broot
-/// writes on stdout, on stderr or elsewhere.
-
+//! This module deals is where is defined whether broot
+//! writes on stdout, on stderr or elsewhere. It also provides helper
+//! structs for io.
+use std::{
+    fmt,
+    io::{self, Write},
+};
 
 /// the type used by all GUI writing functions
 pub type W = std::io::Stderr;
@@ -8,4 +12,125 @@ pub type W = std::io::Stderr;
 /// return the writer used by the application
 pub fn writer() -> W {
     std::io::stderr()
+}
+
+/// RAII wrapper for writer to control state transitions.
+pub struct WriteCleanup<W, F, E>
+where
+    W: Write,
+    F: Fn(&mut W) -> Result<(), E>,
+    E: fmt::Display,
+{
+    writer: W,
+    cleanup: F,
+}
+
+impl<W, F, E> WriteCleanup<W, F, E>
+where
+    W: Write,
+    F: Fn(&mut W) -> Result<(), E>,
+    E: fmt::Display,
+{
+    #[inline]
+    pub fn new(writer: W, cleanup: F) -> Self {
+        WriteCleanup { writer, cleanup }
+    }
+
+    #[inline]
+    pub fn build<E2, F2: Fn(&mut W) -> Result<(), E2>>(
+        mut writer: W,
+        build: F2,
+        cleanup: F,
+    ) -> Result<Self, E2> {
+        build(&mut writer)?;
+        Ok(Self::new(writer, cleanup))
+    }
+}
+
+impl<W, F, E> Drop for WriteCleanup<W, F, E>
+where
+    W: Write,
+    F: Fn(&mut W) -> Result<(), E>,
+    E: fmt::Display,
+{
+    fn drop(&mut self) {
+        if let Err(err) = (self.cleanup)(&mut self.writer) {
+            warn!("Error cleaning up terminal: {}", err);
+        }
+    }
+}
+
+impl<W, F, E> fmt::Debug for WriteCleanup<W, F, E>
+where
+    W: Write + fmt::Debug,
+    F: Fn(&mut W) -> Result<(), E>,
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("WriteCleanup")
+            .field("writer", &self.writer)
+            .field("cleanup", &"<closure>")
+            .finish()
+    }
+}
+
+impl<W, F, E> Write for WriteCleanup<W, F, E>
+where
+    W: Write,
+    F: Fn(&mut W) -> Result<(), E>,
+    E: fmt::Display,
+{
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writer.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[io::IoSlice]) -> io::Result<usize> {
+        self.writer.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.writer.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+        self.writer.write_fmt(fmt)
+    }
+}
+
+#[test]
+fn test_write_cleanup() -> io::Result<()> {
+    use std::str;
+
+    let mut buffer: Vec<u8> = Vec::new();
+
+    {
+        let writer = WriteCleanup::build(
+            &mut buffer,
+            |writer| write!(writer, "abc "),
+            |writer| write!(writer, " xyz"),
+        )?;
+
+        let mut writer = WriteCleanup::build(
+            writer,
+            |writer| write!(writer, "123 "),
+            |writer| write!(writer, " 789"),
+        )?;
+
+        write!(&mut writer, "Hello, World!")?;
+    }
+
+    let result = str::from_utf8(&buffer).unwrap();
+
+    assert_eq!(result, "abc 123 Hello, World! 789 xyz");
+
+    Ok(())
 }

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -48,7 +48,7 @@ impl Screen {
         if let Some(h) = con.launch_args.height {
             self.height = h;
         }
-        self.input_field.change_area(0, h - 1, w - FLAGS_AREA_WIDTH);
+        self.input_field.change_area(0, h-1, w - FLAGS_AREA_WIDTH);
     }
     pub fn read_size(&mut self, con: &AppContext) -> Result<(), ProgramError> {
         let (w, h) = termimad::terminal_size();

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -1,13 +1,8 @@
-
 use {
     crate::{
         app_context::AppContext,
         errors::ProgramError,
-        io::W,
-        mad_skin::{
-            self,
-            StatusMadSkinSet,
-        },
+        mad_skin::{self, StatusMadSkinSet},
         skin::Skin,
     },
     crossterm::{
@@ -15,6 +10,7 @@ use {
         terminal::{Clear, ClearType},
         QueueableCommand,
     },
+    std::io::Write,
     termimad::{Area, CompoundStyle, InputField, MadSkin},
 };
 
@@ -52,7 +48,7 @@ impl Screen {
         if let Some(h) = con.launch_args.height {
             self.height = h;
         }
-        self.input_field.change_area(0, h-1, w - FLAGS_AREA_WIDTH);
+        self.input_field.change_area(0, h - 1, w - FLAGS_AREA_WIDTH);
     }
     pub fn read_size(&mut self, con: &AppContext) -> Result<(), ProgramError> {
         let (w, h) = termimad::terminal_size();
@@ -60,28 +56,22 @@ impl Screen {
         Ok(())
     }
     /// move the cursor to x,y and clears the line.
-    pub fn goto_clear(&self, w: &mut W, x: u16, y: u16)
-    -> Result<(), ProgramError> {
+    pub fn goto_clear(&self, w: &mut impl Write, x: u16, y: u16) -> Result<(), ProgramError> {
         self.goto(w, x, y)?;
         self.clear_line(w)
     }
     /// move the cursor to x,y
-    pub fn goto(
-        &self,
-        w: &mut W,
-        x: u16,
-        y: u16
-    ) -> Result<(), ProgramError> {
+    pub fn goto(&self, w: &mut impl Write, x: u16, y: u16) -> Result<(), ProgramError> {
         w.queue(cursor::MoveTo(x, y))?;
         Ok(())
     }
     /// clear the whole screen
-    pub fn clear(&self, w: &mut W) -> Result<(), ProgramError> {
+    pub fn clear(&self, w: &mut impl Write) -> Result<(), ProgramError> {
         w.queue(Clear(ClearType::All))?;
         Ok(())
     }
     /// clear from the cursor to the end of line
-    pub fn clear_line(&self, w: &mut W) -> Result<(), ProgramError> {
+    pub fn clear_line(&self, w: &mut impl Write) -> Result<(), ProgramError> {
         w.queue(Clear(ClearType::UntilNewLine))?;
         Ok(())
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -11,6 +11,7 @@ pub struct Status<'a> {
 }
 
 impl<'a> Status<'a> {
+
     pub fn new(
         pending_task: Option<&'static str>,
         message: Composite<'a>,

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,14 +1,6 @@
-
-use minimad::{
-    Alignment,
-    Composite,
-};
-
-use crate::{
-    errors::ProgramError,
-    io::W,
-    screens::Screen,
-};
+use crate::{errors::ProgramError, screens::Screen};
+use minimad::{Alignment, Composite};
+use std::io::Write;
 
 /// the status contains information written on the grey line
 ///  near the bottom of the screen
@@ -19,7 +11,6 @@ pub struct Status<'a> {
 }
 
 impl<'a> Status<'a> {
-
     pub fn new(
         pending_task: Option<&'static str>,
         message: Composite<'a>,
@@ -48,11 +39,7 @@ impl<'a> Status<'a> {
         }
     }
 
-    pub fn display(
-        self,
-        w: &mut W,
-        screen: &Screen,
-    ) -> Result<(), ProgramError> {
+    pub fn display(self, w: &mut impl Write, screen: &Screen) -> Result<(), ProgramError> {
         let y = screen.height - 2;
         screen.goto_clear(w, 0, y)?;
         let mut x = 0;
@@ -72,6 +59,4 @@ impl<'a> Status<'a> {
         skin.write_composite_fill(w, self.message, remaining_width, Alignment::Left)?;
         screen.clear_line(w)
     }
-
 }
-

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -6,18 +6,13 @@ use {
         app_context::AppContext,
         app_state::AppStateCmdResult,
         errors::{ConfError, ProgramError},
-        external,
-        io::W,
-        keys,
+        external, keys,
         screens::Screen,
         selection_type::SelectionType,
         status::Status,
         verb_invocation::VerbInvocation,
     },
-    crossterm::event::{
-        KeyCode,
-        KeyEvent,
-    },
+    crossterm::event::{KeyCode, KeyEvent},
     minimad::Composite,
     regex::{self, Captures, Regex},
     std::{
@@ -45,7 +40,7 @@ pub struct Verb {
     pub description: Option<String>, // a description for the user
     pub from_shell: bool, // whether it must be launched from the parent shell (eg because it's a shell function)
     pub leave_broot: bool, // only defined for external
-    pub confirm: bool, // not yet used...
+    pub confirm: bool,    // not yet used...
     pub selection_condition: SelectionType,
 }
 
@@ -100,7 +95,10 @@ impl Verb {
         // we use the selection condition to prevent configured
         // verb execution on enter on directories
         let selection_condition = match key {
-            Some(KeyEvent{code:KeyCode::Enter, ..}) => SelectionType::File,
+            Some(KeyEvent {
+                code: KeyCode::Enter,
+                ..
+            }) => SelectionType::File,
             _ => SelectionType::Any,
         };
         Ok(Verb {
@@ -205,7 +203,7 @@ impl Verb {
 
     pub fn write_status(
         &self,
-        w: &mut W,
+        w: &mut impl Write,
         task: Option<&'static str>,
         path: PathBuf,
         invocation: &VerbInvocation,
@@ -219,8 +217,7 @@ impl Verb {
             let composite = if let Some(description) = &self.description {
                 markdown = format!(
                     "Hit *enter* to **{}**: {}",
-                    &self.invocation.name,
-                    description,
+                    &self.invocation.name, description,
                 );
                 Composite::from_inline(&markdown)
             } else {
@@ -231,11 +228,7 @@ impl Verb {
                     &verb_description,
                 )
             };
-            Status::new(
-                task,
-                composite,
-                false
-            ).display(w, screen)
+            Status::new(task, composite, false).display(w, screen)
         }
     }
 
@@ -276,7 +269,7 @@ impl Verb {
                 match execution {
                     Ok(()) => {
                         debug!("ok");
-                        AppStateCmdResult::RefreshState{clear_cache: true}
+                        AppStateCmdResult::RefreshState { clear_cache: true }
                     }
                     Err(e) => {
                         warn!("launchable failed : {:?}", e);
@@ -406,4 +399,3 @@ mod path_normalize_tests {
         );
     }
 }
-

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -12,7 +12,10 @@ use {
         status::Status,
         verb_invocation::VerbInvocation,
     },
-    crossterm::event::{KeyCode, KeyEvent},
+    crossterm::event::{
+        KeyCode,
+        KeyEvent,
+    },
     minimad::Composite,
     regex::{self, Captures, Regex},
     std::{
@@ -40,7 +43,7 @@ pub struct Verb {
     pub description: Option<String>, // a description for the user
     pub from_shell: bool, // whether it must be launched from the parent shell (eg because it's a shell function)
     pub leave_broot: bool, // only defined for external
-    pub confirm: bool,    // not yet used...
+    pub confirm: bool, // not yet used...
     pub selection_condition: SelectionType,
 }
 
@@ -95,10 +98,7 @@ impl Verb {
         // we use the selection condition to prevent configured
         // verb execution on enter on directories
         let selection_condition = match key {
-            Some(KeyEvent {
-                code: KeyCode::Enter,
-                ..
-            }) => SelectionType::File,
+            Some(KeyEvent{code:KeyCode::Enter, ..}) => SelectionType::File,
             _ => SelectionType::Any,
         };
         Ok(Verb {
@@ -217,7 +217,8 @@ impl Verb {
             let composite = if let Some(description) = &self.description {
                 markdown = format!(
                     "Hit *enter* to **{}**: {}",
-                    &self.invocation.name, description,
+                    &self.invocation.name,
+                    description,
                 );
                 Composite::from_inline(&markdown)
             } else {
@@ -228,7 +229,11 @@ impl Verb {
                     &verb_description,
                 )
             };
-            Status::new(task, composite, false).display(w, screen)
+            Status::new(
+                task,
+                composite,
+                false
+            ).display(w, screen)
         }
     }
 
@@ -269,7 +274,7 @@ impl Verb {
                 match execution {
                     Ok(()) => {
                         debug!("ok");
-                        AppStateCmdResult::RefreshState { clear_cache: true }
+                        AppStateCmdResult::RefreshState{clear_cache: true}
                     }
                     Err(e) => {
                         warn!("launchable failed : {:?}", e);


### PR DESCRIPTION
Fixed #162; see that issue for a detailed design discussion, including a reproduction of the bug this fixes.

I did my best to keep this PR minimal; the biggest thing it required was replacing `&mut W` with `&mut impl io::Write` pretty much everywhere. I did rustfmt the lines that I touched, but I did my best to not rustfmt unrelated parts of files.

- Added `WriteCleanup`, an RAII wrapper for doing cleanup with `io::Write`
    - Includes test
- Replaced many uses of `W` (an stderr alias) with `&mut impl io::Write`
- Removed App::end. The functionality automatically happens with Drop handlers.
- Rustfmt'd modified files.