### PR TITLE
Initial root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "splitty"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae68aa5bd5dc2d3a2137b0f6bcdd8255dce1983dc155fe0246572e179c9c3a"
+checksum = "2db70a1e6827e4d71c655b606caf1346862c38ae52ab4f58c32635e7c7aedd67"
 
 [[package]]
 name = "str-buf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ custom_error = "1.6"
 deser-hjson = "2.2.3"
 directories = "4.0"
 file-size = "1.0.3"
-git2 = { version = "0.14", default-features = false }
+git2 = { version = "0.14", default-features = false } # waiting for a good pure-rust alternative
 glob = "0.3"
 id-arena = "2.2.1"
 image = "0.24"
@@ -54,7 +54,7 @@ rustc-hash = "1"
 secular = { version = "1.0", features = ["normalization", "bmp"] }
 serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.11" # version 2 is still alpha
-splitty = "1.0"
+splitty = "1.0.2"
 strict = "0.1.4"
 syntect = { package = "syntect-no-panic", version = "4.6.1" } # see issue #485
 tempfile = "3.2"

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -259,6 +259,17 @@ impl AppContext {
     }
 }
 
+/// An unsafe implementation of Default, for tests only
+#[cfg(test)]
+impl Default for AppContext {
+    fn default() -> Self {
+        let mut config = Conf::default();
+        let verb_store = VerbStore::new(&mut config).unwrap();
+        let launch_args = parse_default_flags("").unwrap();
+        Self::from(launch_args, verb_store, &config).unwrap()
+    }
+}
+
 /// try to determine whether the terminal supports true
 /// colors. This doesn't work well, hence the use of an
 /// optional config setting.

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -668,7 +668,7 @@ pub trait PanelState {
                     }
                 };
                 if let Some(pattern) = internal_exec.arg.as_ref() {
-                    let line = exec_builder.string(pattern);
+                    let line = exec_builder.string(pattern, con);
                     verb_write(con, &line)?;
                 } else {
                     let line = input_invocation
@@ -847,7 +847,7 @@ pub trait PanelState {
                 None
             },
         );
-        let sequence = exec_builder.sequence(&seq_ex.sequence, &cc.app.con.verb_store);
+        let sequence = exec_builder.sequence(&seq_ex.sequence, &cc.app.con.verb_store, &cc.app.con);
         Ok(CmdResult::ExecuteSequence { sequence })
     }
 
@@ -1092,7 +1092,7 @@ pub trait PanelState {
         verb: &Verb,
         invocation: &VerbInvocation,
         sel_info: SelInfo<'_>,
-        _cc: &CmdContext,
+        cc: &CmdContext,
         app_state: &AppState,
     ) -> Status {
         if sel_info.count_paths() > 1 {
@@ -1114,6 +1114,7 @@ pub trait PanelState {
                     sel_info,
                     app_state,
                     invocation,
+                    &cc.app.con,
                 ),
                 false,
             )

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -847,7 +847,7 @@ pub trait PanelState {
                 None
             },
         );
-        let sequence = exec_builder.sequence(&seq_ex.sequence, &cc.app.con.verb_store, &cc.app.con);
+        let sequence = exec_builder.sequence(&seq_ex.sequence, &cc.app.con.verb_store, cc.app.con);
         Ok(CmdResult::ExecuteSequence { sequence })
     }
 
@@ -1114,7 +1114,7 @@ pub trait PanelState {
                     sel_info,
                     app_state,
                     invocation,
-                    &cc.app.con,
+                    cc.app.con,
                 ),
                 false,
             )

--- a/src/command/panel_input.rs
+++ b/src/command/panel_input.rs
@@ -449,7 +449,8 @@ impl PanelInput {
                     app_state,
                 );
                 let verb_invocation = exec_builder.invocation_with_default(
-                    &invocation_parser.invocation_pattern
+                    &invocation_parser.invocation_pattern,
+                    con,
                 );
                 let mut parts = parts;
                 parts.verb_invocation = Some(verb_invocation);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -16,7 +16,7 @@ pub fn update_title(
     con: &AppContext,
 ) {
     if let Some(pattern) = &con.terminal_title_pattern {
-        set_title(w, pattern, app_state);
+        set_title(w, pattern, app_state, con);
     }
 }
 
