### PR TITLE
Prevent `br` from using `rm` alias or function in Bash

### DIFF
--- a/src/shell_install/bash.rs
+++ b/src/shell_install/bash.rs
@@ -43,11 +43,11 @@ function br {
     cmd_file=$(mktemp)
     if broot --outcmd "$cmd_file" "$@"; then
         cmd=$(<"$cmd_file")
-        rm -f "$cmd_file"
+        command rm -f "$cmd_file"
         eval "$cmd"
     else
         code=$?
-        rm -f "$cmd_file"
+        command rm -f "$cmd_file"
         return "$code"
     fi
 }


### PR DESCRIPTION
See https://github.com/Canop/broot/issues/206. I don't use nor know much about fish, so it would be nice if someone tested, if a similar change would work there as `command` is a shell built-in.