### PR TITLE
Allow dir size computation in /run/media

### DIFF
--- a/src/file_sum/sum_computation.rs
+++ b/src/file_sum/sum_computation.rs
@@ -84,7 +84,7 @@ impl DirSummer {
             debug!("not summing in /proc");
             return Some(FileSum::zero());
         }
-        if path.starts_with("/run") {
+        if path.starts_with("/run") && ! path.starts_with("/run/media") {
             debug!("not summing in /run");
             return Some(FileSum::zero());
         }


### PR DESCRIPTION
Dir size computation is disabled in /proc and /run by: https://github.com/Canop/broot/commit/aecfe73ba9947e2a1c04f70526cab87e49f4baef

However, usb disks are auto-mounted under /run/media, so let's allow dir size in this dir.

FIX: https://github.com/Canop/broot/issues/704