### PR TITLE
switch_terminal verb config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- `switch_terminal` verb parameter - Thanks @stevenxxiu
+
 ### v1.21.2 - 2023-03-30
 <a name="v1.21.2"></a>
 - update dependencies because of some yanked ones
@@ -5,7 +8,7 @@
 ### v1.21.1 - 2023-03-23
 <a name="v1.21.1"></a>
 - resolve ~ in special paths - Fix #685
-- better clipboard support on MacOS - thanks @bryan824
+- better clipboard support on MacOS - Thanks @bryan824
 
 ### v1.21.0 - 2023-03-17
 <a name="v1.21.0"></a>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broot"
-version = "1.21.2"
+version = "1.21.3-dev"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/broot"
 homepage = "https://dystroy.org/broot"

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -69,8 +69,7 @@ impl SelectionType {
 impl Selection<'_> {
 
     /// build a CmdResult with a launchable which will be used to
-    ///  1/ quit broot
-    ///  2/ open the relevant file the best possible way
+    /// open the relevant file the best possible way
     pub fn to_opener(
         self,
         con: &AppContext,
@@ -86,6 +85,7 @@ impl Selection<'_> {
                 CmdResult::from(Launchable::program(
                     vec![path],
                     None, // we don't set the working directory
+                    true, // we switch the terminal during execution
                     con,
                 )?)
             }

--- a/src/conf/verb_conf.rs
+++ b/src/conf/verb_conf.rs
@@ -52,6 +52,8 @@ pub struct VerbConf {
 
     auto_exec: Option<bool>,
 
+    switch_terminal: Option<bool>,
+
     #[serde(default)]
     panels: Vec<PanelStateType>,
 }
@@ -81,11 +83,15 @@ impl VerbConf {
                 (Some(true), None) => Some("{directory}".to_owned()),
                 (None, None) => None,
             };
-            ExternalExecution::new(
+            let mut external_execution = ExternalExecution::new(
                 s,
                 ExternalExecutionMode::from_conf(vc.from_shell, vc.leave_broot),
             )
-            .with_working_dir(working_dir)
+            .with_working_dir(working_dir);
+            if let Some(b) = self.switch_terminal {
+                external_execution.switch_terminal = b;
+            }
+            external_execution
         };
         let execution = match (execution, internal, external, cmd) {
             // old definition with "execution": we guess whether it's an internal or

--- a/src/verb/external_execution.rs
+++ b/src/verb/external_execution.rs
@@ -36,6 +36,10 @@ pub struct ExternalExecution {
     /// the working directory of the new process, or none if we don't
     /// want to set it
     pub working_dir: Option<String>,
+
+    /// whether we need to switch to the normal terminal for
+    /// the duration of the execution of the process
+    pub switch_terminal: bool,
 }
 
 impl ExternalExecution {
@@ -47,6 +51,7 @@ impl ExternalExecution {
             exec_pattern,
             exec_mode,
             working_dir: None,
+            switch_terminal: true, // by default we switch
         }
     }
 
@@ -138,6 +143,7 @@ impl ExternalExecution {
         let launchable = Launchable::program(
             builder.exec_token(&self.exec_pattern),
             self.working_dir_path(&builder),
+            self.switch_terminal,
             con,
         )?;
         Ok(CmdResult::from(launchable))
@@ -158,6 +164,7 @@ impl ExternalExecution {
                 let launchable = Launchable::program(
                     builder.exec_token(&self.exec_pattern),
                     working_dir_path,
+                    self.switch_terminal,
                     con,
                 )?;
                 info!("Executing not leaving, launchable {:?}", launchable);
@@ -179,6 +186,7 @@ impl ExternalExecution {
                     let launchable = Launchable::program(
                         builder.sel_exec_token(&self.exec_pattern, Some(sel)),
                         working_dir_path.clone(),
+                        self.switch_terminal,
                         con,
                     )?;
                     if let Err(e) = launchable.execute(Some(w)) {

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -44,6 +44,7 @@ working_dir | | the working directory of the external application, for example `
 set_working_dir | `false` | whether the working dir of the process must be set to the currently selected directory (it's equivalent to `workding_dir: "{directory}"`)
 auto_exec | `true` | whether to execute the verb as soon as it's key-triggered (instead of waiting for <kbd>enter</kbd>)
 panels | *all* | optional list of panel types in which the verb can be called. Default is all panels: `[tree, fs, preview, help, stage]`
+switch_terminal | `true` | whether to switch from alternate to normal terminal during execution
 
 The execution is defined either by `internal`, `external` or `cmd` so a verb must have exactly one of those (for compatibility with older versions broot still accepts `execution` for `internal` or `external` and guesses which one it is).
 


### PR DESCRIPTION
Broot runs in an "alternate terminal".
By default,  broot switches back to the normal terminal during the execution of a program it launches, then back to its alternate terminal on end of the external process.
In some cases, this adds an unnecessary flicker.
The `switch_terminal` verb parameter, whose default value is `true`, lets you disable this behaviour.

Same goal than https://github.com/Canop/broot/pull/692 but with some different data structures.