### PR TITLE
Use XDG_RUNTIME_DIR when available

### DIFF
--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -110,7 +110,11 @@ export def --env br [
     if $whale_spotting { $args = ($args | append $'--whale-spotting') }
     if $write_default_conf != null { $args = ($args | append $'--write-default-conf=($write_default_conf)') }
 
-    let cmd_file = ([ $nu.temp-path, $"broot-(random chars).tmp" ] | path join)
+    let cmd_file = (
+        if ($env.XDG_RUNTIME_DIR? | is-not-empty) { $env.XDG_RUNTIME_DIR } else { $nu.temp-path }
+        | path join $"broot-(random chars).tmp"
+    )
+
     touch $cmd_file
     if ($file == null) {
         ^broot --outcmd $cmd_file ...$args


### PR DESCRIPTION
XDG_RUNTIME_DIR is almost guaranteed to be living inside in-memory filesystem (tmpfs) which is much more suitable for such a create and drop temp files. On many systems /tmp is still on hard disk.