### PR TITLE
Allow printing relative paths as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "minimad 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "open 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "termimad 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -659,6 +660,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1190,7 @@ dependencies = [
 "checksum open 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "94b424e1086328b0df10235c6ff47be63708071881bead9e76997d9291c0134b"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+"checksum pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ minimad = "0.6.3"
 termimad = "0.8.10"
 id-arena = "2.2.1"
 lazy-regex = "0.1"
+pathdiff = "0.1.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/browser_verbs.rs
+++ b/src/browser_verbs.rs
@@ -104,6 +104,9 @@ impl VerbExecutor for BrowserState {
             ":print_path" => {
                 external::print_path(&self.displayed_tree().selected_line().target(), con)?
             }
+            ":print_relative_path" => {
+                external::print_relative_path(&self.displayed_tree().selected_line().target(), con)?
+            }
             ":print_tree" => external::print_tree(&self.displayed_tree(), screen, con)?,
             ":refresh" => AppStateCmdResult::RefreshState { clear_cache: true },
             ":select_first" => {

--- a/src/external.rs
+++ b/src/external.rs
@@ -174,7 +174,7 @@ pub fn print_relative_path(path: &Path, con: &AppContext) -> io::Result<AppState
     let canonical_path = path.canonicalize()?;
 
     let relative_path = match pathdiff::diff_paths(
-        canonical_path.clone().as_path(),
+        canonical_path.as_path(),
         current_path.as_path()) {
         None => return Ok(AppStateCmdResult::DisplayError(format!(
             "Cannot relativize {} against {}",

--- a/src/help_verbs.rs
+++ b/src/help_verbs.rs
@@ -70,6 +70,9 @@ impl VerbExecutor for HelpState {
                 AppStateCmdResult::Keep
             }
             ":print_path" => external::print_path(&Conf::default_location(), con)?,
+            ":print_relative_path" => {
+                external::print_relative_path(&Conf::default_location(), con)?
+            }
             ":quit" => AppStateCmdResult::Quit,
             ":focus_user_home" | ":focus_root" => AppStateCmdResult::PopStateAndReapply,
             _ if verb.execution.starts_with(":toggle") => AppStateCmdResult::PopStateAndReapply,

--- a/src/verb_store.rs
+++ b/src/verb_store.rs
@@ -193,6 +193,12 @@ impl VerbStore {
             "print path and leaves broot",
         );
         self.add_builtin(
+            "print_relative_path",
+            None,
+            Some("prp".to_string()),
+            "print relative path and leaves broot",
+        );
+        self.add_builtin(
             "print_tree",
             None,
             Some("pt".to_string()),


### PR DESCRIPTION
This is a use-case I have where I want to sometimes reference things relatively. This lets me do `file:prp` and have it printed relative to the CWD.

This is just the code I use. Happy to rewrite it to your standards to upstream.