### PR TITLE
feat: add a `is_terminal` verb attribute, so externals that don't have terminal output, don't flicker

### DIFF
--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -973,7 +973,7 @@ pub trait PanelState {
     ) -> Status {
         if sel_info.count_paths() > 1 {
             if let VerbExecution::External(external) = &verb.execution {
-                if external.exec_mode != ExternalExecutionMode::StayInBroot {
+                if external.exec_mode != ExternalExecutionMode::StayInBrootTerminal {
                     return Status::new(
                         "only verbs returning to broot on end can be executed on a multi-selection".to_owned(),
                         true,

--- a/src/conf/verb_conf.rs
+++ b/src/conf/verb_conf.rs
@@ -42,6 +42,8 @@ pub struct VerbConf {
 
     from_shell: Option<bool>,
 
+    is_terminal: Option<bool>,
+
     apply_to: Option<String>,
 
     set_working_dir: Option<bool>,
@@ -83,7 +85,7 @@ impl VerbConf {
             };
             ExternalExecution::new(
                 s,
-                ExternalExecutionMode::from_conf(vc.from_shell, vc.leave_broot),
+                ExternalExecutionMode::from_conf(vc.from_shell, vc.leave_broot, vc.is_terminal),
             )
             .with_working_dir(working_dir)
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     match broot::cli::run() {
         Ok(Some(launchable)) => {
             debug!("launching {:#?}", launchable);
-            if let Err(e) = launchable.execute(None) {
+            if let Err(e) = launchable.execute(true, None) {
                 warn!("Failed to launch {:?}", &launchable);
                 warn!("Error: {:?}", e);
                 eprintln!("{e}");

--- a/src/verb/builtin.rs
+++ b/src/verb/builtin.rs
@@ -88,10 +88,10 @@ pub fn builtin_verbs() -> Vec<Verb> {
             .with_description("change directory and quit"),
 
         #[cfg(unix)]
-        external("chmod {args}", "chmod {args} {file}", StayInBroot)
+        external("chmod {args}", "chmod {args} {file}", StayInBrootTerminal)
             .with_stype(SelectionType::File),
         #[cfg(unix)]
-        external("chmod {args}", "chmod -R {args} {file}", StayInBroot)
+        external("chmod {args}", "chmod -R {args} {file}", StayInBrootTerminal)
             .with_stype(SelectionType::Directory),
         internal(open_preview),
         internal(close_preview),
@@ -109,14 +109,14 @@ pub fn builtin_verbs() -> Vec<Verb> {
         external(
             "copy {newpath}",
             "cp -r {file} {newpath:path-from-parent}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("cp"),
         #[cfg(windows)]
         external(
             "copy {newpath}",
             "xcopy /Q /H /Y /I {file} {newpath:path-from-parent}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("cp"),
         #[cfg(feature = "clipboard")]
@@ -128,14 +128,14 @@ pub fn builtin_verbs() -> Vec<Verb> {
         external(
             "copy_to_panel",
             "cp -r {file} {other-panel-directory}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("cpp"),
         #[cfg(windows)]
         external(
             "copy_to_panel",
             "xcopy /Q /H /Y /I {file} {other-panel-directory}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("cpp"),
         #[cfg(unix)]
@@ -157,49 +157,49 @@ pub fn builtin_verbs() -> Vec<Verb> {
         external(
             "mkdir {subpath}",
             "mkdir -p {subpath:path-from-directory}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("md"),
         #[cfg(windows)]
         external(
             "mkdir {subpath}",
             "cmd /c mkdir {subpath:path-from-directory}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("md"),
         #[cfg(unix)]
         external(
             "move {newpath}",
             "mv {file} {newpath:path-from-parent}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("mv"),
         #[cfg(windows)]
         external(
             "move {newpath}",
             "cmd /c move /Y {file} {newpath:path-from-parent}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("mv"),
         #[cfg(unix)]
         external(
             "move_to_panel",
             "mv {file} {other-panel-directory}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("mvp"),
         #[cfg(windows)]
         external(
             "move_to_panel",
             "cmd /c move /Y {file} {other-panel-directory}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_shortcut("mvp"),
         #[cfg(unix)]
         external(
             "rename {new_filename:file-name}",
             "mv {file} {parent}/{new_filename}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_auto_exec(false)
             .with_key(key!(f2)),
@@ -207,7 +207,7 @@ pub fn builtin_verbs() -> Vec<Verb> {
         external(
             "rename {new_filename:file-name}",
             "cmd /c move /Y {file} {parent}/{new_filename}",
-            StayInBroot,
+            StayInBrootTerminal,
         )
             .with_auto_exec(false)
             .with_key(key!(f2)),
@@ -276,12 +276,12 @@ pub fn builtin_verbs() -> Vec<Verb> {
         internal(sort_by_size).with_shortcut("ss"),
         internal(sort_by_type).with_shortcut("st"),
         #[cfg(unix)]
-        external("rm", "rm -rf {file}", StayInBroot),
+        external("rm", "rm -rf {file}", StayInBrootTerminal),
         #[cfg(windows)]
-        external("rm", "cmd /c rmdir /Q /S {file}", StayInBroot)
+        external("rm", "cmd /c rmdir /Q /S {file}", StayInBrootTerminal)
             .with_stype(SelectionType::Directory),
         #[cfg(windows)]
-        external("rm", "cmd /c del /Q {file}", StayInBroot)
+        external("rm", "cmd /c del /Q {file}", StayInBrootTerminal)
             .with_stype(SelectionType::File),
         internal(toggle_counts).with_shortcut("counts"),
         internal(toggle_dates).with_shortcut("dates"),

--- a/src/verb/external_execution.rs
+++ b/src/verb/external_execution.rs
@@ -73,7 +73,14 @@ impl ExternalExecution {
                 builder,
                 con,
             ),
-            ExternalExecutionMode::StayInBroot => self.cmd_result_exec_stay_in_broot(
+            ExternalExecutionMode::StayInBrootTerminal => self.cmd_result_exec_stay_in_broot(
+                true,
+                w,
+                builder,
+                con,
+            ),
+            ExternalExecutionMode::StayInBrootGUI => self.cmd_result_exec_stay_in_broot(
+                false,
                 w,
                 builder,
                 con,
@@ -147,6 +154,7 @@ impl ExternalExecution {
     /// launched by broot
     fn cmd_result_exec_stay_in_broot(
         &self,
+        switch_terminal: bool,
         w: &mut W,
         builder: ExecutionStringBuilder<'_>,
         con: &AppContext,
@@ -161,7 +169,7 @@ impl ExternalExecution {
                     con,
                 )?;
                 info!("Executing not leaving, launchable {:?}", launchable);
-                if let Err(e) = launchable.execute(Some(w)) {
+                if let Err(e) = launchable.execute(switch_terminal, Some(w)) {
                     warn!("launchable failed : {:?}", e);
                     return Ok(CmdResult::error(e.to_string()));
                 }
@@ -181,7 +189,7 @@ impl ExternalExecution {
                         working_dir_path.clone(),
                         con,
                     )?;
-                    if let Err(e) = launchable.execute(Some(w)) {
+                    if let Err(e) = launchable.execute(switch_terminal, Some(w)) {
                         warn!("launchable failed : {:?}", e);
                         return Ok(CmdResult::error(e.to_string()));
                     }

--- a/src/verb/external_execution_mode.rs
+++ b/src/verb/external_execution_mode.rs
@@ -6,8 +6,11 @@ pub enum ExternalExecutionMode {
     /// executed on broot leaving, not necessarly in the parent shell
     LeaveBroot,
 
-    /// executed in a sub process without quitting broot
-    StayInBroot,
+    /// executed in a sub process without quitting broot, while restoring the terminal
+    StayInBrootTerminal,
+
+    /// executed in a sub process without quitting broot, without restoring the terminal
+    StayInBrootGUI,
 }
 
 impl ExternalExecutionMode {
@@ -15,19 +18,22 @@ impl ExternalExecutionMode {
         matches!(self, Self::FromParentShell)
     }
     pub fn is_leave_broot(self) -> bool {
-        !matches!(self, Self::StayInBroot)
+        !matches!(self, Self::StayInBrootTerminal)
     }
 
     pub fn from_conf(
         from_shell: Option<bool>,  // default is false
         leave_broot: Option<bool>, // default is true
+        is_terminal: Option<bool>, // default is true
     ) -> Self {
         if from_shell.unwrap_or(false) {
             Self::FromParentShell
         } else if leave_broot.unwrap_or(true) {
             Self::LeaveBroot
+        } else if is_terminal.unwrap_or(true) {
+            Self::StayInBrootTerminal
         } else {
-            Self::StayInBroot
+            Self::StayInBrootGUI
         }
     }
 }


### PR DESCRIPTION
I have a few custom external commands. One copies the current path with the home directory replaced with `~`. I use this one quite often. The constant flicker is rather annoying. Pretty much all of these commands flicker when run.

I discovered that the flicker is caused by `broot::launchable::Launchable::execute()` restoring the normal terminal for the command to run, and then reverting to *Broot*'s terminal. However none of the commands I use even have a terminal output.

So here I added a new `is_terminal` verb attribute. This defaults to `true` which is the previous behavior. But if set to `false`, it stops *Broot* restoring the normal terminal, hence removing the flicker