### PR TITLE
fix builds on android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ exclude = ["website", "broot*.zip"]
 
 [features]
 default = []
+
 clipboard = ["terminal-clipboard"]
 kitty-csi-check = ["xterm-query"]
+trash = ["dep:trash"]
 
 [dependencies]
 ahash = { version = "0.8.3", features = ["serde"] }
@@ -62,7 +64,7 @@ termimad = "0.29.2"
 terminal-clipboard = { version = "0.4.1", optional = true }
 terminal-light = "1.4.0"
 toml = "0.8"
-trash = "3.1.2"
+trash = { version = "3.1.2", optional = true }
 umask = "2.1.0"
 unicode-width = "0.1.10"
 which = "4.4.0"

--- a/compile-all-targets.sh
+++ b/compile-all-targets.sh
@@ -50,7 +50,7 @@ cross_build "ARM 32" "armv7-unknown-linux-gnueabihf" ""
 cross_build "ARM 32 MUSL" "armv7-unknown-linux-musleabi" ""
 cross_build "ARM 64" "aarch64-unknown-linux-gnu" ""
 cross_build "ARM 64 MUSL" "aarch64-unknown-linux-musl" ""
-cross_build "Windows" "x86_64-pc-windows-gnu" "clipboard"
+cross_build "Windows" "x86_64-pc-windows-gnu" "clipboard,trash"
 # cross_build "Android" "aarch64-linux-android" "clipboard" Doesn't work anymore - See https://github.com/Canop/broot/issues/565
 
 

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -632,6 +632,8 @@ impl PanelState for BrowserState {
             Internal::trash => {
                 let path = self.displayed_tree().selected_line().path.to_path_buf();
                 info!("trash {:?}", &path);
+
+                #[cfg(feature = "trash")]
                 match trash::delete(&path) {
                     Ok(()) => CmdResult::RefreshState { clear_cache: true },
                     Err(e) => {
@@ -639,6 +641,9 @@ impl PanelState for BrowserState {
                         CmdResult::DisplayError(format!("trash error: {:?}", &e))
                     }
                 }
+
+                #[cfg(not(feature = "trash"))]
+                CmdResult::DisplayError("feature not enabled or platform does not support trash".into())
             }
             Internal::quit => CmdResult::Quit,
             _ => self.on_internal_generic(

--- a/src/stage/stage_state.rs
+++ b/src/stage/stage_state.rs
@@ -496,6 +496,8 @@ impl PanelState for StageState {
             }
             Internal::trash => {
                 info!("trash {} staged files", app_state.stage.len());
+
+                #[cfg(feature = "trash")]
                 match trash::delete_all(app_state.stage.paths()) {
                     Ok(()) => CmdResult::RefreshState { clear_cache: true },
                     Err(e) => {
@@ -503,6 +505,9 @@ impl PanelState for StageState {
                         CmdResult::DisplayError(format!("trash error: {:?}", &e))
                     }
                 }
+
+                #[cfg(not(feature = "trash"))]
+                CmdResult::DisplayError("feature not enabled or platform does not support trash".into())
             }
             _ => self.on_internal_generic(
                 w,


### PR DESCRIPTION
Since #803 introduced a dependency on the trash crate, broot does not compile any more on Android. This change makes the trash crate only pulled in on platforms which support it, and otherwise the trash command displays an error.

Fixes #861