### PR TITLE
add colored help

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ansi_colours = "1.0"
 base64 = "0.13"
 bet = "0.4.0"
 char_reader = "0.1"
-clap = { version="2.33", default-features=false, features=["suggestions"] }
+clap = { version="2.33", default-features=false, features=["suggestions", "color"] }
 cli-log = "1.1"
 chrono = "0.4"
 crossbeam = "0.8"

--- a/src/cli/clap_args.rs
+++ b/src/cli/clap_args.rs
@@ -10,6 +10,7 @@ pub fn clap_app() -> clap::App<'static, 'static> {
             "A tree explorer and a customizable launcher\n\
             Complete documentation lives at https://dystroy.org/broot"
         )
+        .setting(clap::AppSettings::ColoredHelp)
         .arg(clap::Arg::with_name("ROOT").help("sets the root directory"))
         // tree flags
         .arg(


### PR DESCRIPTION
Thank you for maintaining this awesome tool in advance.

Lots of cli tools written in rust have a colored help (fd, bat etc.). I think adding this tiny feature to `broot` is not a bad idea :)

![image](https://user-images.githubusercontent.com/6105425/111727113-3c71bb80-88a5-11eb-9389-044cd2d2f7b0.png)


( I noticed that `default-features` for clap are disabled in the `Cargo.toml`. Since the `color` feature is one of them I don't know if it was intentional disabled. )