### PR TITLE
fish completion for br

### DIFF
--- a/src/shell_install/fish.rs
+++ b/src/shell_install/fish.rs
@@ -31,7 +31,7 @@ const FISH_FUNC: &str = r#"
 # it produces, if any.
 # It's needed because some shell commands, like `cd`,
 # have no useful effect if executed in a subshell.
-function br
+function br --wraps=broot
     set -l cmd_file (mktemp)
     if broot --outcmd $cmd_file $argv
         read --local --null cmd < $cmd_file


### PR DESCRIPTION
make `br` inherit completion of `broot`

https://fishshell.com/docs/current/cmds/function.html
> `-w WRAPPED_COMMAND` or `--wraps=WRAPPED_COMMAND` causes the function to inherit completions from the given wrapped command.

https://github.com/Canop/broot/issues/337