### PR TITLE
Document the --color option

### DIFF
--- a/man/page
+++ b/man/page
@@ -73,8 +73,8 @@ Don't trim the root (still trim the deeper levels). A scrollbar may be used when
 .B \-\-install
 Install or reinstall the \fBbr\fR shell function
 .TP
-.B \-\-no-style
-Remove all style and colors
+.B \-\-color <yes|no|auto>
+Controls styling of the output (default: auto). If set to auto, all styling is removed when output is piped.
 .TP
 .B \-\-help
 Prints a help page, with more or less the same content as this man page


### PR DESCRIPTION
I've simply added the `--color` option to the `man` page, whilst removing `--no-style`, which was seemingly removed sometime between 93b1ffcc701a7753e8376c80b0c10683f7e3e36d and 7d512894808500946a6acb6d4939d4ba1473c14d.