### PR TITLE
Remove unneeded clippy lints whitelist

### DIFF
--- a/src/task_sync.rs
+++ b/src/task_sync.rs
@@ -85,7 +85,6 @@ impl Dam {
         self.select(comp_receiver)
     }
 
-    #[allow(clippy::drop_copy, clippy::zero_ptr)]
     pub fn select<V>(
         &mut self,
         comp_receiver: Receiver<ComputationResult<V>>,


### PR DESCRIPTION
While working on clippy I was checking why some crates whitelisted `drop_copy` lint, and found it was not needed here.