### PR TITLE
Powershell br function install

### DIFF
--- a/src/shell_install/mod.rs
+++ b/src/shell_install/mod.rs
@@ -3,6 +3,7 @@ mod fish;
 mod nushell;
 mod state;
 mod util;
+mod powershell;
 
 use {
     crate::{
@@ -87,6 +88,7 @@ impl ShellInstall {
             "bash" | "zsh" => println!("{}", bash::get_script()),
             "fish" => println!("{}", fish::get_script()),
             "nushell" => println!("{}", nushell::get_script()),
+            "powershell" => println!("{}", powershell::get_script()),
             _ => {
                 return Err(ProgramError::UnknowShell {
                     shell: shell.to_string(),
@@ -135,6 +137,7 @@ impl ShellInstall {
         bash::install(self)?;
         fish::install(self)?;
         nushell::install(self)?;
+        powershell::install(self)?;
         self.should_quit = true;
         if self.done {
             self.skin.print_text(MD_INSTALL_DONE);

--- a/src/shell_install/powershell.rs
+++ b/src/shell_install/powershell.rs
@@ -1,0 +1,116 @@
+use std::fs;
+
+use directories::UserDirs;
+
+use {
+    super::{util, ShellInstall},
+    crate::{conf, errors::*},
+    std::path::PathBuf,
+    termimad::mad_print_inline,
+};
+
+const NAME: &str = "powershell";
+const VERSION: &str = "1";
+
+const PS_FUNC: &str = r#"
+# https://github.com/Canop/broot/issues/460#issuecomment-1303005689
+Function br {
+  $args = $args -join ' '
+  $cmd_file = New-TemporaryFile
+  
+  $process = Start-Process -FilePath 'broot.exe' `
+                           -ArgumentList "--outcmd $($cmd_file.FullName) $args" `
+                           -NoNewWindow -PassThru -WorkingDirectory $PWD
+
+  Wait-Process -InputObject $process #Faster than Start-Process -Wait
+  If ($process.ExitCode -eq 0) {
+    $cmd = Get-Content $cmd_file
+    Remove-Item $cmd_file
+    If ($cmd -ne $null) { Invoke-Expression -Command $cmd }
+  } Else {
+    Remove-Item $cmd_file
+    Write-Host "`n" # Newline to tidy up broot unexpected termination
+    Write-Error "broot.exe exited with error code $($process.ExitCode)"
+  }
+}
+"#;
+
+pub fn get_script() -> &'static str {
+    PS_FUNC
+}
+
+/// return the path to the link to the function script
+fn get_link_path() -> PathBuf {
+    conf::dir().join("launcher").join(NAME).join("br.ps1")
+}
+
+/// return the path to the script containing the function.
+///
+/// In XDG_DATA_HOME (typically ~/.local/share on linux)
+fn get_script_path() -> PathBuf {
+    conf::app_dirs()
+        .data_dir()
+        .join("launcher")
+        .join(NAME)
+        .join(VERSION)
+}
+
+/// Check whether the shell function is installed, install
+/// it if it wasn't refused before or if broot is launched
+/// with --install.
+pub fn install(si: &mut ShellInstall) -> Result<(), ShellInstallError> {
+    info!("install {NAME}");
+    #[cfg(unix)]
+    {
+        debug!("Shell install not supported for PowerShell on unix-based systems.");
+        return Ok(());
+    }
+    let Some(user_dir) = UserDirs::new() else {
+        warn!("Could not find user directory.");
+        return Ok(());
+    };
+    let Some(document_dir) = user_dir.document_dir() else {
+        warn!("Could not find document directory.");
+        return Ok(());
+    };
+
+    let script_path = get_script_path();
+    si.write_script(&script_path, PS_FUNC)?;
+    let link_path = get_link_path();
+    si.create_link(&link_path, &script_path)?;
+
+    let escaped_path = link_path.to_string_lossy().replace(' ', "\\ ");
+    let source_line = format!(". {}", &escaped_path);
+
+    let sourcing_path = document_dir.join("WindowsPowerShell").join("Profile.ps1");
+    if !sourcing_path.exists() {
+        debug!("Creating missing PowerShell profile file.");
+        if let Some(parent) = sourcing_path.parent() {
+            if let Err(_e) = fs::create_dir(parent) {
+                warn!("Error creating WindowsPowerShell directory.");
+                return Ok(());
+            }
+        }
+        if let std::io::Result::Err(_err) = fs::File::create(&sourcing_path) {
+            warn!("Error creating PowerShell profile file.");
+            return Ok(());
+        };
+    }
+    let sourcing_path_str = sourcing_path.to_string_lossy();
+    if util::file_contains_line(&sourcing_path, &source_line)? {
+        mad_print_inline!(
+            &si.skin,
+            "`$0` already patched, no change made.\n",
+            &sourcing_path_str,
+        );
+    } else {
+        util::append_to_file(&sourcing_path, format!("\n{source_line}\n"))?;
+        mad_print_inline!(
+            &si.skin,
+            "`$0` successfully patched, you can make the function immediately available with `. $0`\n",
+            &sourcing_path_str,
+        );
+    }
+    si.done = true;
+    Ok(())
+}


### PR DESCRIPTION
A PowerShell br function install module based on [AeliusSaionji's br function](https://github.com/Canop/broot/issues/460#issuecomment-1303005689) as suggested in #625 and #159.  It follows the same conventions as the other install modules. The function is added to the $HOME\Documents\WindowsPowerShell\Profile.ps1 profile.

I tested this on two Windows 10 machines but not on Windows 11.