### PR TITLE
search_again internal

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -435,6 +435,29 @@ impl App {
                                 .refresh_input_status(app_state, &app_cmd_context);
                         }
                     }
+                    Internal::search_again => {
+                        if let Some(raw_pattern) = &self.panel().last_raw_pattern {
+                            let sequence = Sequence::new_single(raw_pattern.clone());
+                            self.tx_seqs.send(sequence).unwrap();
+                        }
+                    }
+                    Internal::set_syntax_theme => {
+                        let arg = cmd.as_verb_invocation().and_then(|vi| vi.args.as_ref());
+                        match arg {
+                            Some(arg) => match SyntaxTheme::from_str(arg) {
+                                Ok(theme) => {
+                                    con.syntax_theme = Some(theme);
+                                    self.update_preview(con, true);
+                                }
+                                Err(e) => {
+                                    error = Some(e.to_string());
+                                }
+                            },
+                            None => {
+                                error = Some("no theme provided".to_string());
+                            }
+                        }
+                    }
                     Internal::toggle_second_tree => {
                         let panels_count = self.panels.len().get();
                         let trees_count = self
@@ -482,23 +505,6 @@ impl App {
                                     self.close_panel(i);
                                     break;
                                 }
-                            }
-                        }
-                    }
-                    Internal::set_syntax_theme => {
-                        let arg = cmd.as_verb_invocation().and_then(|vi| vi.args.as_ref());
-                        match arg {
-                            Some(arg) => match SyntaxTheme::from_str(arg) {
-                                Ok(theme) => {
-                                    con.syntax_theme = Some(theme);
-                                    self.update_preview(con, true);
-                                }
-                                Err(e) => {
-                                    error = Some(e.to_string());
-                                }
-                            },
-                            None => {
-                                error = Some("no theme provided".to_string());
                             }
                         }
                     }

--- a/src/app/panel.rs
+++ b/src/app/panel.rs
@@ -31,6 +31,7 @@ pub struct Panel {
     status: Status,
     pub purpose: PanelPurpose,
     pub input: PanelInput,
+    pub last_raw_pattern: Option<String>,
 }
 
 impl Panel {
@@ -51,6 +52,7 @@ impl Panel {
             status,
             purpose: PanelPurpose::None,
             input,
+            last_raw_pattern: None,
         }
     }
 
@@ -71,6 +73,9 @@ impl Panel {
         app_state: &mut AppState,
         app_cmd_context: &'c AppCmdContext<'c>,
     ) -> Result<CmdResult, ProgramError> {
+        if let Command::PatternEdit { raw, .. } = cmd {
+            self.last_raw_pattern = Some(raw.clone());
+        }
         let state_idx = self.states.len() - 1;
         let cc = CmdContext {
             cmd,
@@ -275,4 +280,14 @@ impl Panel {
         Ok(())
     }
 
+    // /// return the last non empty pattern used in a previous state
+    // pub fn last_pattern(&self) -> Option<&InputPattern> {
+    //     for state in self.states.iter().rev().skip(1) {
+    //         let pattern = state.pattern();
+    //         if pattern.is_some() {
+    //             return Some(pattern);
+    //         }
+    //     }
+    //     None
+    // }
 }

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         app::*,
-        command::{Command, TriggerType},
+        command::*,
         display::{DisplayableTree, Screen, W},
         errors::{ProgramError, TreeBuildError},
         flag::Flag,
@@ -374,34 +374,9 @@ impl PanelState for BrowserState {
                     cc,
                 )
             }
