### PR TITLE
Extend 'apply_to' with 'text_file' and 'binary_file'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### next
+- the `apply_to` verb filter accepts new values: `text_file` and `binary_file`. Broot users editing files in their terminal (vi, emacs, etc.) should configure broot to open their text editor on `enter`: see https://dystroy.org/broot/tricks/#change-standard-file-opening
 - small breaking change: `:stage_all_files` now stages also symlinks - Fix #606
 - new `{git-root}` verb argument - Fix 760 - Thanks @9999years
 

--- a/resources/default-conf/verbs.hjson
+++ b/resources/default-conf/verbs.hjson
@@ -6,23 +6,10 @@
 
 verbs: [
 
-    # Example 1: launching `tail -n` on the selected file (leaving broot)
-    # {
-    #     name: tail_lines
-    #     invocation: tl {lines_count}
-    #     execution: "tail -f -n {lines_count} {file}"
-    # }
-
-    # Example 2: creating a new file without leaving broot
-    # {
-    #     name: touch
-    #     invocation: touch {new_file}
-    #     execution: "touch {directory}/{new_file}"
-    #     leave_broot: false
-    # }
-
-    # A standard recommended command for editing files, that you
-    # can customize.
+    # You should customize this standard opening of text files.
+    # If you edit text files in your terminal (vi, emacs, helix, eg.), then
+    #  you'll find it convenient to change the 'key' from 'ctrl-e' to 'enter'.
+    #
     # If $EDITOR isn't set on your computer, you should either set it using
     #  something similar to
     #    export EDITOR=/usr/local/bin/nvim
@@ -37,9 +24,26 @@ verbs: [
     {
         invocation: edit
         shortcut: e
+        key: ctrl-e
+        apply_to: text_file
         execution: "$EDITOR {file}"
         leave_broot: false
     }
+
+    # Example 1: launching `tail -n` on the selected file (leaving broot)
+    # {
+    #     name: tail_lines
+    #     invocation: tl {lines_count}
+    #     execution: "tail -f -n {lines_count} {file}"
+    # }
+
+    # Example 2: creating a new file without leaving broot
+    # {
+    #     name: touch
+    #     invocation: touch {new_file}
+    #     execution: "touch {directory}/{new_file}"
+    #     leave_broot: false
+    # }
 
     # A convenient shortcut to create new text files in
     #  the current directory or below
@@ -84,6 +88,12 @@ verbs: [
     #     invocation: home
     #     key: ctrl-home
     #     execution: ":focus ~"
+    # }
+
+    # Here's going to the work-dir root of the current git repository
+    # {
+    #     invocation: gtr
+    #     execution: ":focus {git-root}"
     # }
 
     # A popular set of shortcuts for going up and down:

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -7,6 +7,7 @@ use {
         errors::ProgramError,
         launchable::Launchable,
         stage::Stage,
+        verb::FileTypeCondition,
     },
     std::{
         fs::OpenOptions,
@@ -110,6 +111,20 @@ impl<'a> SelInfo<'a> {
             SelInfo::None => 0,
             SelInfo::One(_) => 1,
             SelInfo::More(stage) => stage.len(),
+        }
+    }
+    pub fn is_accepted_by(&self, condition: FileTypeCondition) -> bool {
+        match self {
+            SelInfo::None => true,
+            SelInfo::One(sel) => condition.accepts_path(sel.path),
+            SelInfo::More(stage) => {
+                for path in stage.paths().iter() {
+                    if !condition.accepts_path(path) {
+                        return false;
+                    }
+                }
+                true
+            }
         }
     }
     pub fn common_stype(&self) -> Option<SelectionType> {

--- a/src/command/panel_input.rs
+++ b/src/command/panel_input.rs
@@ -287,7 +287,7 @@ impl PanelInput {
             if !verb.keys.contains(&key) {
                 continue;
             }
-            if !verb.selection_condition.is_respected_by(sel_info.common_stype()) {
+            if !sel_info.is_accepted_by(verb.selection_condition) {
                 continue;
             }
             if !verb.can_be_called_in_panel(panel_state_type) {

--- a/src/conf/verb_conf.rs
+++ b/src/conf/verb_conf.rs
@@ -38,7 +38,8 @@ pub struct VerbConf {
 
     pub from_shell: Option<bool>,
 
-    pub apply_to: Option<String>,
+    #[serde(default)]
+    pub apply_to: FileTypeCondition,
 
     pub set_working_dir: Option<bool>,
 

--- a/src/content_search/mod.rs
+++ b/src/content_search/mod.rs
@@ -4,7 +4,7 @@ mod content_search_result;
 mod needle;
 
 pub use {
-    crate::content_type::{extensions, magic_numbers},
+    crate::content_type::{self, extensions, magic_numbers},
     content_match::ContentMatch,
     content_search_result::ContentSearchResult,
     needle::Needle,
@@ -46,10 +46,17 @@ pub fn get_mmap_if_suitable<P: AsRef<Path>>(hay_path: P, max_size: usize) -> io:
 
 /// return true when the file looks suitable for searching as text.
 ///
-/// This function is quite slow as it creates a memmap just to check
-/// a few bytes. If the memmap can be used, prefer `get_mmap_if_not_binary`
+/// If a memmap will be needed afterwards, prefer to use `get_mmap_if_not_binary`
+/// which optimizes testing and getting the mmap.
 pub fn is_path_suitable<P: AsRef<Path>>(path: P, max_size: usize) -> bool {
-    matches!(get_mmap_if_suitable(path, max_size), Ok(Some(_)))
+    let path = path.as_ref();
+    let Ok(metadata) = path.metadata() else {
+        return false;
+    };
+    if metadata.len() > max_size as u64 {
+        return false;
+    }
+    content_type::is_file_text(path).unwrap_or(false)
 }
 
 /// Return the 1-indexed line number for the byte at position pos

--- a/src/content_search/mod.rs
+++ b/src/content_search/mod.rs
@@ -1,11 +1,10 @@
 
 mod content_match;
 mod content_search_result;
-mod magic_numbers;
-mod extensions;
 mod needle;
 
 pub use {
+    crate::content_type::{extensions, magic_numbers},
     content_match::ContentMatch,
     content_search_result::ContentSearchResult,
     needle::Needle,
@@ -53,6 +52,7 @@ pub fn is_path_suitable<P: AsRef<Path>>(path: P, max_size: usize) -> bool {
     matches!(get_mmap_if_suitable(path, max_size), Ok(Some(_)))
 }
 
+/// Return the 1-indexed line number for the byte at position pos
 pub fn line_count_at_pos<P: AsRef<Path>>(path: P, pos: usize) -> io::Result<usize> {
     let mut reader = BufReader::new(File::open(path)?);
     let mut line = String::new();

--- a/src/content_type/extensions.rs
+++ b/src/content_type/extensions.rs
@@ -88,3 +88,4 @@ static BINARY_EXTENSIONS: Set<&'static str> = phf_set! {
 pub fn is_known_binary(ext: &str) -> bool {
     BINARY_EXTENSIONS.contains(ext)
 }
+

--- a/src/content_type/magic_numbers.rs
+++ b/src/content_type/magic_numbers.rs
@@ -120,6 +120,6 @@ pub fn is_known_binary(bytes: &[u8]) -> bool {
 pub fn is_file_known_binary<P: AsRef<Path>>(path: P) -> io::Result<bool> {
     let mut buf = [0; 4];
     let mut file = File::open(path)?;
-    file.read(&mut buf)?;
-    Ok(is_known_binary(&buf))
+    let n = file.read(&mut buf)?;
+    Ok(is_known_binary(&buf[0..n]))
 }

--- a/src/content_type/magic_numbers.rs
+++ b/src/content_type/magic_numbers.rs
@@ -1,7 +1,11 @@
 
 use {
-    memmap2::Mmap,
     phf::{phf_set, Set},
+    std::{
+        path::Path,
+        fs::File,
+        io::{self, Read},
+    },
 };
 
 pub const MIN_FILE_SIZE: usize = 100;
@@ -73,11 +77,11 @@ static SIGNATURES_4: Set<[u8; 4]> = phf_set! {
 ///
 /// If you feel this list should maybe be changed, contact
 /// me on miaou or raise an issue.
-pub fn is_known_binary(hay: &Mmap) -> bool {
-    if hay.len() < MIN_FILE_SIZE {
+pub fn is_known_binary(bytes: &[u8]) -> bool {
+    if bytes.len() < 4 {
         return false;
     }
-    let c = unsafe { *hay.get_unchecked(0) };
+    let c = bytes[0];
     if c < 9 || (c > 13 && c < 32) || c >= 254 {
         // c < 9 include several signatures
         // 14 to 31 includes several signatures among them some variants of zip, gzip, etc.
@@ -87,27 +91,35 @@ pub fn is_known_binary(hay: &Mmap) -> bool {
         return true;
     }
     // for signature in &SIGNATURES_2 {
-    //     if signature == &hay[0..2] {
+    //     if signature == &bytes[0..2] {
     //         return true;
     //     }
     // }
     // for signature in &SIGNATURES_3 {
-    //     if signature == &hay[0..3] {
+    //     if signature == &bytes[0..3] {
     //         return true;
     //     }
     // }
-    if SIGNATURES_4.contains(&hay[0..4]) {
+    if SIGNATURES_4.contains(&bytes[0..4]) {
         return true;
     }
     // for signature in &SIGNATURES_5 {
-    //     if signature == &hay[0..5] {
+    //     if signature == &bytes[0..5] {
     //         return true;
     //     }
     // }
     // for signature in &SIGNATURES_6 {
-    //     if signature == &hay[0..6] {
+    //     if signature == &bytes[0..6] {
     //         return true;
     //     }
     // }
     false
+}
+
+/// Tell whether the file i
+pub fn is_file_known_binary<P: AsRef<Path>>(path: P) -> io::Result<bool> {
+    let mut buf = [0; 4];
+    let mut file = File::open(path)?;
+    file.read(&mut buf)?;
+    Ok(is_known_binary(&buf))
 }

--- a/src/content_type/mod.rs
+++ b/src/content_type/mod.rs
@@ -1,0 +1,28 @@
+pub mod magic_numbers;
+pub mod extensions;
+
+use {
+    std::{
+        io,
+        path::Path,
+    },
+};
+
+/// Assuming the path is already checked to be to a file
+/// (not a link or directory), tell whether it looks like a text file
+pub fn is_file_text<P: AsRef<Path>>(path: P) -> io::Result<bool> {
+    // the current algorithm is rather crude. If needed I'll add
+    // more, like checking the start of the file is UTF8 compatible
+    Ok(!is_file_binary(path)?)
+}
+
+/// Assuming the path is already checked to be to a file
+/// (not a link or directory), tell whether it looks like a binary file
+pub fn is_file_binary<P: AsRef<Path>>(path: P) -> io::Result<bool> {
+    if let Some(ext) = path.as_ref().extension().and_then(|s| s.to_str()) {
+        if extensions::is_known_binary(ext) {
+            return Ok(true);
+        }
+    }
+    magic_numbers::is_file_known_binary(path)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod command;
 pub mod conf;
 pub mod content_search;
+pub mod content_type;
 pub mod display;
 pub mod errors;
 pub mod file_sum;

--- a/src/verb/file_type_condition.rs
+++ b/src/verb/file_type_condition.rs
@@ -18,7 +18,6 @@ pub enum FileTypeCondition {
     File,
     TextFile,
     BinaryFile,
-    //ImageFile, no support yet, unsure whether it could be useful
 }
 
 impl FileTypeCondition {

--- a/src/verb/file_type_condition.rs
+++ b/src/verb/file_type_condition.rs
@@ -1,0 +1,64 @@
+use {
+    crate::{
+        app::SelectionType,
+        content_type,
+        tree::{TreeLine, TreeLineType},
+    },
+    serde::Deserialize,
+    std::path::Path,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileTypeCondition {
+    #[default]
+    Any,
+    // directory or link to a directory
+    Directory,
+    File,
+    TextFile,
+    BinaryFile,
+    //ImageFile, no support yet, unsure whether it could be useful
+}
+
+impl FileTypeCondition {
+    pub fn accepts_path(self, path: &Path) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Directory => path.is_dir(),
+            Self::File => path.is_file(),
+            Self::TextFile => {
+                path.is_file() && matches!(content_type::is_file_text(path), Ok(true))
+            }
+            Self::BinaryFile => {
+                path.is_file() && matches!(content_type::is_file_binary(path), Ok(true))
+            }
+        }
+    }
+    pub fn accepts_line(self, line: &TreeLine) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Directory => line.is_dir(),
+            Self::File => matches!(line.line_type, TreeLineType::File),
+            Self::TextFile => {
+                line.is_file() && matches!(content_type::is_file_text(&line.path), Ok(true))
+            }
+            Self::BinaryFile => {
+                line.is_file() && matches!(content_type::is_file_binary(&line.path), Ok(true))
+            }
+        }
+    }
+    /// a little clunky, should be used only on well defined cases, like documenting
+    /// internals
+    pub fn accepts_selection_type(
+        self,
+        stype: SelectionType,
+    ) -> bool {
+        match (self, stype) {
+            (Self::Any, _) => true,
+            (Self::Directory, SelectionType::Directory) => true,
+            (Self::File, SelectionType::File) => true,
+            _ => false,
+        }
+    }
+}

--- a/src/verb/mod.rs
+++ b/src/verb/mod.rs
@@ -3,6 +3,7 @@ mod exec_pattern;
 mod execution_builder;
 mod external_execution;
 mod external_execution_mode;
+mod file_type_condition;
 mod internal;
 mod internal_execution;
 pub mod internal_focus;
@@ -21,6 +22,7 @@ pub use {
     execution_builder::ExecutionStringBuilder,
     external_execution::ExternalExecution,
     external_execution_mode::ExternalExecutionMode,
+    file_type_condition::*,
     internal::Internal,
     internal_execution::InternalExecution,
     invocation_parser::InvocationParser,

--- a/src/verb/verb.rs
+++ b/src/verb/verb.rs
@@ -53,7 +53,7 @@ pub struct Verb {
     pub description: VerbDescription,
 
     /// the type of selection this verb applies to
-    pub selection_condition: SelectionType,
+    pub selection_condition: FileTypeCondition,
 
     /// extension filtering. If empty, all extensions apply
     pub file_extensions: Vec<String>,
@@ -119,7 +119,7 @@ impl Verb {
             invocation_parser,
             execution,
             description,
-            selection_condition: SelectionType::Any,
+            selection_condition: FileTypeCondition::Any,
             file_extensions: Vec::new(),
             needs_selection,
             needs_another_panel,
@@ -149,8 +149,8 @@ impl Verb {
         self.names.push(shortcut.to_string());
         self
     }
-    pub fn with_stype(&mut self, stype: SelectionType) -> &mut Self {
-        self.selection_condition = stype;
+    pub fn with_condition(&mut self, selection_condition: FileTypeCondition) -> &mut Self {
+        self.selection_condition = selection_condition;
         self
     }
     pub fn needing_another_panel(&mut self) -> &mut Self {
@@ -288,5 +288,13 @@ impl Verb {
 
     pub fn can_be_called_in_panel(&self, panel_state_type: PanelStateType) -> bool {
         self.panels.is_empty() || self.panels.contains(&panel_state_type)
+    }
+    pub fn accepts_extension(&self, extension: Option<&str>) -> bool {
+        if self.file_extensions.is_empty() {
+            true
+        } else {
+            extension
+                .map_or(false, |ext| self.file_extensions.iter().any(|ve| ve == ext))
+        }
     }
 }

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -39,7 +39,7 @@ keys | | several keyboard shortcuts triggering execution (if you want to have th
 shortcut | | an alternate way to call the verb (without the arguments part)
 leave_broot | `true` | whether to quit broot on execution
 from_shell | `false` | whether the verb must be executed from the parent shell (needs `br`). As this is executed after broot closed, this isn't compatible with `leave_broot = false`
-apply_to | | the type of selection this verb applies to, may be `"file"`, `"directory"` or `"any"`. You may declare two verbs with the same key if the first one applies to only files or only directories
+apply_to | | the type of selection this verb applies to: `"file"`, `"text_file"`, `"binary_file"`, `"directory"` or `"any"`. You may declare two verbs with the same key if the first one applies, eg, to only text files or only to directories
 working_dir | | the working directory of the external application, for example `"{directory}"` for the closest directory (the working dir isn't set if the directory doesn't exist)
 set_working_dir | `false` | whether the working dir of the process must be set to the currently selected directory (it's equivalent to `workding_dir: "{directory}"`)
 auto_exec | `true` | whether to execute the verb as soon as it's key-triggered (instead of waiting for <kbd>enter</kbd>)

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -176,4 +176,7 @@ The simplest solution is to remove your old configuration directory (or rename i
 
 # After installation
 
-Now you should [install the br shell function](../install-br/).
+Now you should
+
+1. [install the br shell function](../install-br/)
+2. have a look at the verbs.hjson configuration file, and especially setup the editor of your choice

--- a/website/docs/tricks.md
+++ b/website/docs/tricks.md
@@ -114,37 +114,38 @@ This can be done with the `:focus` verb which can be called with <kbd>ctrl</kbd>
 
 # Run a script or program from broot
 
-If your system is normally configured, doing `alt`-`enter` on an executable will close broot and executes the file.
+If your system is normally configured, doing `alt`-`enter` on an executable will close broot and execute the file.
 
 # Change standard file opening
 
-When you hit enter on a file, broot asks the system to open the file. It's usually the best solution as it selects the program according to the file's type and settings you set system wide.
+When you hit enter on a file, broot asks the system to open the file.
+It's usually the best solution as it selects the program according to the file's type and to settings you set system wide.
 
-You might still wish to change that, for example when you're on a server without xdg-open or equivalent.
+If you're editing text files in your terminal (vi, emacs, helix, etc.), then you'd rather have your editor open in the same terminal on enter, and be back to broot on quitting it.
 
-Here's an example of configuration changing the behaviour on open:
+Here's an example:
 
 ```Hjson
-verbs: [
-    {
-        invocation: edit
-        key: enter
-        external: "$EDITOR {file}"
-        leave_broot: false
-        apply_to: file
-    }
-]
+{
+    invocation: edit
+    key: enter
+    shortcut: e
+    execution: "/usr/bin/nvim +{line} {file}"
+    apply_to: text_file
+    leave_broot: false
+}
 ```
 ```TOML
 [[verbs]]
 invocation = "edit"
 key = "enter"
-external = "$EDITOR {file}"
+shortcut = "e"
+execution = "/usr/bin/nvim +{line} {file}"
+apply_to = "text_file"
 leave_broot = false
-apply_to = "file"
 ```
 
-(the `apply_to` line ensures this verb isn't called when the selected line is a directory)
+You'll also need such kind of setting if your computer is missing xdg-open or equivalent.
 
 If you need to use a different application for some kind(s) of file, you may additionally [filter by extension](../conf_verbs/#file-extensions).
 


### PR DESCRIPTION
This makes it possible, for example, to have text files open in the same terminal on 'enter':

```Hjson
{
    invocation: edit
    key: enter
    shortcut: e
    execution: "/usr/bin/nvim +{line} {file}"
    apply_to: text_file
    leave_broot: false
}
```

Fix #764