### PR TITLE
ask for log on bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,12 @@ We prefer you come to the chat and speak about the problem first.
 Broot chat room: https://miaou.dystroy.org/3490?broot 
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is, including logs when possible:
+
+- start broot with `BROOT_LOG=debug br`
+- do the action which seems not to properly work, and nothing else
+- quit broot
+- paste the content of the broot.log file
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -24,8 +29,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Configuration (please complete the following information):**
- - OS: [e.g. iOS]
- - Version [e.g. 22]
+- broot version: [br --version]
+- OS: [e.g. iOS]
+- Version: [e.g. 22]
 - Relevant configuration items
 
 **Additional context**


### PR DESCRIPTION
This PR improves the bug_report template to add information on how to get the log of br (copied from https://dystroy.org/broot/community/#log)