### PR TITLE
Fix documentation, backtick

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -90,7 +90,7 @@ Sizes are computed in the background, you don't have to wait for them when you n
 
 Use `:gf` to display the statuses of files (what are the new ones, the modified ones, etc.), the current branch name and the change statistics.
 
-And if you want to see *only* the files which would be displayed by the `git status command`, do `:gs`.
+And if you want to see *only* the files which would be displayed by the `git status` command, do `:gs`.
 
 
 # More...


### PR DESCRIPTION
The backtick on the main page includes the word 'command' instead of
just the words that make up `git status`