### PR TITLE
RUSTSEC-2023-0040, RUSTSEC-2023-0059: Switch dependency from "users" to "uzers"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
  "toml",
  "umask",
  "unicode-width",
- "users",
+ "uzers",
  "which",
  "xterm-query 0.1.0",
 ]
@@ -2421,16 +2421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "usvg"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2486,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ glassbench = "0.3.6"
 
 [target.'cfg(unix)'.dependencies]
 lfs-core = "0.11.0"
-users = "0.11"
+uzers = "0.11.3"
 
 [target.'cfg(windows)'.dependencies]
 is_executable = "1.0.1"

--- a/src/permissions/permissions_unix.rs
+++ b/src/permissions/permissions_unix.rs
@@ -16,7 +16,7 @@ pub fn user_name(uid: u32) -> String {
     let name = users_cache
         .entry(uid)
         .or_insert_with(|| {
-            users::get_user_by_uid(uid).map_or_else(
+            uzers::get_user_by_uid(uid).map_or_else(
                 || "????".to_string(),
                 |u| u.name().to_string_lossy().to_string(),
             )
@@ -32,7 +32,7 @@ pub fn group_name(gid: u32) -> String {
     let name = groups_cache
         .entry(gid)
         .or_insert_with(|| {
-            users::get_group_by_gid(gid).map_or_else(
+            uzers::get_group_by_gid(gid).map_or_else(
                 || "????".to_string(),
                 |u| u.name().to_string_lossy().to_string(),
             )


### PR DESCRIPTION
"users" is unmaintained ([RUSTSEC-2023-0040](https://rustsec.org/advisories/RUSTSEC-2023-0040)) and has a listed vulnerability ([RUSTSEC-2023-0059](https://rustsec.org/advisories/RUSTSEC-2023-0059)). Switch to the maintained and updated fork "[uzers](https://github.com/rustadopt/uzers-rs)", and upgrade to [0.11.3](https://github.com/rustadopt/uzers-rs/releases/tag/v0.11.3) that has the fix for RUSTSEC-2023-0059.