### PR TITLE
Fix Windows crash when running -c

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -746,6 +746,7 @@ impl App {
             std::thread::sleep(delay);
             let dropped_events = dam.clear();
             debug!("Dropped {dropped_events} events");
+            event_source.unblock(self.quitting);
         }
 
         if let Some(raw_sequence) = &con.launch_args.cmd {


### PR DESCRIPTION
A previous change adding some PS-specific fixes that affected all Windows instances when -c was called. However if -c was called with an incomplete command (and therefore should put broot into an interactive state) this had the effect of hanging the app.

This should fix #776 . It does make me a bit uncomfortable that this means that you can end up in interactive mode in two different ways. One by running `br` regularly and one with `-c "Incomplete command"` except in the latter case, the window hasn't been resized as the `Resize` event gets dropped. However until I see manifestations of this behaviour I think this might be hacky enough to be ok?

I've tested this with bash and PS, using `-c` and without, and it all seems fine.