### PR TITLE
Fall back on /usr/bin/editor for $EDITOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "users",
  "usvg",
  "usvg-text-layout",
+ "which",
  "xterm-query 0.1.0",
 ]
 
@@ -2503,6 +2504,17 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ umask = "2.0.0"
 unicode-width = "0.1.8"
 usvg = "0.28.0"
 usvg-text-layout = { version = "0.28.0", default-features = false }
+which = "4.4.0"
 xterm-query = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/src/launchable.rs
+++ b/src/launchable.rs
@@ -26,6 +26,7 @@ use {
         path::PathBuf,
         process::Command,
     },
+    which::which,
 };
 
 /// description of a possible launch of an external program
@@ -70,6 +71,14 @@ fn resolve_env_variables(parts: Vec<String>) -> Vec<String> {
             if let Ok(val) = env::var(var_name) {
                 resolved.extend(val.split(' ').map(|s| s.to_string()));
                 continue;
+            }
+            if var_name == "EDITOR" {
+                if let Ok(editor) = which("editor") {
+                    if let Some(editor) = editor.to_str() {
+                        resolved.push(editor.to_string());
+                        continue;
+                    }
+                }
             }
         }
         resolved.push(part);


### PR DESCRIPTION
This makes broot use `/usr/bin/editor` when `$EDITOR` has not been set yet. This reduces friction and improves the new user experience.

`/usr/bin/editor` is the convention on Ubnutu. Many editors such as `/bin/ed`, `/usr/bin/vim.basic` and `/usr/bin/vim.tiny` among others use `update-alternatives` to offer themselves as providers for `/usr/bin/editor` via `/etc/alternatives/editor`. `$EDITOR` is not usually set on Ubuntu. In fact, the Ubuntu developers patched software specifically for this. [For example](https://packages.ubuntu.com/kinetic/bash), `debian/patches/bash-default-editor.diff` in `bash_5.2-1ubuntu2.debian.tar.xz` makes bash consider `/usr/bin/editor` when doing CTRL-x CTRL-e.

This PR implements this Ubuntu-like behavior. It will not change anything if `$EDITOR` is already set. If someone is relying on a literal command called `$EDITOR`, they can start with `export EDITOR='$EDITOR'`, using the absolute path, or something else to get that back.

# Before

```
Unable to launch $EDITOR: No such file or directory (os error 2)
```

# After

vim opens.