### PR TITLE
features.md: add "trash" feature

### DIFF
--- a/features.md
+++ b/features.md
@@ -2,6 +2,7 @@
 This page defines the optional features which may be applied on compilation:
 
 * clipboard
+* trash
 * kitty-csi-check
 
 Feature gating is usually temporary: they may be removed when a technical problem is solved, when a feature becomes "mainstream", or when it's dropped because no user mentioned using it.
@@ -14,6 +15,10 @@ Limits:
 
 - the feature doesn't compile right now on some platforms (for example Raspberry)
 - on some platforms the content leaves the clipboard when you quit broot (so you must paste while broot is still running)
+
+## The "trash" feature
+
+This feature enables commands for managing the system Trash. They are `:open_trash`, `:delete_trashed_file`, `:restore_trashed_file`, `:purge_trash`.
 
 ## The "kitty-csi-check" feature
 


### PR DESCRIPTION
The addition of the [trash feature](https://github.com/Canop/broot/pull/882) hasn't been documented in `feature.md` so far.