### PR TITLE
fix link to vscode.ttf

### DIFF
--- a/website/docs/icons.md
+++ b/website/docs/icons.md
@@ -29,7 +29,7 @@ If you see a rust gear icon, your terminal is displaying the correct font.
 If the font isn't installed, you may
 
 * take it in `/resources/icons/vscode/vscode.ttf` if you have broot sources
-* download it from [https://github.com/Canop/broot/tree/resources/icons/vscode/vscode.ttf](https://github.com/Canop/broot/tree/resources/icons/vscode/vscode.ttf),
+* download it from [https://github.com/Canop/broot/blob/master/resources/icons/vscode/vscode.ttf](https://github.com/Canop/broot/blob/master/resources/icons/vscode/vscode.ttf),
 * or take it in the release archive if you installed broot from its zipped archive.
 
 ### Installation on linux:


### PR DESCRIPTION
Hello!
In https://dystroy.org/broot/icons/ the link to the ttf file ends in a 404 error.
Here is a fix using the master branch version, I hope that's ok.
Peace!