### PR TITLE
Use PATH instead of absolute paths for all verbs

### DIFF
--- a/src/conf/default_conf.rs
+++ b/src/conf/default_conf.rs
@@ -96,13 +96,13 @@ default_flags = ""
 
 # If $EDITOR isn't set on your computer, you should either set it using
 #  something similar to
-#   export EDITOR=/usr/bin/nvim
+#   export EDITOR=nvim
 #  or just replace it with your editor of choice in the 'execution'
 #  pattern.
 #  If your editor is able to open a file on a specific line, use {line}
 #   so that you may jump directly at the right line from a preview.
 # Example:
-#  execution = "/usr/bin/nvim +{line} {file}"
+#  execution = "nvim +{line} {file}"
 
 [[verbs]]
 invocation = "edit"

--- a/src/verb/builtin.rs
+++ b/src/verb/builtin.rs
@@ -86,7 +86,7 @@ pub fn builtin_verbs() -> Vec<Verb> {
             .with_control_key('w'),
         external(
             "copy {newpath:path-from-parent}",
-            "/bin/cp -r {file} {newpath:path-from-parent}",
+            "cp -r {file} {newpath:path-from-parent}",
             StayInBroot,
         )
             .with_shortcut("cp"),
@@ -95,7 +95,7 @@ pub fn builtin_verbs() -> Vec<Verb> {
             .with_alt_key('c'),
         external(
             "copy_to_panel",
-            "/bin/cp -r {file} {other-panel-directory}",
+            "cp -r {file} {other-panel-directory}",
             StayInBroot,
         )
             .with_shortcut("cpp"),
@@ -112,19 +112,19 @@ pub fn builtin_verbs() -> Vec<Verb> {
         internal(line_up).with_key(UP),
         external(
             "mkdir {subpath}",
-            "/bin/mkdir -p {subpath:path-from-directory}",
+            "mkdir -p {subpath:path-from-directory}",
             StayInBroot,
         )
             .with_shortcut("md"),
         external(
             "move {newpath:path-from-parent}",
-            "/bin/mv {file} {newpath:path-from-parent}",
+            "mv {file} {newpath:path-from-parent}",
             StayInBroot,
         )
             .with_shortcut("mv"),
         external(
             "move_to_panel",
-            "/bin/mv {file} {other-panel-directory}",
+            "mv {file} {other-panel-directory}",
             StayInBroot,
         )
             .with_shortcut("mvp"),
@@ -165,7 +165,7 @@ pub fn builtin_verbs() -> Vec<Verb> {
         internal(sort_by_size).with_shortcut("ss"),
         external(
             "rm",
-            "/bin/rm -rf {file}",
+            "rm -rf {file}",
             StayInBroot,
         ),
         internal(toggle_counts).with_shortcut("counts"),

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -11,7 +11,7 @@ invocation = "edit"
 key = "F2"
 shortcut = "e"
 apply_to = "file"
-external = "/usr/bin/nvim {file}"
+external = "nvim {file}"
 leave_broot = false
 ```
 
@@ -127,7 +127,7 @@ This is useful for commands modifying the tree (like creating or moving files).
 
 The execution of a verb can take one or several arguments.
 
-For example it may be defined as `/usr/bin/vi {file}̀`.
+For example it may be defined as `vi {file}̀`.
 
 Some arguments are predefined in broot and depends on the current selection:
 
@@ -149,7 +149,7 @@ But you may also define some arguments in the invocation pattern. For example:
 ```toml
 [[verbs]]
 invocation = "mkdir {subpath}"
-external = "/bin/mkdir -p {directory}/{subpath}"
+external = "mkdir -p {directory}/{subpath}"
 ```
 
 (the `mkdir` verb is standard so you don't have to write it in the configuration file)
@@ -169,7 +169,7 @@ Here's another example, where the invocation pattern defines two arguments by de
 ```toml
 [[verbs]]
 invocation = "blop {name}\\.{type}"
-external = "/bin/mkdir {parent}/{type} && /usr/bin/nvim {parent}/{type}/{name}.{type}"
+external = "mkdir {parent}/{type} && nvim {parent}/{type}/{name}.{type}"
 from_shell = true
 ```
 
@@ -187,7 +187,7 @@ Let's say we don't want the type to contain dots, then we do this:
 ```toml
 [[verbs]]
 invocation = "blop {name}\\.(?P<type>[^.]+)"
-external = "/bin/mkdir {parent}/{type} && /usr/bin/nvim {parent}/{type}/{name}.{type}"
+external = "mkdir {parent}/{type} && nvim {parent}/{type}/{name}.{type}"
 from_shell = true
 ```
 

--- a/website/docs/verbs.md
+++ b/website/docs/verbs.md
@@ -13,7 +13,7 @@ It's defined by this couple (invocation, external):
 
 ```toml
 invocation = "rm"
-external = "/bin/rm -rf {file}"
+external = "rm -rf {file}"
 ```
 
 Selection based arguments:
@@ -31,7 +31,7 @@ Several selection based arguments can be used. For example the (built-in) `:copy
 
 ```toml
 invocation = "copy_to_panel"
-external = "/bin/cp -r {file} {other-panel-directory}"
+external = "cp -r {file} {other-panel-directory}"
 ```
 
 When you type a verb, the execution pattern is completed using the selection(s), the exact command is displayed in the status line:
@@ -49,7 +49,7 @@ For example mkdir is defined as
 
 ```toml
 invocation = "mkdir {subpath}"
-external = "/bin/mkdir -p {directory}/{subpath}"
+external = "mkdir -p {directory}/{subpath}"
 ```
 
 (it's now a built-in, you won't see it in the config file)


### PR DESCRIPTION
## Before this PR

The `chmod` verb was already using `PATH`, but others were using absolute paths that don't necessarily exist on every Linux distro. For example, on NixOS there is no `/bin/rm`, so the `broot` package rewrites `/bin/` to a path in the "Nix store" (this is typical), which works just fine, but makes the UI's verb preview very verbose:

![image](https://user-images.githubusercontent.com/26806/95656042-76bf7b80-0b03-11eb-965b-bb400740fbee.png)

The `chmod` verb specifies `chmod` instead of `/bin/chmod` (relying on `PATH` lookup), which works just as well and has a cleaner verb preview:

![image](https://user-images.githubusercontent.com/26806/95656060-96ef3a80-0b03-11eb-9291-98543d301a35.png)

## After this PR

I made all verbs work like `chmod` does, which cleans up the preview for me:

![image](https://user-images.githubusercontent.com/26806/95656109-f6e5e100-0b03-11eb-856c-251c337ea591.png)

I also changed documentation examples to use bare executable names instead of absolute paths since it's generally more compatible with different executable locations.