### PR TITLE
feat: instant break for circular symlinks

### DIFF
--- a/src/tree/tree_line_type.rs
+++ b/src/tree/tree_line_type.rs
@@ -1,13 +1,14 @@
 use {
     std::{
+        collections::HashSet,
         fs,
         io,
         path::{Path, PathBuf},
     },
 };
 
-/// longer link chains are probably cyclic
-const MAX_LINK_CHAIN_LENGTH: usize = 10;
+/// The maximum number of symlink hops before giving up.
+const MAX_LINK_CHAIN_LENGTH: usize = 128;
 
 /// The type of a line which can be displayed as
 /// part of a tree
@@ -39,15 +40,21 @@ impl TreeLineType {
         let mut final_metadata = fs::symlink_metadata(&final_target)?;
         let mut final_ft = final_metadata.file_type();
         let mut final_is_dir = final_ft.is_dir();
-        let mut link_chain_length = 1;
+        let mut link_chain_length = 0;
+        let mut visited = HashSet::new();
         while final_ft.is_symlink() {
             final_target = read_link(&final_target)?;
+            if visited.contains(&final_target) {
+                info!("circular symlink opened by {} and closed by {}", direct_target.display(), final_target.display());
+                return Ok(Self::BrokenSymLink(direct_target.to_string_lossy().into_owned()))
+            }
+            let _ = visited.insert(final_target.clone());
             final_metadata = fs::symlink_metadata(&final_target)?;
             final_ft = final_metadata.file_type();
             final_is_dir = final_ft.is_dir();
             link_chain_length += 1;
             if link_chain_length > MAX_LINK_CHAIN_LENGTH {
-                info!("too long link chain (maybe cyclic) at {:?}", &direct_target);
+                info!("too long link chain at {}", direct_target.display());
                 return Ok(Self::BrokenSymLink(direct_target.to_string_lossy().into_owned()))
             }
         }


### PR DESCRIPTION
Tiny improvements to avoid going in circles longer than need or not getting to the end of a long link chain due to the heuristic upper limit is kicking in.