### PR TITLE
Fix a wrong path, some typos and indentation

### DIFF
--- a/resources/default-conf.hjson
+++ b/resources/default-conf.hjson
@@ -104,31 +104,31 @@
 
 	###############################################################
 	# Search modes
-        #
-        # broot allows many search modes.
-        # A search mode is defined by
-        # - the way to search: 'fuzzy', 'exact', 'regex', or 'tokens'.
-        # - where to search: file 'name', 'path', or file 'content'
-        # A search pattern may for example be "fuzzy path" (default),
-        # "regex content" or "exact path".
-        #
-        # The search mode is selected from its prefix. For example, if
-        # you type "abc", the default mode is "fuzzy path". If you type
-        # "/abc", the mode is "regex path". If you type "rn/abc", the mode
-        # is "regex name".
-        #
-        # This mapping may be modified. You may want to dedicate the
-        # empty prefix (the one which doesn't need a '/') to the
-        # search mode you use most often. The example below makes it
-        # easy to search on name rather than on the subpath.
-        #
-        # More information on
-        #  https://dystroy.org/broot/input/#the-filtering-pattern
-        #
-        # search_modes: {
-        #     <empty>: fuzzy name
-        #     /: regex name
-        # }
+	#
+	# broot allows many search modes.
+	# A search mode is defined by
+	# - the way to search: 'fuzzy', 'exact', 'regex', or 'tokens'.
+	# - where to search: file 'name', 'path', or file 'content'
+	# A search pattern may for example be "fuzzy path" (default),
+	# "regex content" or "exact path".
+	#
+	# The search mode is selected from its prefix. For example, if
+	# you type "abc", the default mode is "fuzzy path". If you type
+	# "/abc", the mode is "regex path". If you type "rn/abc", the mode
+	# is "regex name".
+	#
+	# This mapping may be modified. You may want to dedicate the
+	# empty prefix (the one which doesn't need a '/') to the
+	# search mode you use most often. The example below makes it
+	# easy to search on name rather than on the subpath.
+	#
+	# More information on
+	#  https://dystroy.org/broot/input/#the-filtering-pattern
+	#
+	# search_modes: {
+	#     <empty>: fuzzy name
+	#     /: regex name
+	# }
 
 	###############################################################
 	# Verbs and shortcuts
@@ -186,7 +186,7 @@
 		}
 
 		# On ctrl-b, propose the creation of a copy of the selection.
-		# While this might occasionnaly be useful, this verb is mostly here
+		# While this might occasionally be useful, this verb is mostly here
 		# as an example to demonstrate rare standard groups like {file-stem}
 		# and {file-dot-extension} and the auto_exec verb property which
 		# allows verbs not executed until you hit enter
@@ -260,9 +260,9 @@
 	# If you want to change the colors of broot,
 	# uncomment the following bloc and start messing
 	# with the various values.
-        # A skin entry value is made of two parts separated with a '/':
-        # The first one is the skin for the active panel.
-        # The second one, optional, is the skin for non active panels.
+	# A skin entry value is made of two parts separated with a '/':
+	# The first one is the skin for the active panel.
+	# The second one, optional, is the skin for non active panels.
 	# You may find explanations and other skins on
 	#  https://dystroy.org/broot/skins
 	###############################################################
@@ -352,8 +352,8 @@
 
 	###############################################################
 	# Max Panels Count
-        #
+	#
 	# Change this if you sometimes want to have more than 2 panels
-        # open
-        # max_panels_count: 2
+	# open
+	# max_panels_count: 2
 }

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -40,7 +40,7 @@ leave_broot | `true` | whether to quit broot on execution
 from_shell | `false` | whether the verb must be executed from the parent shell (needs `br`). As this is executed after broot closed, this isn't compatible with `leave_broot = false`
 apply_to | | the type of selection this verb applies to, may be `"file"`, `"directory"` or `"any"`. You may declare two verbs with the same key if the first one applies to only files or only directories
 working_dir | | the working directory of the external application, for example `"{directory}"` for the closest directory (the working dir isn't set if the directory doesn't exist)
-set_working_dir | `false` | whether the working dir of the process must be set to the currenly selected directory (it's equivalent to `workding_dir: "{directory}"`)
+set_working_dir | `false` | whether the working dir of the process must be set to the currently selected directory (it's equivalent to `workding_dir: "{directory}"`)
 auto_exec | `true` | whether to execute the verb as soon as it's key-triggered (instead of waiting for <kbd>enter</kbd>)
 
 The execution is defined either by `internal`, `external` or `cmd` so a verb must have exactly one of those (for compatibility with older versions broot still accepts `execution` for `internal` or `external` and guesses which one it is).
@@ -50,7 +50,7 @@ The execution is defined either by `internal`, `external` or `cmd` so a verb mus
 
 # Using quotes
 
-If you want broot, for example, to execute `xterm -e "nvim {file}"`, you may either escape the quotes as `\"` or use the array format to separe parts.
+If you want broot, for example, to execute `xterm -e "nvim {file}"`, you may either escape the quotes as `\"` or use the array format to separate parts.
 
 So the two following verb definitions are equivalent.
 

--- a/website/docs/navigation.md
+++ b/website/docs/navigation.md
@@ -117,5 +117,5 @@ Other than executing a command leaving broot, there are several ways to quit:
 
 * if the current root is selected, just hit `enter`
 * hit <kbd>ctrl</kbd>+<kbd>Q</kbd>
-* type `:q` or ` q` then `enter`
+* type `:q` or `space` `q` then `enter`
 

--- a/website/docs/tricks.md
+++ b/website/docs/tricks.md
@@ -16,7 +16,7 @@ This function supports most broot arguments:
 
 The goal here is to have a function you can use in shell to give you a path.
 
-**Step 1:** create a file `~/.config/select.toml` with this content:
+**Step 1:** create a file `~/.config/broot/select.toml` with this content:
 
 ```Hjson
 verbs: [
@@ -178,7 +178,7 @@ In this example I show lines containing "youtube" but not "txt" nor " 0 ms".
 
 ![search log](img/20200716-search-log.png)
 
-# Escpape key
+# Escape key
 
 Broot usage, just like vim, relies a lot on the <kbd>esc</kbd> key. If you're a frequent user of the terminal, you may want to remap an easy to reach and otherwise useless key (for example caps-lock) to <kbd>esc</kbd>.
 


### PR DESCRIPTION
## Website

### Tricks section

* Fix path: `~/config/select.toml` → `~/config/broot/select.toml`. The latter is used later for creating an alias.

### Navigation section

* Change ` q` to `space` `q` because the the whitespace before `q` does get rendered.

### Various places

* Fix some typos

## resources

* `default-conf.hjson` uses tabs for indentation. Some lines in between are indented with spaces. → Changed to tabs.