### PR TITLE
Support the BROOT environment variable for Powershell

### DIFF
--- a/src/shell_install/powershell.rs
+++ b/src/shell_install/powershell.rs
@@ -24,8 +24,12 @@ const PS_FUNC: &str = r#"
 Function br {
   $args = $args -join ' '
   $cmd_file = New-TemporaryFile
+  $broot = $env:BROOT
+  If (-not $broot) {
+       $broot = 'broot.exe'
+  }
 
-  $process = Start-Process -FilePath 'broot.exe' `
+  $process = Start-Process -FilePath $broot `
                            -ArgumentList "--outcmd $($cmd_file.FullName) $args" `
                            -NoNewWindow -PassThru -WorkingDirectory $PWD
 


### PR DESCRIPTION
Allows keeping PATH as minimal as possible and makes e.g. switching between versions when testing also easier since it won't require changes to PATH.
This is partly an RFC: I guess other shells could benefit from this as well but I don't know the syntax for all of them; if this is deemed an ok idea I can look that up and apply it for all launchers.