### PR TITLE
Add Gentoo Linux installation instructions

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -76,6 +76,10 @@ Ubuntu and Debian users may use this apt repository: [https://packages.azlux.fr/
 
     pkgin install broot
 
+## Gentoo Linux
+
+    emerge broot
+
 -----------------------------------
 
 Now you should [install the br shell function](../install-br/).


### PR DESCRIPTION
Broot is available in Gentoo Linux: https://packages.gentoo.org/packages/app-misc/broot

Add it to the list of distro installation instructions.