### PR TITLE
calling :focus on the tree root goes up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- calling `:focus` on the tree root now goes up the tree
+
 ### v1.37.0 - 2024-04-28
 <a name="v1.37.0"></a>
 - optionally display lines surrounding a matching line in preview, with `lines_before_match_in_preview` and  `lines_after_match_in_preview` - Fix #756

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -347,15 +347,26 @@ impl PanelState for BrowserState {
                     CmdResult::PopState
                 }
             }
-            Internal::focus => internal_focus::on_internal(
-                internal_exec,
-                input_invocation,
-                trigger_type,
-                &self.displayed_tree().selected_line().path,
-                self.displayed_tree().options.clone(),
-                app_state,
-                cc,
-            ),
+            Internal::focus => {
+                let tree = self.displayed_tree();
+                let mut path = &tree.selected_line().path;
+                let parent;
+                if tree.is_root_selected() {
+                    if let Some(parent_path) = path.parent() {
+                        parent = parent_path.to_path_buf();
+                        path = &parent;
+                    }
+                }
+                internal_focus::on_internal(
+                    internal_exec,
+                    input_invocation,
+                    trigger_type,
+                    &path,
+                    tree.options.clone(),
+                    app_state,
+                    cc,
+                )
+            }
             Internal::select => internal_select::on_internal(
                 internal_exec,
                 input_invocation,

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -302,6 +302,9 @@ impl Tree {
     pub fn root(&self) -> &PathBuf {
         &self.lines[0].path
     }
+    pub fn is_root_selected(&self) -> bool {
+        self.selection == 0
+    }
     /// select the line with the best matching score
     pub fn try_select_best_match(&mut self) {
         let mut best_score = 0;


### PR DESCRIPTION
This makes it easier to define alternatives to the standard enter on directories.