### PR TITLE
RUSTSEC-2020-0159: upgrade chrono dependency from v0.4.19 to v0.4.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,15 +243,16 @@ checksum = "37a59b22dec21ca7d6c173bd543eeab4cd2f36cf21f039a4134905034c87ed3a"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 


### PR DESCRIPTION
Broot 1.14.2 depends on chrono = "0.4", which is currently fulfilled by 0.4.19.

chrono 0.4.19 is vulnerable to RUSTSEC-2020-0159: Potential segfault in localtime_r invocations

`cargo update --package chrono` bumps the dependency to chrono v0.4.20 and seems to work for me.