### PR TITLE
fix: ✨ nushell deprecation

### DIFF
--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -33,7 +33,7 @@ const NU_FUNC: &str = r#"
 #   > br -hi -c "vacheblan.svg;:open_preview" ..
 #
 # See https://dystroy.org/broot/install-br/
-def-env br [
+def --env br [
     --cmd(-c): string               # Semicolon separated commands to execute
     --color: string = "auto"        # Whether to have styles and colors (auto is default and usually OK) [possible values: auto, yes, no]
     --conf: string                  # Semicolon separated paths to specific config files"),


### PR DESCRIPTION
def-env is now def --env

![image](https://github.com/Canop/broot/assets/7041726/c18908b8-4808-44d7-a8e2-6e2c94839f9f)
