### PR TITLE
Sync broot working dir with current panel's root

### DIFF
--- a/resources/default-conf/conf.hjson
+++ b/resources/default-conf/conf.hjson
@@ -168,6 +168,15 @@ content_search_max_file_size: 10MB
 # max_panels_count: 2
 
 ###############################################################
+# Update work dir
+#
+# By default, broot process' work dir is kept in sync with the
+# current's panel root. If you want to keep it unchanged,
+# uncomment this setting
+#
+# update_work_dir: false
+
+###############################################################
 # Imports
 #
 # While it's possible to have all configuration in one file,

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -589,8 +589,10 @@ impl App {
         if let Some(path) = self.state().tree_root() {
             app_state.root = path.to_path_buf();
             terminal::update_title(w, app_state, con);
-            if let Err(e) = std::env::set_current_dir(&app_state.root) {
-                warn!("Failed to set current dir: {e}");
+            if con.update_work_dir {
+                if let Err(e) = std::env::set_current_dir(&app_state.root) {
+                    warn!("Failed to set current dir: {e}");
+                }
             }
             if let Some(shared_root) = &mut self.shared_root {
                 if let Ok(mut root) = shared_root.lock() {

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -589,6 +589,9 @@ impl App {
         if let Some(path) = self.state().tree_root() {
             app_state.root = path.to_path_buf();
             terminal::update_title(w, app_state, con);
+            if let Err(e) = std::env::set_current_dir(&app_state.root) {
+                warn!("Failed to set current dir: {e}");
+            }
             if let Some(shared_root) = &mut self.shared_root {
                 if let Ok(mut root) = shared_root.lock() {
                     *root = app_state.root.clone();

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -101,6 +101,9 @@ pub struct AppContext {
     /// the optional pattern used to change the terminal's title
     /// (if none, the title isn't modified)
     pub terminal_title_pattern: Option<ExecPattern>,
+
+    /// whether to sync broot's work dir with the current panel's root
+    pub update_work_dir: bool,
 }
 
 impl AppContext {
@@ -197,6 +200,7 @@ impl AppContext {
             max_staged_count,
             content_search_max_file_size,
             terminal_title_pattern,
+            update_work_dir: config.update_work_dir.unwrap_or(true),
         })
     }
     /// Return the --cmd argument, coming from the launch arguments (prefered)

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -112,6 +112,9 @@ pub struct Conf {
     #[serde(alias="terminal-title")]
     pub terminal_title: Option<ExecPattern>,
 
+    #[serde(alias="update-work-dir")]
+    pub update_work_dir: Option<bool>,
+
     // BEWARE: entries added here won't be usable unless also
     // added in read_file!
 }
@@ -195,6 +198,7 @@ impl Conf {
         overwrite!(self, show_matching_characters_on_path_searches, conf);
         overwrite!(self, content_search_max_file_size, conf);
         overwrite!(self, terminal_title, conf);
+        overwrite!(self, update_work_dir, conf);
         self.verbs.append(&mut conf.verbs);
         // the following maps are "additive": we can add entries from several
         // config files and they still make sense

--- a/src/display/luma.rs
+++ b/src/display/luma.rs
@@ -1,5 +1,4 @@
 pub use {
-    crate::cli::{Args, TriBool},
     crokey::crossterm::tty::IsTty,
     once_cell::sync::Lazy,
     serde::Deserialize,

--- a/website/docs/conf_file.md
+++ b/website/docs/conf_file.md
@@ -304,6 +304,19 @@ quit_on_last_cancel: true
 ```TOML
 quit_on_last_cancel = true
 ```
+
+## Update broot's work dir
+
+By default, the work dir of the broot process is synchronized with the root of the current panel.
+If you prefer to keep the work dir unchanged, disable this feature with
+
+```Hjson
+update_work_dir: false
+```
+```TOML
+update_work_dir = false
+```
+
 ## Only show file name even when the pattern is on paths
 
 When your search pattern is applied to a path, the path is shown on each line so that you see why the line matches:


### PR DESCRIPTION
Fix #813

I'm not really sure there are many use cases for this, and I might gate it behind a configuration flag if I suspect there might be unwanted side effects.