### PR TITLE
Add `{git-root}` substitution

### DIFF
--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -148,6 +148,19 @@ impl<'b> ExecutionStringBuilder<'b> {
                 .other_file
                 .and_then(|p| p.parent())
                 .map(path_to_string),
+            "git-root" => {
+                debug!("finding git root");
+                sel.and_then(|s| match git2::Repository::discover(s.path) {
+                    Ok(repo) => repo.workdir().map(path_to_string),
+                    Err(err) => {
+                        error!(
+                            "Failed to open Git repository at {}: {err}",
+                            s.path.display()
+                        );
+                        None
+                    }
+                })
+            }
             _ => None,
         }
     }

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -194,10 +194,6 @@ pub fn on_internal(
                 input_arg,
                 app_state,
             );
-            let tree_options = TreeOptions {
-                pattern: InputPattern::none(),
-                ..tree_options
-            };
             on_path(path, screen, tree_options, bang, con)
         }
         _ => {

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -1,5 +1,7 @@
 //! utility functions to help handle the `:focus` internal
 
+use crate::pattern::InputPattern;
+
 use {
     super::*,
     crate::{
@@ -122,7 +124,13 @@ fn path_from_input(
             // The given path may be relative hence the need for the
             // state's selection
             // (we assume a check before ensured it doesn't need an input)
-            path::path_from(base_path, PathAnchor::Unspecified, verb_arg)
+            let path_builder = ExecutionStringBuilder::with_invocation(
+                &verb.invocation_parser,
+                SelInfo::from_path(base_path),
+                app_state,
+                None,
+            );
+            path_builder.path(verb_arg)
         }
         (None, None) => {
             // user only wants to open the selected path, either in the same panel or
@@ -186,6 +194,10 @@ pub fn on_internal(
                 input_arg,
                 app_state,
             );
+            let tree_options = TreeOptions {
+                pattern: InputPattern::none(),
+                ..tree_options
+            };
             on_path(path, screen, tree_options, bang, con)
         }
         _ => {

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -300,6 +300,7 @@ name | expanded to
 `{other-panel-parent}` | complete path of the current selection's parent in the other panel
 `{other-panel-directory}` | closest directory, either `{file}` or `{parent}` in the other panel
 `{root}` | current tree root (top of the displayed files tree)
+`{git-root}` | The working directory of the Git repository containing the current selection
 
 !!!	Note
 	when you're in the help screen, `{file}` is the configuration file, while `{directory}` is the configuration directory.


### PR DESCRIPTION
Initial attempt at #760. This works well in my testing.