### PR TITLE
remove "bak" from binary files extensions list

### DIFF
--- a/src/content_type/extensions.rs
+++ b/src/content_type/extensions.rs
@@ -12,7 +12,6 @@ static BINARY_EXTENSIONS: Set<&'static str> = phf_set! {
     "aif", "AIF",
     "ap_",
     "apk",
-    "bak", "BAK",
     "bin", "BIN",
     "bmp", "BMP",
     "bzip", "BZIP",


### PR DESCRIPTION
Fix #915