### PR TITLE
Issue #535 program not found on windows

### DIFF
--- a/src/verb/builtin.rs
+++ b/src/verb/builtin.rs
@@ -129,9 +129,17 @@ pub fn builtin_verbs() -> Vec<Verb> {
         #[cfg(feature="clipboard")]
         internal(input_paste)
             .with_key(key!(ctrl-v)),
+        #[cfg(unix)]
         external(
             "mkdir {subpath}",
             "mkdir -p {subpath:path-from-directory}",
+            StayInBroot,
+        )
+            .with_shortcut("md"),
+        #[cfg(windows)]
+        external(
+            "mkdir {subpath}",
+            "cmd /c mkdir {subpath:path-from-directory}",
             StayInBroot,
         )
             .with_shortcut("md"),

--- a/src/verb/builtin.rs
+++ b/src/verb/builtin.rs
@@ -231,7 +231,14 @@ pub fn builtin_verbs() -> Vec<Verb> {
         internal(sort_by_date).with_shortcut("sd"),
         internal(sort_by_size).with_shortcut("ss"),
         internal(sort_by_type).with_shortcut("st"),
+        #[cfg(unix)]
         external("rm", "rm -rf {file}", StayInBroot),
+        #[cfg(windows)]
+        external("rm", "cmd /c rmdir /Q /S {file}", StayInBroot)
+            .with_stype(SelectionType::Directory),
+        #[cfg(windows)]
+        external("rm", "cmd /c del /Q /S {file}", StayInBroot)
+            .with_stype(SelectionType::File),
         internal(toggle_counts).with_shortcut("counts"),
         internal(toggle_dates).with_shortcut("dates"),
         internal(toggle_device_id).with_shortcut("dev"),

--- a/src/verb/builtin.rs
+++ b/src/verb/builtin.rs
@@ -151,21 +151,46 @@ pub fn builtin_verbs() -> Vec<Verb> {
             StayInBroot,
         )
             .with_shortcut("md"),
+        #[cfg(unix)]
         external(
             "move {newpath}",
             "mv {file} {newpath:path-from-parent}",
             StayInBroot,
         )
             .with_shortcut("mv"),
+        #[cfg(windows)]
+        external(
+            "move {newpath}",
+            "cmd /c move /Y {file} {newpath:path-from-parent}",
+            StayInBroot,
+        )
+            .with_shortcut("mv"),
+        #[cfg(unix)]
         external(
             "move_to_panel",
             "mv {file} {other-panel-directory}",
             StayInBroot,
         )
             .with_shortcut("mvp"),
+        #[cfg(windows)]
+        external(
+            "move_to_panel",
+            "cmd /c move /Y {file} {other-panel-directory}",
+            StayInBroot,
+        )
+            .with_shortcut("mvp"),
+        #[cfg(unix)]
         external(
             "rename {new_filename:file-name}",
             "mv {file} {parent}/{new_filename}",
+            StayInBroot,
+        )
+            .with_auto_exec(false)
+            .with_key(key!(f2)),
+        #[cfg(windows)]
+        external(
+            "rename {new_filename:file-name}",
+            "cmd /c move /Y {file} {parent}/{new_filename}",
             StayInBroot,
         )
             .with_auto_exec(false)

--- a/src/verb/builtin.rs
+++ b/src/verb/builtin.rs
@@ -97,9 +97,17 @@ pub fn builtin_verbs() -> Vec<Verb> {
         internal(close_panel_ok),
         internal(close_panel_cancel)
             .with_key(key!(ctrl-w)),
+        #[cfg(unix)]
         external(
             "copy {newpath}",
             "cp -r {file} {newpath:path-from-parent}",
+            StayInBroot,
+        )
+            .with_shortcut("cp"),
+        #[cfg(windows)]
+        external(
+            "copy {newpath}",
+            "xcopy /Q /H /Y /I {file} {newpath:path-from-parent}",
             StayInBroot,
         )
             .with_shortcut("cp"),


### PR DESCRIPTION
Added a cfg for windows for the following commands
* mkdir
* cp
* mv
* rm

Tested on Windows 11

The flags that are passed to the respective windows commands are open do discussion as I am not sure if they behave the same like in unix.