### PR TITLE
clear events after delay on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "broot"
-version = "1.21.2"
+version = "1.21.3-dev"
 dependencies = [
  "ahash 0.7.6",
  "ansi_colours",

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -31,6 +31,7 @@ pub struct BrowserState {
 }
 
 /// A task that can be computed in background
+#[derive(Debug)]
 enum BrowserTask {
     Search {
         pattern: InputPattern,

--- a/src/task_sync.rs
+++ b/src/task_sync.rs
@@ -114,6 +114,16 @@ impl Dam {
         !self.receiver.is_empty()
     }
 
+    /// drop all events, returns the count of removed events
+    pub fn clear(&mut self) -> usize {
+        let mut n = 0;
+        while self.has_event() {
+            n += 1;
+            self.next_event();
+        }
+        n
+    }
+
     /// block until next event (including the one which
     ///  may have been pushed back into the dam).
     /// no event means the source is dead (i.e. we


### PR DESCRIPTION
On Windows, powershell sends to broot a Resize event after it was launched, which interrupts its task (for example a filtering provided with `--cmd`).

Asking broot to wait for 10ms before cleaning its event queue and then working on its task queue solves the problem.

Fix #699