### PR TITLE
Add dependabot config for cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Creates update PRs similar to https://github.com/dbast/broot/pulls with history for each dependency bump etc for review.

PRs can be merged if CI is green or closed to ignore the dependency regarding auto updates.