### PR TITLE
restrict verbs to specific panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- you can restrict the panels in which verbs apply with the verb configuration `panels` parameter
+
 ### v1.16.1 - 2022-10-13
 <a name="v1.16.1"></a>
 - fix ctrl-left not usable anymore in filtered preview to remove filtering

--- a/src/app/panel.rs
+++ b/src/app/panel.rs
@@ -133,7 +133,9 @@ impl Panel {
         con: &AppContext,
     ) -> Result<Command, ProgramError> {
         let sel_info = self.states[self.states.len() - 1].sel_info(app_state);
-        self.input.on_event(w, event, con, sel_info, app_state, self.state().get_mode())
+        let mode = self.state().get_mode();
+        let panel_state_type = self.state().get_type();
+        self.input.on_event(w, event, con, sel_info, app_state, mode, panel_state_type)
     }
 
     pub fn push_state(&mut self, new_state: Box<dyn PanelState>) {

--- a/src/app/state_type.rs
+++ b/src/app/state_type.rs
@@ -1,21 +1,25 @@
+use {
+    serde::Deserialize,
+};
 
 /// one of the types of state that you could
 /// find in a panel today
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PanelStateType {
 
-    /// The standard browsing tree
+    /// standard browsing tree
     Tree,
 
-    /// the filesystem
+    /// filesystems
     Fs,
 
-    /// The help "screen"
+    /// help "screen"
     Help,
 
-    /// The preview panel, never alone on screen
+    /// preview panel, never alone on screen
     Preview,
 
-    /// The stage panel, never alone on screen
+    /// stage panel, never alone on screen
     Stage,
 }

--- a/src/command/panel_input.rs
+++ b/src/command/panel_input.rs
@@ -74,6 +74,7 @@ impl PanelInput {
     /// - maybe change the input
     /// - build a command
     /// then redraw the input field
+    #[allow(clippy::too_many_arguments)]
     pub fn on_event(
         &mut self,
         w: &mut W,
@@ -82,8 +83,9 @@ impl PanelInput {
         sel_info: SelInfo<'_>,
         app_state: &AppState,
         mode: Mode,
+        panel_state_type: PanelStateType,
     ) -> Result<Command, ProgramError> {
-        let cmd = self.get_command(event, con, sel_info, app_state, mode);
+        let cmd = self.get_command(event, con, sel_info, app_state, mode, panel_state_type);
         self.input_field.display_on(w)?;
         Ok(cmd)
     }
@@ -187,6 +189,7 @@ impl PanelInput {
         sel_info: SelInfo<'_>,
         app_state: &AppState,
         mode: Mode,
+        panel_state_type: PanelStateType,
     ) -> Command {
         match timed_event.event {
             Event::Mouse(MouseEvent { kind, column, row, modifiers: KeyModifiers::NONE }) => {
@@ -323,6 +326,9 @@ impl PanelInput {
                                 return Command::from_raw(self.input_field.get_content(), false);
                             }
                             if !verb.selection_condition.is_respected_by(sel_info.common_stype()) {
+                                continue;
+                            }
+                            if !verb.can_be_called_in_panel(panel_state_type) {
                                 continue;
                             }
                             if mode != Mode::Input && verb.is_internal(Internal::mode_input) {

--- a/src/conf/verb_conf.rs
+++ b/src/conf/verb_conf.rs
@@ -1,6 +1,9 @@
 use {
     crate::{
-        app::SelectionType,
+        app::{
+            PanelStateType,
+            SelectionType,
+        },
         command::Sequence,
         errors::ConfError,
         keys,
@@ -49,6 +52,8 @@ pub struct VerbConf {
 
     auto_exec: Option<bool>,
 
+    #[serde(default)]
+    panels: Vec<PanelStateType>,
 }
 
 /// read a deserialized verb conf item into a verb,
@@ -154,6 +159,9 @@ impl VerbConf {
         }
         if vc.auto_exec == Some(false) {
             verb.auto_exec = false;
+        }
+        if !vc.panels.is_empty() {
+            verb.panels = vc.panels.clone();
         }
         verb.selection_condition = match vc.apply_to.as_deref() {
             Some("file") => SelectionType::File,

--- a/src/verb/verb.rs
+++ b/src/verb/verb.rs
@@ -71,7 +71,9 @@ pub struct Verb {
 
     /// whether to show the verb in help screen
     /// (if we show all input related actions, the doc is unusable)
-    pub show_in_doc: bool
+    pub show_in_doc: bool,
+
+    pub panels: Vec<PanelStateType>,
 }
 
 impl PartialEq for Verb {
@@ -122,6 +124,7 @@ impl Verb {
             needs_another_panel,
             auto_exec: true,
             show_in_doc: true,
+            panels: Vec::new(),
         })
     }
     fn update_key_desc(&mut self) {
@@ -294,5 +297,9 @@ impl Verb {
 
     pub fn is_sequence(&self) -> bool {
         matches!(self.execution, VerbExecution::Sequence(_))
+    }
+
+    pub fn can_be_called_in_panel(&self, panel_state_type: PanelStateType) -> bool {
+        self.panels.is_empty() || self.panels.contains(&panel_state_type)
     }
 }

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -43,6 +43,7 @@ apply_to | | the type of selection this verb applies to, may be `"file"`, `"dire
 working_dir | | the working directory of the external application, for example `"{directory}"` for the closest directory (the working dir isn't set if the directory doesn't exist)
 set_working_dir | `false` | whether the working dir of the process must be set to the currently selected directory (it's equivalent to `workding_dir: "{directory}"`)
 auto_exec | `true` | whether to execute the verb as soon as it's key-triggered (instead of waiting for <kbd>enter</kbd>)
+panels | *all* | optional list of panel types in which the verb can be called. Default is all panels: `[tree, fs, preview, help, stage]`
 
 The execution is defined either by `internal`, `external` or `cmd` so a verb must have exactly one of those (for compatibility with older versions broot still accepts `execution` for `internal` or `external` and guesses which one it is).
 


### PR DESCRIPTION
The optional `panels` verb configuration parameter allows specifying the list of panels in which the verb can be called.

It's thus possible to define a key which works differently depending on the panel:

        {
            key: F8
            execution: ":page_down"
            panels: [preview, help, fs]
        }
        
        {
            key: F8
            execution: ":page_up"
        }

(F8 would there do a page up in the file tree and a page down elsewhere)