### PR TITLE
Treat files in .git/info/exclude as ignored

### DIFF
--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -156,16 +156,18 @@ impl GitIgnorer {
     pub fn root_chain(&mut self, mut dir: &Path) -> GitIgnoreChain {
         let mut chain = GitIgnoreChain::default();
         loop {
-            let ignore_file = dir.join(".gitignore");
             let is_repo = is_repo(dir);
             if is_repo {
                 if let Some(gif) = GitIgnoreFile::global(dir) {
                     chain.push(self.files.alloc(gif));
                 }
             }
-            if let Ok(gif) = GitIgnoreFile::new(&ignore_file, dir) {
-                //debug!("pushing GIF {:#?}", &gif);
-                chain.push(self.files.alloc(gif));
+            for filename in [".gitignore", ".git/info/exclude"] {
+                let file = dir.join(filename);
+                if let Ok(gif) = GitIgnoreFile::new(&file, dir) {
+                    //debug!("pushing GIF {:#?}", &gif);
+                    chain.push(self.files.alloc(gif));
+                }
             }
             if is_repo {
                 chain.in_repo = true;


### PR DESCRIPTION
.git/info/exclude has equivalent syntax to .gitignore, for the purpose
of placing ignored files that are local to the current clone. This
change adds support for this file as if it were a regular .gitignore.

Signed-off-by: Ryan Gonzalez <rymg19@gmail.com>