### PR TITLE
Update nushell.rs to fix error on exit

### DIFF
--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -113,7 +113,7 @@ def --env br [
     let cmd_file = ([ $nu.temp-path, $"broot-(random chars).tmp" ] | path join)
     touch $cmd_file
     if ($file == null) {
-        ^broot --outcmd $cmd_file $args
+        ^broot --outcmd $cmd_file ...$args
     } else {
         ^broot --outcmd $cmd_file $args $file
     }

--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -115,7 +115,7 @@ def --env br [
     if ($file == null) {
         ^broot --outcmd $cmd_file ...$args
     } else {
-        ^broot --outcmd $cmd_file $args $file
+        ^broot --outcmd $cmd_file ...$args $file
     }
     let $cmd = (open $cmd_file)
     rm -p -f $cmd_file


### PR DESCRIPTION
_Nushell_ deprecated the use of automatic spreading lists in favor of the `...` syntax, which throws an error each time _broot_ launched via `br` is closed.

This PR just update the syntax accordingly.