### PR TITLE
Non erased global ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ deploy.sh
 /press
 /glassbench_*.db
 .bacon-locations
+.ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- support of `.ignore` files with the same syntax than `.gitignore`. They have priority over `.gitignore` so that a personal `.ignore` file can override a shared `.gitignore` - Fix #613
+
 ### v1.41.1 - 2024-08-04
 <a name="v1.41.1"></a>
 - allow compilation with rustc 1.76 - Fix #925

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next
-- support of `.ignore` files with the same syntax than `.gitignore`. They have priority over `.gitignore` so that a personal `.ignore` file can override a shared `.gitignore` - Fix #613
+- support of `.ignore` files with the same syntax than `.gitignore`. They have priority over `.gitignore` so that a personal `.ignore` file can override a shared `.gitignore` - See https://dystroy.org/broot/tree_view/#hidden-ignored-files - Fix #613
+- `:toggle_ignore` internal, identical to `:toggle_git_ignore`, but with a clearer name so should be preferred
 
 ### v1.41.1 - 2024-08-04
 <a name="v1.41.1"></a>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "broot"
-version = "1.41.1"
+version = "1.41.2-dev"
 dependencies = [
  "ansi_colours",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broot"
-version = "1.41.1"
+version = "1.41.2-dev"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/broot"
 homepage = "https://dystroy.org/broot"

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -482,7 +482,7 @@ pub trait PanelState {
 					con,
 				)
             }
