### PR TITLE
terminal_title parameter in config

### DIFF
--- a/resources/default-conf/conf.hjson
+++ b/resources/default-conf/conf.hjson
@@ -27,6 +27,17 @@
 # default_flags:
 
 ###############################################################
+# Terminal's title
+# If you want the terminal's title to be updated when you change
+# directory, set a terminal_title pattern by uncommenting one of
+# the examples below and tuning it to your taste.
+# Note that this may slow down some systems.
+#
+# terminal_title: "[broot] {git-name}"
+# terminal_title: "🐄 {file}"
+# terminal_title: "-= {file-name} =-"
+
+###############################################################
 # Date/Time format
 # If you want to change the format for date/time, uncomment the
 # following line and change it according to

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -12,7 +12,7 @@ use {
         skin::ExtColorMap,
         syntactic::SyntaxTheme,
         tree::TreeOptions,
-        verb::VerbStore,
+        verb::*,
     },
     std::{
         convert::{TryFrom, TryInto},
@@ -97,6 +97,10 @@ pub struct AppContext {
 
     /// max file size when searching file content
     pub content_search_max_file_size: usize,
+
+    /// the optional pattern used to change the terminal's title
+    /// (if none, the title isn't modified)
+    pub terminal_title_pattern: Option<ExecPattern>,
 }
 
 impl AppContext {
@@ -167,6 +171,8 @@ impl AppContext {
             .map(|u64value| usize::try_from(u64value).unwrap_or(usize::MAX))
             .unwrap_or(content_search::DEFAULT_MAX_FILE_SIZE);
 
+        let terminal_title_pattern = config.terminal_title.clone();
+
         Ok(Self {
             initial_root,
             initial_file,
@@ -190,6 +196,7 @@ impl AppContext {
             file_sum_threads_count,
             max_staged_count,
             content_search_max_file_size,
+            terminal_title_pattern,
         })
     }
     /// Return the --cmd argument, coming from the launch arguments (prefered)

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -14,6 +14,7 @@ use {
         },
         skin::SkinEntry,
         syntactic::SyntaxTheme,
+        verb::ExecPattern,
     },
     ahash::AHashMap,
     crokey::crossterm::style::Attribute,
@@ -107,6 +108,12 @@ pub struct Conf {
 
     #[serde(alias="content-search-max-file-size", deserialize_with="file_size::deserialize", default)]
     pub content_search_max_file_size: Option<u64>,
+
+    #[serde(alias="terminal-title")]
+    pub terminal_title: Option<ExecPattern>,
+
+    // BEWARE: entries added here won't be usable unless also
+    // added in read_file!
 }
 
 impl Conf {
@@ -187,6 +194,7 @@ impl Conf {
         overwrite!(self, max_staged_count, conf);
         overwrite!(self, show_matching_characters_on_path_searches, conf);
         overwrite!(self, content_search_max_file_size, conf);
+        overwrite!(self, terminal_title, conf);
         self.verbs.append(&mut conf.verbs);
         // the following maps are "additive": we can add entries from several
         // config files and they still make sense

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod shell_install;
 pub mod skin;
 pub mod syntactic;
 pub mod task_sync;
+pub mod terminal;
 pub mod tree;
 pub mod tree_build;
 pub mod verb;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,43 @@
+use {
+    crate::{
+        app::*,
+        display::W,
+        verb::*,
+    },
+    std::io::Write,
+};
+
+/// Change the terminal's title if broot was configured with
+/// a `terminal_title` entry
+#[inline]
+pub fn update_title(
+    w: &mut W,
+    app_state: &AppState,
+    con: &AppContext,
+) {
+    if let Some(pattern) = &con.terminal_title_pattern {
+        set_title(w, pattern, app_state);
+    }
+}
+
+fn set_title(
+    w: &mut W,
+    pattern: &ExecPattern,
+    app_state: &AppState,
+) {
+    let builder = ExecutionStringBuilder::without_invocation(
+        SelInfo::from_path(&app_state.root),
+        app_state,
+    );
+    let title = builder.shell_exec_string(pattern);
+    set_title_str(w, &title)
+}
+
+#[inline]
+fn set_title_str(
+    w: &mut W,
+    title: &str,
+) {
+    let _ = write!(w, "\u{1b}]0;{title}\u{07}");
+    let _ = w.flush();
+}


### PR DESCRIPTION
Allow automating the terminal's title change.
Add this in configuration:

    ###############################################################
    # Terminal's title
    # If you want the terminal's title to be updated when you change
    # directory, set a terminal_title pattern by uncommenting one of
    # the examples below and tuning it to your taste.
    # Note that this may slow down some systems.
    #
    # terminal_title: "[broot] {git-name}"
    terminal_title: "🐄 {file} "
    # terminal_title: "-= {file-name} =-"

Fix #794