-            Internal::select => internal_select::on_internal(
-                internal_exec,
-                input_invocation,
-                trigger_type,
-                self.displayed_tree_mut(),
-                app_state,
-                cc,
-            ),
-            Internal::up_tree => match self.displayed_tree().root().parent() {
-                Some(path) => internal_focus::on_path(
-                    path.to_path_buf(),
-                    screen,
-                    self.displayed_tree().options.clone(),
-                    bang,
-                    con,
-                ),
-                None => CmdResult::error("no parent found"),
-            },
-            Internal::open_stay => self.open_selection_stay_in_broot(screen, con, bang, false)?,
-            Internal::open_stay_filter => self.open_selection_stay_in_broot(screen, con, bang, true)?,
             Internal::line_down => {
                 let count = get_arg(input_invocation, internal_exec, 1);
                 self.displayed_tree_mut().move_selection(count, page_height, true);
-                CmdResult::Keep
-            }
-            Internal::line_up => {
-                let count = get_arg(input_invocation, internal_exec, 1);
-                self.displayed_tree_mut().move_selection(-count, page_height, true);
                 CmdResult::Keep
             }
             Internal::line_down_no_cycle => {
@@ -409,28 +384,19 @@ impl PanelState for BrowserState {
                 self.displayed_tree_mut().move_selection(count, page_height, false);
                 CmdResult::Keep
             }
+            Internal::line_up => {
+                let count = get_arg(input_invocation, internal_exec, 1);
+                self.displayed_tree_mut().move_selection(-count, page_height, true);
+                CmdResult::Keep
+            }
             Internal::line_up_no_cycle => {
                 let count = get_arg(input_invocation, internal_exec, 1);
                 self.displayed_tree_mut().move_selection(-count, page_height, false);
                 CmdResult::Keep
             }
-            Internal::previous_dir => {
-                self.displayed_tree_mut().try_select_previous_filtered(
-                    |line| line.is_dir(),
-                    page_height,
-                );
-                CmdResult::Keep
-            }
             Internal::next_dir => {
                 self.displayed_tree_mut().try_select_next_filtered(
                     |line| line.is_dir(),
-                    page_height,
-                );
-                CmdResult::Keep
-            }
-            Internal::previous_match => {
-                self.displayed_tree_mut().try_select_previous_filtered(
-                    |line| line.direct_match,
                     page_height,
                 );
                 CmdResult::Keep
@@ -442,14 +408,12 @@ impl PanelState for BrowserState {
                 );
                 CmdResult::Keep
             }
-            Internal::previous_same_depth => {
-                self.displayed_tree_mut().try_select_previous_same_depth(page_height);
-                CmdResult::Keep
-            }
             Internal::next_same_depth => {
                 self.displayed_tree_mut().try_select_next_same_depth(page_height);
                 CmdResult::Keep
             }
+            Internal::open_stay => self.open_selection_stay_in_broot(screen, con, bang, false)?,
+            Internal::open_stay_filter => self.open_selection_stay_in_broot(screen, con, bang, true)?,
             Internal::page_down => {
                 let tree = self.displayed_tree_mut();
                 if !tree.try_scroll(page_height as i32, page_height) {
@@ -508,25 +472,28 @@ impl PanelState for BrowserState {
             }
             Internal::panel_right_no_open => CmdResult::HandleInApp(Internal::panel_right_no_open),
             Internal::parent => self.go_to_parent(screen, con, bang),
+            Internal::previous_dir => {
+                self.displayed_tree_mut().try_select_previous_filtered(
+                    |line| line.is_dir(),
+                    page_height,
+                );
+                CmdResult::Keep
+            }
+            Internal::previous_match => {
+                self.displayed_tree_mut().try_select_previous_filtered(
+                    |line| line.direct_match,
+                    page_height,
+                );
+                CmdResult::Keep
+            }
+            Internal::previous_same_depth => {
+                self.displayed_tree_mut().try_select_previous_same_depth(page_height);
+                CmdResult::Keep
+            }
             Internal::print_tree => {
                 print::print_tree(self.displayed_tree(), cc.app.screen, cc.app.panel_skin, con)?
             }
-            Internal::root_up => {
-                let tree = self.displayed_tree();
-                let root = tree.root();
-                if let Some(new_root) = root.parent() {
-                    self.modified(
-                        screen,
-                        new_root.to_path_buf(),
-                        tree.options.clone(),
-                        None,
-                        bang,
-                        con,
-                    )
-                } else {
-                    CmdResult::error(format!("{root:?} has no parent"))
-                }
-            }
+            Internal::quit => CmdResult::Quit,
             Internal::root_down => {
                 let tree = self.displayed_tree();
                 if tree.selection > 0 {
@@ -546,6 +513,55 @@ impl PanelState for BrowserState {
                 } else {
                     CmdResult::error("No selected line")
                 }
+            }
+            Internal::root_up => {
+                let tree = self.displayed_tree();
+                let root = tree.root();
+                if let Some(new_root) = root.parent() {
+                    self.modified(
+                        screen,
+                        new_root.to_path_buf(),
+                        tree.options.clone(),
+                        None,
+                        bang,
+                        con,
+                    )
+                } else {
+                    CmdResult::error(format!("{root:?} has no parent"))
+                }
+            }
+            Internal::search_again => {
+                match self.filtered_tree.as_ref().map(|t| t.total_search) {
+                    None => {
+                        // we delegate to the app the task of looking for a preview pattern
+                        // used before this state
+                        CmdResult::HandleInApp(Internal::search_again)
+                    }
+                    Some(true) => {
+                        CmdResult::error("search was already total: all possible matches have been ranked")
+                    }
+                    Some(false) => {
+                        self.search(self.displayed_tree().options.pattern.clone(), true);
+                        CmdResult::Keep
+                    }
+                }
+            }
+            Internal::select => internal_select::on_internal(
+                internal_exec,
+                input_invocation,
+                trigger_type,
+                self.displayed_tree_mut(),
+                app_state,
+                cc,
+            ),
+            Internal::select_first => {
+                self.displayed_tree_mut().try_select_first();
+                CmdResult::Keep
+            }
+            Internal::select_last => {
+                let page_height = BrowserState::page_height(screen);
+                self.displayed_tree_mut().try_select_last(page_height);
+                CmdResult::Keep
             }
             Internal::stage_all_directories => {
                 let pattern = self.displayed_tree().options.pattern.clone();
@@ -576,15 +592,6 @@ impl PanelState for BrowserState {
                 } else {
                     CmdResult::Keep
                 }
-            }
-            Internal::select_first => {
-                self.displayed_tree_mut().try_select_first();
-                CmdResult::Keep
-            }
-            Internal::select_last => {
-                let page_height = BrowserState::page_height(screen);
-                self.displayed_tree_mut().try_select_last(page_height);
-                CmdResult::Keep
             }
             Internal::start_end_panel => {
                 if cc.panel.purpose.is_arg_edition() {
@@ -652,7 +659,16 @@ impl PanelState for BrowserState {
                 #[cfg(not(feature = "trash"))]
                 CmdResult::DisplayError("feature not enabled or platform does not support trash".into())
             }
-            Internal::quit => CmdResult::Quit,
+            Internal::up_tree => match self.displayed_tree().root().parent() {
+                Some(path) => internal_focus::on_path(
+                    path.to_path_buf(),
+                    screen,
+                    self.displayed_tree().options.clone(),
+                    bang,
+                    con,
+                ),
+                None => CmdResult::error("no parent found"),
+            },
             _ => self.on_internal_generic(
                 w,
                 invocation_parser,

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -152,6 +152,7 @@ Internals! {
     toggle_tree: "toggle showing more than one level of the tree" true,
     toggle_trim_root: "toggle removing nodes at first level too" false,
     total_search: "search again but on all children" false,
+    search_again: "either put pack the search, or search deeper" false,
     trash: "move file to system trash" true,
     unstage: "remove selection from staging area" true,
     up_tree: "focus the parent of the current root" true,

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -329,7 +329,8 @@ impl VerbStore {
         self.add_internal(toggle_perm).with_shortcut("perm");
         self.add_internal(toggle_sizes).with_shortcut("sizes");
         self.add_internal(toggle_trim_root);
-        self.add_internal(total_search).with_key(key!(ctrl-s));
+        self.add_internal(total_search);
+        self.add_internal(search_again).with_key(key!(ctrl-s));
         self.add_internal(up_tree).with_shortcut("up");
 
         self.add_internal(clear_output);


### PR DESCRIPTION
This brings the `search_again` internal, which tries to fix a frequent annoyance, which is the loss of the search pattern when navigating, something I hadn't found good ergonomics for before.

`:search_again` is mapped by default to `ctrl-s`.

- When there's already an active filtering, and it wasn't complete, make it total (it thus does what the `total_search` internal was doing).
- When there's no active filtering, brings back the last used.

Main use case: you search, have a lot of matches, focus a folder to look inside, then you can bring back the search pattern with ctrl-s.

I'd be very interested in tester feedback on this.