### PR TITLE
add Alpine Linux into third party repositories

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -55,6 +55,12 @@ If you want a custom compilation, have a look at the [optional features document
 
     brew install broot
 
+## Alpine Linux
+
+    apk add broot
+
+*note: broot package is available in Alpine 3.13 and newer*
+
 ## APT / Deb
 
 Ubuntu and Debian users may use this apt repository: [https://packages.azlux.fr/](https://packages.azlux.fr/)


### PR DESCRIPTION
Note: Alpine 3.13 has not been released yet, it should be till the end of this year.