@@ -24,12 +24,13 @@ fn set_title(
     w: &mut W,
     pattern: &ExecPattern,
     app_state: &AppState,
+    con: &AppContext,
 ) {
     let builder = ExecutionStringBuilder::without_invocation(
         SelInfo::from_path(&app_state.root),
         app_state,
     );
-    let title = builder.shell_exec_string(pattern);
+    let title = builder.shell_exec_string(pattern, con);
     set_title_str(w, &title)
 }
 

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -471,8 +471,9 @@ mod execution_builder_test {
             map.insert(k.to_owned(), v.to_owned());
         }
         builder.invocation_values = Some(map);
+        let con = AppContext::default();
         for exec_pattern in exec_patterns {
-            let exec_token = builder.exec_token(&exec_pattern);
+            let exec_token = builder.exec_token(&exec_pattern, &con);
             assert_eq!(exec_token, chk_exec_token);
         }
     }

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -95,9 +95,13 @@ impl<'b> ExecutionStringBuilder<'b> {
             }
         }
     }
-    fn get_raw_capture_replacement(&self, ec: &Captures<'_>) -> Option<String> {
+    fn get_raw_capture_replacement(
+        &self,
+        ec: &Captures<'_>,
+        con: &AppContext,
+    ) -> Option<String> {
         self.get_raw_replacement(|sel| {
-            self.get_raw_sel_capture_replacement(ec, sel)
+            self.get_raw_sel_capture_replacement(ec, sel, con)
         })
     }
     /// return the standard replacement (ie not one from the invocation)
@@ -105,10 +109,12 @@ impl<'b> ExecutionStringBuilder<'b> {
         &self,
         name: &str,
         sel: Option<Selection<'_>>,
+        con: &AppContext,
     ) -> Option<String> {
         debug!("repl name : {:?}", name);
         match name {
             "root" => Some(path_to_string(self.root)),
+            "initial-root" => Some(path_to_string(&con.initial_root)),
             "line" => sel.map(|s| s.line.to_string()),
             "file" => sel.map(|s| s.path)
                 .map(path_to_string),
@@ -188,9 +194,10 @@ impl<'b> ExecutionStringBuilder<'b> {
         &self,
         ec: &Captures<'_>,
         sel: Option<Selection<'_>>,
+        con: &AppContext,
     ) -> Option<String> {
         let name = ec.get(1).unwrap().as_str();
-        self.get_raw_sel_name_standard_replacement(name, sel)
+        self.get_raw_sel_name_standard_replacement(name, sel, con)
             .or_else(||{
                 // it's not one of the standard group names, so we'll look
                 // into the ones provided by the invocation pattern
@@ -216,8 +223,12 @@ impl<'b> ExecutionStringBuilder<'b> {
             })
     }
     #[inline]
-    fn get_capture_replacement(&self, ec: &Captures<'_>) -> String {
-        self.get_raw_capture_replacement(ec)
+    fn get_capture_replacement(
+        &self,
+        ec: &Captures<'_>,
+        con: &AppContext,
+    ) -> String {
+        self.get_raw_capture_replacement(ec, con)
             .unwrap_or_else(||
                 if self.keep_groups { ec[0].to_string() } else { "".to_string() }
             )
@@ -226,8 +237,9 @@ impl<'b> ExecutionStringBuilder<'b> {
         &self,
         ec: &Captures<'_>,
         sel: Option<Selection<'_>>,
+        con: &AppContext,
     ) -> String {
-        self.get_raw_sel_capture_replacement(ec, sel)
+        self.get_raw_sel_capture_replacement(ec, sel, con)
             .unwrap_or_else(||
                 if self.keep_groups { ec[0].to_string() } else { "".to_string() }
             )
@@ -239,6 +251,7 @@ impl<'b> ExecutionStringBuilder<'b> {
     pub fn invocation_with_default(
         &self,
         verb_invocation: &VerbInvocation,
+        con: &AppContext,
     ) -> VerbInvocation {
         VerbInvocation {
             name: verb_invocation.name.clone(),
@@ -250,7 +263,7 @@ impl<'b> ExecutionStringBuilder<'b> {
                             .map(|default_name| default_name.as_str())
                             .and_then(|default_name|
                                 self.get_raw_replacement(|sel|
-                                    self.get_raw_sel_name_standard_replacement(default_name, sel)
+                                    self.get_raw_sel_name_standard_replacement(default_name, sel, con)
                                 )
                             )
                             .unwrap_or_default()
@@ -279,6 +292,7 @@ impl<'b> ExecutionStringBuilder<'b> {
         &self,
         sequence: &Sequence,
         verb_store: &VerbStore,
+        con: &AppContext,
     ) -> Sequence {
         let mut inputs = Vec::new();
         for input in sequence.raw.split(&sequence.separator) {
@@ -297,9 +311,9 @@ impl<'b> ExecutionStringBuilder<'b> {
                 })
                 .map_or(false, |verb| verb.get_internal().is_none());
             let input = if verb_is_external {
-                self.shell_exec_string(&ExecPattern::from_string(input))
+                self.shell_exec_string(&ExecPattern::from_string(input), con)
             } else {
-                self.string(input)
+                self.string(input, con)
             };
             inputs.push(input);
         }
@@ -312,11 +326,12 @@ impl<'b> ExecutionStringBuilder<'b> {
     pub fn string(
         &self,
         pattern: &str,
+        con: &AppContext,
     ) -> String {
         GROUP
             .replace_all(
                 pattern,
-                |ec: &Captures<'_>| self.get_capture_replacement(ec),
+                |ec: &Captures<'_>| self.get_capture_replacement(ec, con),
             )
             .to_string()
     }
@@ -324,13 +339,14 @@ impl<'b> ExecutionStringBuilder<'b> {
     pub fn path(
         &self,
         pattern: &str,
+        con: &AppContext,
     ) -> PathBuf {
         path::path_from(
             self.base_dir(),
             path::PathAnchor::Unspecified,
             &GROUP.replace_all(
                 pattern,
-                |ec: &Captures<'_>| self.get_capture_replacement(ec),
+                |ec: &Captures<'_>| self.get_capture_replacement(ec, con),
             )
         )
     }
@@ -338,12 +354,13 @@ impl<'b> ExecutionStringBuilder<'b> {
     pub fn shell_exec_string(
         &self,
         exec_pattern: &ExecPattern,
+        con: &AppContext,
     ) -> String {
         exec_pattern
             .apply(&|s| {
                 GROUP.replace_all(
                     s,
-                    |ec: &Captures<'_>| self.get_capture_replacement(ec),
+                    |ec: &Captures<'_>| self.get_capture_replacement(ec, con),
                 ).to_string()
             })
             .fix_paths()
@@ -356,12 +373,13 @@ impl<'b> ExecutionStringBuilder<'b> {
         &self,
         exec_pattern: &ExecPattern,
         sel: Option<Selection<'_>>,
+        con: &AppContext,
     ) -> String {
         exec_pattern
             .apply(&|s| {
                 GROUP.replace_all(
                     s,
-                    |ec: &Captures<'_>| self.get_sel_capture_replacement(ec, sel),
+                    |ec: &Captures<'_>| self.get_sel_capture_replacement(ec, sel, con),
                 ).to_string()
             })
             .fix_paths()
@@ -372,12 +390,13 @@ impl<'b> ExecutionStringBuilder<'b> {
     pub fn exec_token(
         &self,
         exec_pattern: &ExecPattern,
+        con: &AppContext,
     ) -> Vec<String> {
         exec_pattern
             .apply(&|s| {
                 GROUP.replace_all(
                     s,
-                    |ec: &Captures<'_>| self.get_capture_replacement(ec),
+                    |ec: &Captures<'_>| self.get_capture_replacement(ec, con),
                 ).to_string()
             })
             .fix_paths()
@@ -389,12 +408,13 @@ impl<'b> ExecutionStringBuilder<'b> {
         &self,
         exec_pattern: &ExecPattern,
         sel: Option<Selection<'_>>,
+        con: &AppContext,
     ) -> Vec<String> {
         exec_pattern
             .apply(&|s| {
                 GROUP.replace_all(
                     s,
-                    |ec: &Captures<'_>| self.get_sel_capture_replacement(ec, sel),
+                    |ec: &Captures<'_>| self.get_sel_capture_replacement(ec, sel, con),
                 ).to_string()
             })
             .fix_paths()

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -201,7 +201,7 @@ pub fn on_internal(
                 selected_path,
                 input_arg,
                 app_state,
-                &cc.app.con,
+                cc.app.con,
             );
             on_path(path, screen, tree_options, bang, con)
         }

--- a/src/verb/internal_select.rs
+++ b/src/verb/internal_select.rs
@@ -44,6 +44,7 @@ pub fn on_internal(
                 &tree.selected_line().path,
                 input_arg,
                 app_state,
+                &cc.app.con,
             );
             on_path(path, tree, screen, bang)
         }
@@ -84,6 +85,7 @@ fn path_from_input(
     base_path: &Path, // either the selected path or the root path
     input_arg: Option<&String>,
     app_state: &AppState,
+    con: &AppContext,
 ) -> PathBuf {
     match (input_arg, internal_exec.arg.as_ref()) {
         (Some(input_arg), Some(verb_arg)) => {
@@ -100,7 +102,7 @@ fn path_from_input(
                 app_state,
                 Some(input_arg),
             );
-            path_builder.path(verb_arg)
+            path_builder.path(verb_arg, con)
         }
         (Some(input_arg), None) => {
             // the verb defines nothing

--- a/src/verb/internal_select.rs
+++ b/src/verb/internal_select.rs
@@ -44,7 +44,7 @@ pub fn on_internal(
                 &tree.selected_line().path,
                 input_arg,
                 app_state,
-                &cc.app.con,
+                cc.app.con,
             );
             on_path(path, tree, screen, bang)
         }

--- a/src/verb/verb.rs
+++ b/src/verb/verb.rs
@@ -230,6 +230,7 @@ impl Verb {
         sel_info: SelInfo<'_>,
         app_state: &AppState,
         invocation: &VerbInvocation,
+        con: &AppContext,
     ) -> String {
         let name = self.names.first().unwrap_or(&invocation.name);
 
@@ -246,6 +247,7 @@ impl Verb {
                     sel_info,
                     invocation,
                     app_state,
+                    con,
                 );
             }
         }
@@ -260,11 +262,12 @@ impl Verb {
         };
         if let VerbExecution::Sequence(seq_ex) = &self.execution {
             let exec_desc = builder().shell_exec_string(
-                &ExecPattern::from_string(&seq_ex.sequence.raw)
+                &ExecPattern::from_string(&seq_ex.sequence.raw),
+                con,
             );
             format!("Hit *enter* to **{}**: `{}`", name, &exec_desc)
         } else if let VerbExecution::External(external_exec) = &self.execution {
-            let exec_desc = builder().shell_exec_string(&external_exec.exec_pattern);
+            let exec_desc = builder().shell_exec_string(&external_exec.exec_pattern, con);
             format!("Hit *enter* to **{}**: `{}`", name, &exec_desc)
         } else if self.description.code {
             format!("Hit *enter* to **{}**: `{}`", name, &self.description.content)

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -302,6 +302,7 @@ name | expanded to
 `{other-panel-parent}` | complete path of the current selection's parent in the other panel
 `{other-panel-directory}` | closest directory, either `{file}` or `{parent}` in the other panel
 `{root}` | current tree root (top of the displayed files tree)
+`{initial-root}` | tree root at launch
 `{git-root}` | The working directory of the Git repository containing the current selection
 `{git-name}` | Name of the working directory of the current Git repository
 `{file-git-relative}` | path of the current selection relative to the working directory of the containing Git repository. If the selection is not in a Git repository then the absolute path.


### PR DESCRIPTION
Allow verbs like 


    {
        key: ctrl-esc
        execution: ":focus {initial-root}"
    }

(if the kitty keyboard protocol is enabled)


Fix #919