### PR TITLE
fix Powershell br function install error

### DIFF
--- a/src/shell_install/powershell.rs
+++ b/src/shell_install/powershell.rs
@@ -12,10 +12,7 @@ use {
     super::{util, ShellInstall},
     crate::{conf, errors::*},
     directories::UserDirs,
-    std::{
-        fs,
-        path::PathBuf,
-    },
+    std::{fs, path::PathBuf},
     termimad::mad_print_inline,
 };
 
@@ -97,7 +94,7 @@ pub fn install(si: &mut ShellInstall) -> Result<(), ShellInstallError> {
     if !sourcing_path.exists() {
         debug!("Creating missing PowerShell profile file.");
         if let Some(parent) = sourcing_path.parent() {
-            fs::create_dir(parent).context(&|| format!("creating {parent:?} directory"))?;
+            fs::create_dir_all(parent).context(&|| format!("creating {parent:?} directory"))?;
         }
         fs::File::create(&sourcing_path).context(&|| format!("creating {sourcing_path:?}"))?;
     }


### PR DESCRIPTION
Fix a [bug](https://github.com/Canop/broot/pull/720#issuecomment-1637196067) where the install fails if the WindowsPowerShell directory already exists but the Profile file does not.  The error is raised because fs::create_dir fails if the target directory already exists. fs::create_dir_all does not.