-            Internal::toggle_git_ignore => {
+            Internal::toggle_git_ignore | Internal::toggle_ignore => {
                 self.with_new_options(
 					screen,
 					&|o| {

--- a/src/app/standard_status.rs
+++ b/src/app/standard_status.rs
@@ -25,7 +25,7 @@ pub struct StandardStatus {
     help: String,
     no_verb: String,
     pub all_files_hidden: Option<String>,
-    pub all_files_git_ignored: Option<String>,
+    pub all_files_ignored: Option<String>,
 }
 
 impl StandardStatus {
@@ -60,9 +60,10 @@ impl StandardStatus {
         let all_files_hidden = verb_store
             .key_desc_of_internal(Internal::toggle_hidden)
             .map(|k| format!("Some files are hidden, use *{k}* to display them"));
-        let all_files_git_ignored = verb_store
-            .key_desc_of_internal(Internal::toggle_git_ignore)
-            .map(|k| format!("Some files are git-ignored, use *{k}* to display them"));
+        let all_files_ignored = verb_store
+            .key_desc_of_internal(Internal::toggle_ignore)
+            .or(verb_store.key_desc_of_internal(Internal::toggle_git_ignore))
+            .map(|k| format!("Some files are ignored, use *{k}* to display them"));
         Self {
             tree_top_focus,
             tree_dir_focus,
@@ -80,7 +81,7 @@ impl StandardStatus {
             help,
             no_verb,
             all_files_hidden,
-            all_files_git_ignored,
+            all_files_ignored,
         }
     }
     pub fn builder<'s>(

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -693,7 +693,7 @@ impl PanelState for BrowserState {
             if let Some(md) = con.standard_status.all_files_hidden.clone() {
                 parts.push(md);
             }
-            if let Some(md) = con.standard_status.all_files_git_ignored.clone() {
+            if let Some(md) = con.standard_status.all_files_ignored.clone() {
                 parts.push(md);
             }
             if !parts.is_empty() {

--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -192,6 +192,9 @@ impl GitIgnorer {
         // we reset the chain to the root one:
         // we don't want the .gitignore files of super repositories
         // (see https://github.com/Canop/broot/issues/160)
+        // TODO do we want to spare .ignore files? If so we should not build a new
+        // chain but just clean the current one from .gitignore files (assuming we
+        // flag the added .gitignore files for easy removal)
         let mut chain = if is_repo(dir) {
             let mut chain = GitIgnoreChain::default();
             if let Some(gif) = GitIgnoreFile::global(dir) {

--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -168,7 +168,7 @@ impl GitIgnorer {
                     chain.push(self.files.alloc(gif));
                 }
             }
-            for filename in [".gitignore", ".git/info/exclude"] {
+            for filename in [".gitignore", ".git/info/exclude", ".ignore"] {
                 let file = dir.join(filename);
                 if let Ok(gif) = GitIgnoreFile::new(&file, dir) {
                     //debug!("pushing GIF {:#?}", &gif);
@@ -203,9 +203,11 @@ impl GitIgnorer {
             parent_chain.clone()
         };
         if chain.in_repo {
-            let ignore_file = dir.join(".gitignore");
-            if let Ok(gif) = GitIgnoreFile::new(&ignore_file, dir) {
-                chain.push(self.files.alloc(gif));
+            for filename in [".gitignore", ".ignore"] {
+                let ignore_file = dir.join(filename);
+                if let Ok(gif) = GitIgnoreFile::new(&ignore_file, dir) {
+                    chain.push(self.files.alloc(gif));
+                }
             }
         }
         chain

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -145,6 +145,7 @@ Internals! {
     toggle_git_ignore: "toggle use of .gitignore and .ignore" false,
     toggle_git_status: "toggle showing only files relevant for git status" false,
     toggle_hidden: "toggle showing hidden files" false,
+    toggle_ignore: "toggle use of .gitignore and .ignore" false,
     toggle_perm: "toggle showing file permissions" false,
     toggle_preview: "open/close the preview panel" false,
     toggle_root_fs: "toggle showing filesystem info on top" false,

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -142,7 +142,7 @@ Internals! {
     toggle_device_id: "toggle showing device id" false,
     toggle_files: "toggle showing files (or just folders)" false,
     toggle_git_file_info: "toggle display of git file information" false,
-    toggle_git_ignore: "toggle use of .gitignore" false,
+    toggle_git_ignore: "toggle use of .gitignore and .ignore" false,
     toggle_git_status: "toggle showing only files relevant for git status" false,
     toggle_hidden: "toggle showing hidden files" false,
     toggle_perm: "toggle showing file permissions" false,

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -320,7 +320,7 @@ impl VerbStore {
         self.add_internal(toggle_dates).with_shortcut("dates");
         self.add_internal(toggle_device_id).with_shortcut("dev");
         self.add_internal(toggle_files).with_shortcut("files");
-        self.add_internal(toggle_git_ignore)
+        self.add_internal(toggle_ignore)
             .with_key(key!(alt-i))
             .with_shortcut("gi");
         self.add_internal(toggle_git_file_info).with_shortcut("gf");

--- a/website/docs/conf_file.md
+++ b/website/docs/conf_file.md
@@ -136,7 +136,7 @@ special_paths: {
 "~/my-link-I-want-to-explore" = { list = "always" }
 ```
 
-Be careful that those paths (globs, in fact) are checked a lot when broot builds trees and that defining a lot of paths will impact the overall speed.
+Be careful that those paths (globs, in fact) are checked a lot when broot builds trees and that defining a lot of paths will impact the overall speed. When the goal is to have a gitignored file visible, it's more convenient and efficient to use a `.ignore` file.
 
 # Search Modes
 

--- a/website/docs/css/details.css
+++ b/website/docs/css/details.css
@@ -1,0 +1,23 @@
+.admonition.closed {
+    padding: 15px 15px 5px 15px;
+}
+.note.details {
+    background: #ffffff80;
+    color: #555;
+}
+.note.details .admonition-title {
+    cursor: pointer;
+    color: #777;
+}
+.note.details .admonition-title:hover {
+    color: #555;
+}
+.note.details.closed .admonition-title::before {
+    content: "▼";
+}
+.note.details .admonition-title::before {
+    content: "▲";
+}
+.note.details.closed > *:not(.admonition-title) {
+    display: none;
+}

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -15,9 +15,9 @@ Notice the *unlisted*?
 
 That's what makes it usable where the old `tree` command would produce pages of output.
 
-`.gitignore` files are properly dealt with to put unwanted files out of your way.
+`.gitignore` and `.ignore` files are properly dealt with to put unwanted files out of your way.
 
-As you sometimes want to see gitignored files, or hidden ones, you'll soon get used to the <kbd>alt</kbd><kbd>i</kbd> and <kbd>alt</kbd><kbd>h</kbd> shortcuts to toggle those visibilities.
+As you sometimes want to see ignored files, or hidden ones, you'll soon get used to the <kbd>alt</kbd><kbd>i</kbd> and <kbd>alt</kbd><kbd>h</kbd> shortcuts to toggle those visibilities.
 
 (you can ignore them though, see [documentation](../navigation/#toggles)).
 
@@ -42,7 +42,7 @@ Most useful keys for this:
 * <kbd class=b>↓</kbd> and <kbd class=b>↑</kbd> may be used to move the selection
 * <kbd>alt</kbd><kbd>enter</kbd> to get back to the shell having `cd` to the selected directory
 * <kbd>alt</kbd><kbd>h</kbd> to toggle showing hidden files (the ones whose name starts with a dot)
-* <kbd>alt</kbd><kbd>i</kbd> to toggle showing gitignored files
+* <kbd>alt</kbd><kbd>i</kbd> to toggle showing ignored files
 * `:q` if you just want to quit (you can use <kbd>ctrl</kbd><kbd>q</kbd> if you prefer)
 
 # Never lose track of file hierarchy while you search

--- a/website/docs/js/details.js
+++ b/website/docs/js/details.js
@@ -1,0 +1,22 @@
+/// Make sections with class "note details" collapsible
+// (initially closed)
+//
+// Such a section is created by the following markdown:
+//
+// ```markdown
+// !!! Note Details
+//
+//     Some **markdown** content
+// ```
+(function main(){
+	$(".note.details").each(function(){
+		let section = this;
+		section.classList.add("closed");
+		$(section).children(".admonition-title")
+			.text("Details")
+			.click(function(){
+				section.classList.toggle("closed");
+			});
+	});
+})();
+

--- a/website/docs/tree_view.md
+++ b/website/docs/tree_view.md
@@ -33,6 +33,38 @@ If you use those toggles frequently enough, you'll remember the <kbd>alt</kbd><k
 
 And if you forget the combinations, have a look at [the help](../help/#verbs).
 
+!!! Note Details
+
+    The files applicable to a directory are:
+
+    - the global `.gitignore` file (if any)
+    - all the `.ignore` files found in the current directory and in parents
+    - the `.git/info/exclude` file of the current git repository
+    - all the `.gitignore` files found in the current directory and in parents but not outside  the current git repository (i.e. not in git repositories containing the current git repository)
+
+    Deeper file have a bigger priority.
+
+    `.ignore` files have a bigger priority than `.gitignore` files.
+
+    ---
+
+    Those rules allow for example having personal `my-notes.*` files always ignored by git but visible in broot, with only global files:
+
+    **~/.config/git/ignore*** :
+
+    ```
+    .ignore
+    my-notes.*
+    ```
+
+    **~/.ignore** :
+
+    ```
+    !my-notes.*
+    ```
+
+    (note the `!` before the pattern)
+
 
 # File Properties
 

--- a/website/docs/tree_view.md
+++ b/website/docs/tree_view.md
@@ -9,7 +9,7 @@ It does so with a parallel trimming of child directories to give you a balanced 
 
 This basic representation will probably be the one you'll most frequently use but you'll also want at times
 
-- to show hidden files, or gitignored ones
+- to show hidden files, or ignored ones
 - to show the many properties of the files and directories
 - to sort files
 - to disable trimming
@@ -17,9 +17,9 @@ This basic representation will probably be the one you'll most frequently use bu
 - to show the device's occupation
 - to trim or not
 
-# hidden & gitignored files
+# hidden & ignored files
 
-With default configuration, hidden files (the ones whose name starts with a dot) and gitignored files (when in a git repository) are initially hidden.
+With default configuration, hidden files (the ones whose name starts with a dot), ignored files (due to a `.ignore` or `.gitignore` file) are initially hidden.
 
 If you don't want to hide those files, you may either
 
@@ -126,7 +126,7 @@ Each of those toggles lets you alternate between 2 or 3 modes.
  | toggle_dates         | dates    |       | toggle showing last modified dates (deep computed)
  | toggle_files         | files    |       | toggle showing files (or just folders)
  | toggle_git_file_info | gf       |       | toggle display of git file information
- | toggle_git_ignore    | gi       | <kbd>alt</kbd><kbd>i</kbd> | toggle use of .gitignore
+ | toggle_git_ignore    | gi       | <kbd>alt</kbd><kbd>i</kbd> | toggle use of .gitignore and .ignore
  | toggle_hidden        | h        | <kbd>alt</kbd><kbd>h</kbd> | toggle showing hidden files
  | toggle_perm          | perm     |       | toggle showing file permissions (Unix only)
  | toggle_sizes         | sizes    |       | toggle showing sizes

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -36,10 +36,12 @@ extra_css:
         - css/extra.css
         - css/tab-langs.css
         - css/link-to-dystroy.css
+        - css/details.css
 
 extra_javascript:
         - js/tab-langs.js
         - js/link-to-dystroy.js
+        - js/details.js
 
 theme:
         name: null


### PR DESCRIPTION
The list of ignore files applicable to a directory contains
- the global `.gitignore` file (if any)
- all the `.ignore` files found in the current directory and in parents
- the `.git/info/exclude` file of the current git repository
- all the `.gitignore` files found in the current directory and in parents but not outside  the current git repository (i.e. not in git repositories containing the current git repository)

Deeper file have a bigger priority.
`.ignore` files have a bigger priority than `.gitignore` files.

---

Those rules allow for example having personal `my-notes.*` files always ignored by git but visible in broot, with only global files:

In `~/.config/git/ignore` :

```
.ignore
my-notes.*
```

In `~/.ignore` :

```
!my-notes.*
```

(note the `!` before the pattern)
