### PR TITLE
Allow ignore/unignore rules in .ignore

### DIFF
--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -168,7 +168,7 @@ impl GitIgnorer {
                     chain.push(self.files.alloc(gif));
                 }
             }
-            for filename in [".gitignore", ".git/info/exclude"] {
+            for filename in [".gitignore", ".git/info/exclude", ".ignore"] {
                 let file = dir.join(filename);
                 if let Ok(gif) = GitIgnoreFile::new(&file, dir) {
                     //debug!("pushing GIF {:#?}", &gif);
@@ -203,9 +203,11 @@ impl GitIgnorer {
             parent_chain.clone()
         };
         if chain.in_repo {
-            let ignore_file = dir.join(".gitignore");
-            if let Ok(gif) = GitIgnoreFile::new(&ignore_file, dir) {
-                chain.push(self.files.alloc(gif));
+            for filename in [".gitignore", ".ignore"] {
+                let ignore_file = dir.join(filename);
+                if let Ok(gif) = GitIgnoreFile::new(&ignore_file, dir) {
+                    chain.push(self.files.alloc(gif));
+                }
             }
         }
         chain


### PR DESCRIPTION
Files called `.ignore` with the syntax of gitignore files are now read and used just like `.gitignore` files.

When, at the same level, broot finds rules from both a `.ignore` and a `.gitignore` files, the `.ignore` is the decisive one (it's assumed to be personal and meant to override the shared `.gitignore` file.

Eg I can have a global `.gitignore` file with 

    dys-notes.*
    
which helps me have notes everywhere and not sharing them.

And I can have a `.ignore` file, which reveals some of those files in broot:

    !dys-notes.md 
    
Fix #613