### PR TITLE
Fix install-br website link

### DIFF
--- a/src/shell_install/mod.rs
+++ b/src/shell_install/mod.rs
@@ -25,7 +25,7 @@ pub use {
 const MD_INSTALL_REQUEST: &str = r#"
 **Broot** should be launched using a shell function.
 This function most notably makes it possible to `cd` from inside broot
-(see *https://dystroy.org/broot/install* for explanations).
+(see *https://dystroy.org/broot/install-br/* for explanations).
 
 Can I install it now? [**Y**/n]
 "#;
@@ -42,7 +42,7 @@ You can still used `broot` but some features won't be available.
 If you want the `br` shell function, you may either
 * do `broot --install`
 * install the various pieces yourself
-(see *https://dystroy.org/broot/install* for details).
+(see *https://dystroy.org/broot/install-br/* for details).
 
 "#;
 


### PR DESCRIPTION
Fix `https://dystroy.org/broot/install` -> `https://dystroy.org/broot/install-br/` when prompting before installing the shell function.

The shell installation page is at https://dystroy.org/broot/install-br/ . It was wrongly pointing to the binary installation instructions at https://dystroy.org/broot/install , which would be useless to someone who is seeing that message after running the executable.

# Before

```
Broot should be launched using a shell function.
This function most notably makes it possible to cd from inside broot
(see https://dystroy.org/broot/install for explanations).

Can I install it now? [Y/n]
n

You refused the installation (for now).
You can still used broot but some features won't be available.
If you want the br shell function, you may either
• do broot --install
• install the various pieces yourself
(see https://dystroy.org/broot/install for details).

New Configuration files written in "/home/home/.config/broot".
You should have a look at them.
```

# After

```
Broot should be launched using a shell function.
This function most notably makes it possible to cd from inside broot
(see https://dystroy.org/broot/install-br/ for explanations).

Can I install it now? [Y/n]
n

You refused the installation (for now).
You can still used broot but some features won't be available.
If you want the br shell function, you may either
• do broot --install
• install the various pieces yourself
(see https://dystroy.org/broot/install-br/ for details).

New Configuration files written in "/home/home/.config/broot".
You should have a look at them.
```