### PR TITLE
MVC to fix path issues on Windows

### DIFF
--- a/src/shell_install/bash.rs
+++ b/src/shell_install/bash.rs
@@ -129,7 +129,14 @@ pub fn install(si: &mut ShellInstall) -> Result<(), ShellInstallError> {
         return Ok(());
     }
     let escaped_path = link_path.to_string_lossy().replace(' ', "\\ ");
-    let source_line = format!("source {}", &escaped_path);
+    let source_line = {
+        if env::consts::OS == "windows" {
+            // Bash on Windows doesn't like C:\Users\... but will accept "C:\Users\..."
+            format!("source \"{}\"", &escaped_path)
+        } else {
+            format!("source {}", &escaped_path)
+        }
+    };
     for sourcing_path in &sourcing_paths {
         let sourcing_path_str = sourcing_path.to_string_lossy();
         if util::file_contains_line(sourcing_path, &source_line)? {

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -409,5 +409,10 @@ mod execution_builder_test {
 }
 
 fn path_to_string<P: AsRef<Path>>(path: P) -> String {
-    path.as_ref().to_string_lossy().to_string()
+    let is_bash_on_windows = true;
+    if is_bash_on_windows {
+        format!("\"{}\"", path.as_ref().to_string_lossy().to_string())
+    } else {
+        path.as_ref().to_string_lossy().to_string()
+    }
 }


### PR DESCRIPTION
I'm a Windows user who mainly uses bash. I can see there are some rough edges on Windows, and it's noted elsewhere that the maintainers aren't Windows users themselves (which is understandable). I'm hoping to try and work through some of the rough edges to do with path handling, especially with bash.

I can see #588, #460, #78, #98, #99 which should mostly be fixed by something similar to the below. Have you got any others?

I'll have to do some work to formally detect cygwin / bash on windows, but I'll hardcode it locally for myself and run it for a while to see how it goes.

I wonder if the more elegant solution is to use / for paths everywhere instead of quoting, but that will bring up its own issues. I'll see how it works with the quoting for a while and then think about it a bit more.