### PR TITLE
use temp_file transmission medium for kitty img

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "broot"
-version = "1.33.1"
+version = "1.33.2-dev"
 dependencies = [
  "ahash 0.8.7",
  "ansi_colours",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broot"
-version = "1.33.1"
+version = "1.33.2-dev"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/broot"
 homepage = "https://dystroy.org/broot"

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -8,6 +8,7 @@ use {
         errors::*,
         file_sum,
         icon::*,
+        kitty::TransmissionMedium,
         pattern::SearchModeMap,
         path::SpecialPaths,
         skin::ExtColorMap,
@@ -118,6 +119,8 @@ pub struct AppContext {
     /// the execution of a terminal program.
     /// This is determined by app::run on launching the event source.
     pub keyboard_enhanced: bool,
+
+    pub kitty_graphics_transmission: TransmissionMedium,
 }
 
 impl AppContext {
@@ -216,6 +219,8 @@ impl AppContext {
             terminal_title_pattern,
             update_work_dir: config.update_work_dir.unwrap_or(true),
             keyboard_enhanced: false,
+            kitty_graphics_transmission: config.kitty_graphics_transmission
+                .unwrap_or_default(),
         })
     }
     /// Return the --cmd argument, coming from the launch arguments (prefered)

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -7,6 +7,7 @@ use {
         app::Mode,
         display::ColsConf,
         errors::{ConfError, ProgramError},
+        kitty::TransmissionMedium,
         path::{
             path_from,
             PathAnchor,
@@ -122,6 +123,9 @@ pub struct Conf {
     #[serde(alias="enable-keyboard-enhancements")]
     pub enable_kitty_keyboard: Option<bool>,
 
+    #[serde(alias="kitty-graphics-transmission")]
+    pub kitty_graphics_transmission: Option<TransmissionMedium>,
+
     // BEWARE: entries added here won't be usable unless also
     // added in read_file!
 }
@@ -208,6 +212,7 @@ impl Conf {
         overwrite!(self, terminal_title, conf);
         overwrite!(self, update_work_dir, conf);
         overwrite!(self, enable_kitty_keyboard, conf);
+        overwrite!(self, kitty_graphics_transmission, conf);
         self.verbs.append(&mut conf.verbs);
         // the following maps are "additive": we can add entries from several
         // config files and they still make sense

--- a/src/image/image_view.rs
+++ b/src/image/image_view.rs
@@ -119,7 +119,7 @@ impl ImageView {
         }
 
         self.kitty_image_id = kitty_manager
-            .try_print_image(w, &self.source_img, area, bg, disc.count)?;
+            .try_print_image(w, &self.source_img, area, bg, disc.count, &disc.con)?;
 
         if self.kitty_image_id.is_some() {
             return Ok(());

--- a/website/docs/conf_file.md
+++ b/website/docs/conf_file.md
@@ -273,7 +273,25 @@ terminal_title = "{file} 🐄"
 
 # Miscellaneous
 
-## Disable keyboard enhancements
+## Kitty Graphics
+
+Whenever possible, previewed images will be displayed in high resolution using [Kitty's graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/).
+
+Two transmission media are possible:
+
+* `chunks`: slow but works remotely
+* `temp_file`: faster but doesn't work when broot is remotely executed, default
+
+```Hjson
+kitty_graphics_transmission: chunks
+#kitty_graphics_transmission: temp_file
+```
+```TOML
+kitty_graphics_transmission = "chunks"
+#kitty_graphics_transmission = "temp_file"
+```
+
+## Keyboard enhancements
 
 By default, ANSI terminals make a lot of keyboard combinations impossible, for example <kbd>space</kbd><kbd>n</kbd>, or <kbd>alt</kbd><kbd>a</kbd><kbd>b</kbd>, or <kbd>shift</kbd><kbd>space</kbd>, etc.
 Some terminals implement [Kitty's keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) and basically make it possible to bind verbs to such combinations.
@@ -293,7 +311,9 @@ enable_kitty_keyboard: true
 enable_kitty_keyboard = true
 ```
 
-## Maximal number of files added by a :stage_all_files command
+## Max staged count
+
+This is the maximal number of files added by a :stage_all_files command
 
 ```Hjson
 max_staged_count: 1234
@@ -313,8 +333,9 @@ capture_mouse: false
 capture_mouse = false
 ```
 
-## Number of threads for directory size computation
+## File Sum Threads Count
 
+This is the number of threads used for directory size computation.
 Most users should not change this. In my measurements a number of 4 to 6 looks optimal.
 
 ```Hjson
@@ -349,7 +370,7 @@ update_work_dir: false
 update_work_dir = false
 ```
 
-## Only show file name even when the pattern is on paths
+## Pattern match display
 
 When your search pattern is applied to a path, the path is shown on each line so that you see why the line matches:
 


### PR DESCRIPTION
Use one of those settings:

```
kitty_graphics_transmission: chunks
kitty_graphics_transmission: temp_file
```

The faster `temp_file` mode is the current default. Downside is it won't work for a remote broot execution.

May solve #789