### PR TITLE
Add 16 color native skin

### DIFF
--- a/resources/default-conf/skins/native-16.hjson
+++ b/resources/default-conf/skins/native-16.hjson
@@ -1,0 +1,132 @@
+###############################################################
+# 16 ANSI color theme. Colors in this theme are restricted from
+# ANSI color 0 - 15. This will allow the theme to adapt to your
+# terminal emulator's theme. Note that, for now, the preview
+# mode does not yet support this theme because of syntect not
+# having a 16 ansi color theme.
+#
+# More info at https://jeffkreeftmeijer.com/vim-16-color/
+# Doc at https://dystroy.org/broot/skins/
+###############################################################
+
+skin: {
+    directory: ansi(12)
+    file: ansi(7)
+    pruning: ansi(8) none italic
+    selected_line: none ansi(0)
+    tree: ansi(8)
+
+    # Search
+    char_match: ansi(3) none underlined
+    parent: ansi(4) none bold
+
+    # File properties
+    exe: ansi(2)
+    link: ansi(13)
+    sparse: ansi(12)
+
+    # Prompt
+    input: ansi(6)
+
+    # Status bar
+    status_bold: ansi(7) ansi(8) bold
+    status_code: ansi(10) ansi(8)
+    status_ellipsis: ansi(7) ansi(8)
+    status_error: ansi(7) ansi(8)
+    status_italic: ansi(7) ansi(8) italic
+    status_job: ansi(7) ansi(8)
+    status_normal: ansi(7) ansi(8)
+
+    # Flag status
+    flag_label: ansi(6)
+    flag_value: ansi(14) none bold
+
+    # Background
+    default: none none
+
+    # Scrollbar
+    scrollbar_track: ansi(0)
+    scrollbar_thumb: ansi(3)
+
+    # Git
+    git_branch: ansi(13)
+    git_deletions: ansi(1)
+    git_insertions: ansi(2)
+    git_status_conflicted: ansi(1)
+    git_status_current: ansi(6)
+    git_status_ignored: ansi(8)
+    git_status_modified: ansi(3)
+    git_status_new: ansi(2) none bold
+    git_status_other: ansi(5)
+
+    # Staging area
+    staging_area_title: ansi(3)
+
+    # Documentation
+    help_bold: ansi(7) none bold
+    help_code: ansi(4)
+    help_headers: ansi(3)
+    help_italic: ansi(7) none italic
+    help_paragraph: ansi(7)
+    help_table_border: ansi(8)
+
+    # Device column
+    device_id_major: ansi(5)
+    device_id_minor: ansi(5)
+    device_id_sep: ansi(5)
+
+    # Counts column
+    count: ansi(13)
+
+    # Dates column
+    dates: ansi(6)
+
+    # Permissions column
+    group: ansi(3)
+    owner: ansi(3)
+    perm__: ansi(8)
+    perm_r: ansi(3)
+    perm_w: ansi(1)
+    perm_x: ansi(2)
+
+    # Hex preview
+    hex_null: ansi(8)
+    hex_ascii_graphic: ansi(2)
+    hex_ascii_whitespace: ansi(3)
+    hex_ascii_other: ansi(4)
+    hex_non_ascii: ansi(5)
+
+    # Preview
+    # preview: none
+    # preview_line_number: none
+    # preview_match: none
+    # preview_title: none
+
+    # Used for displaying errors
+    file_error: ansi(1)
+
+    # Content searches
+    content_extract: ansi(7)
+    content_match: ansi(3) none underlined
+
+    # Used in status line
+    purpose_bold: ansi(0) ansi(7) bold
+    purpose_ellipsis: ansi(0)
+    purpose_italic: ansi(0) ansi(7) italic
+    purpose_normal: ansi(0)
+
+    # Modal indicator
+    mode_command_mark: ansi(7) ansi(4)
+
+    # File system occupation
+    good_to_bad_0: ansi(2)
+    good_to_bad_1: ansi(2)
+    good_to_bad_2: ansi(2)
+    good_to_bad_3: ansi(2)
+    good_to_bad_4: ansi(2)
+    good_to_bad_5: ansi(1)
+    good_to_bad_6: ansi(1)
+    good_to_bad_7: ansi(1)
+    good_to_bad_8: ansi(1)
+    good_to_bad_9: ansi(1)
+}


### PR DESCRIPTION
This adds the skin discussed in https://github.com/Canop/broot/issues/203. The colors depend on the underlying terminal theme, so it might be useful to have a couple known good themes to use as a baseline. This is the terminal emulator theme I've used:

```
name='Birds Of Paradise'
foreground='#e0dbb7'
background='#2a1f1d'
cursor='#e99d2a'
black='#573d26'
red='#be2d26'
green='#6ba18a'
yellow='#e99d2a'
blue='#5a86ad'
magenta='#ac80a6'
cyan='#74a6ad'
white='#e0dbb7'
brblack='#9b6c4a'
brred='#e84627'
brgreen='#95d8ba'
bryellow='#d0d150'
brblue='#b8d3ed'
brmagenta='#d19ecb'
brcyan='#93cfd7'
brwhite='#fff9d5'
```

It has good contrast and follows the ANSI color naming scheme (so the color for `red` is actually red, the brighter colors are actually brighter, etc.). I can imagine users will start submitting issues/PR's for this skin that are actually issues with their own terminal theme, so it might be useful to then ask them first to resort to a known good theme like the one above. That way all troubleshooting can have the same starting point.

There are two areas of the skin I wasn't able to test:

1. The :fs command yielded a `Failed to fetch mounts: Could not read dir "/sys/block"` error on my Mac. So the good_to_bad colors are untested.
2. I couldn't find exactly where the purpose_* colors were used in the status line, so they're untested as well.

Let me know what you think!