### PR TITLE
size & date in trash screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "deser-hjson",
  "directories 4.0.1",
  "file-size",
+ "flex-grow",
  "git2",
  "glassbench",
  "glob",
@@ -806,6 +807,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "flex-grow"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d504ae1bb01561686fa31189fe56754a5d869392890a1e64e69d198557a8eb78"
 
 [[package]]
 name = "float-cmp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ custom_error = "1.6"
 deser-hjson = "2.2.3"
 directories = "4.0"
 file-size = "1.0.3"
+flex-grow = "0.1"
 git2 = { version = "0.19", default-features = false } # waiting for a good pure-rust alternative
 glob = "0.3"
 id-arena = "2.2.1"

--- a/src/app/cmd_result.rs
+++ b/src/app/cmd_result.rs
@@ -67,7 +67,7 @@ impl CmdResult {
     pub fn verb_not_found(text: &str) -> CmdResult {
         CmdResult::DisplayError(format!("verb not found: {:?}", &text))
     }
-    pub fn from_optional_state(
+    pub fn from_optional_browser_state(
         os: Result<BrowserState, TreeBuildError>,
         message: Option<&'static str>,
         in_new_panel: bool,

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -102,7 +102,7 @@ impl BrowserState {
                 bs.displayed_tree_mut().try_select_path(&tree.selected_line().path);
             }
         }
-        CmdResult::from_optional_state(
+        CmdResult::from_optional_browser_state(
             new_state,
             message,
             in_new_panel,
@@ -148,7 +148,7 @@ impl BrowserState {
                 }
             }
             let dam = Dam::unlimited();
-            Ok(CmdResult::from_optional_state(
+            Ok(CmdResult::from_optional_browser_state(
                 BrowserState::new(
                     target,
                     if keep_pattern {
@@ -181,7 +181,7 @@ impl BrowserState {
         in_new_panel: bool,
     ) -> CmdResult {
         match &self.displayed_tree().selected_line().path.parent() {
-            Some(path) => CmdResult::from_optional_state(
+            Some(path) => CmdResult::from_optional_browser_state(
                 BrowserState::new(
                     path.to_path_buf(),
                     self.displayed_tree().options.without_pattern(),

--- a/src/filesystems/filesystems_state.rs
+++ b/src/filesystems/filesystems_state.rs
@@ -516,7 +516,7 @@ impl PanelState for FilesystemState {
                 let dam = Dam::unlimited();
                 let mut tree_options = self.tree_options();
                 tree_options.show_root_fs = true;
-                CmdResult::from_optional_state(
+                CmdResult::from_optional_browser_state(
                     BrowserState::new(
                         self.no_opt_selected_path().to_path_buf(),
                         tree_options,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ pub mod skin;
 pub mod syntactic;
 pub mod task_sync;
 pub mod terminal;
-pub mod trash;
 pub mod tree;
 pub mod tree_build;
 pub mod verb;
@@ -38,6 +37,9 @@ pub mod verb;
 #[cfg(unix)]
 pub mod filesystems;
 
-
 #[cfg(unix)]
 pub mod net;
+
+#[cfg(feature = "trash")]
+pub mod trash;
+

--- a/src/trash/mod.rs
+++ b/src/trash/mod.rs
@@ -1,6 +1,39 @@
 
-#[cfg(feature = "trash")]
+mod trash_sort;
 mod trash_state;
+mod trash_state_cols;
 
-#[cfg(feature = "trash")]
 pub use trash_state::*;
+
+use {
+    trash::{
+        self as trash_crate,
+        TrashItem,
+        TrashItemSize,
+    },
+};
+
+/// Determine whether an item in the trash is a directory.
+///
+/// There's probably a simpler solution in the trash crate, but I didn't found it.
+fn item_is_dir(item: &TrashItem) -> bool {
+    match trash_crate::os_limited::metadata(item) {
+        Ok(metadata) => {
+            match metadata.size {
+                TrashItemSize::Bytes(_) => false,
+                TrashItemSize::Entries(_) => true,
+            }
+        }
+        Err(_) => false,
+    }
+}
+
+/// Return either the byte size or the number of entries of a trash item.
+///
+/// Return None when it couldn't be determined.
+fn item_unified_size(item: &TrashItem) -> Option<u64> {
+    match trash_crate::os_limited::metadata(item).ok()?.size {
+        TrashItemSize::Bytes(v) => Some(v),
+        TrashItemSize::Entries(v) => v.try_into().ok(),
+    }
+}

--- a/src/trash/trash_sort.rs
+++ b/src/trash/trash_sort.rs
@@ -1,0 +1,25 @@
+use {
+    super::*,
+    crate::{
+        tree::*,
+    },
+    trash::{
+        TrashItem,
+    },
+};
+
+/// Sort trash items according to the current tree options.
+pub fn sort(
+    items: &mut [TrashItem],
+    tree_options: &TreeOptions,
+) {
+    info!("sorting itemsi by {:?}", tree_options.sort);
+    match tree_options.sort {
+        Sort::Date => items.sort_by_key(|item| std::cmp::Reverse(item.time_deleted)),
+        Sort::Size => items.sort_by_key(|item| std::cmp::Reverse(
+            item_unified_size(item).unwrap_or(0)
+        )),
+        _ => items.sort_by_key(|item| (item.name.clone(), item.original_parent.clone())),
+    }
+
+}

--- a/src/trash/trash_state_cols.rs
+++ b/src/trash/trash_state_cols.rs
@@ -1,0 +1,148 @@
+use {
+    super::*,
+    crate::{
+        skin::StyleMap,
+        tree::TreeOptions,
+    },
+    chrono::{
+        Local,
+        LocalResult,
+        TimeZone,
+    },
+    termimad::CompoundStyle,
+    trash::TrashItem,
+    unicode_width::UnicodeWidthStr,
+};
+
+/// A displayable column, related to properties of the TrashItem
+#[derive(Debug, Clone, Copy)]
+pub enum TrashItemProperty {
+    OriginalParent,
+    Name,
+    DeletionDate,
+    Size,
+}
+
+impl TrashItemProperty {
+    pub fn title(self) -> &'static str {
+        // only single byte characters allowed here
+        match self {
+            Self::OriginalParent => "Original parent",
+            Self::Name => "Deleted file name",
+            Self::DeletionDate => "Deletion",
+            Self::Size => "Size",
+        }
+    }
+    pub fn style<'s>(
+        self,
+        is_dir: bool,
+        styles: &'s StyleMap,
+    ) -> &'s CompoundStyle {
+        match self {
+            Self::DeletionDate => &styles.dates,
+            _ => {
+                if is_dir {
+                    &styles.directory
+                } else {
+                    &styles.file
+                }
+            }
+        }
+    }
+    pub fn value_of(
+        self,
+        item: &TrashItem,
+        options: &TreeOptions,
+    ) -> String {
+        match self {
+            Self::OriginalParent => item.original_parent.to_string_lossy().to_string(),
+            Self::Name => item.name.clone(),
+            Self::DeletionDate => {
+                let seconds = item.time_deleted;
+                if let LocalResult::Single(date_time) = Local.timestamp_opt(seconds, 0) {
+                    date_time.format(options.date_time_format).to_string()
+                } else {
+                    "???".to_string()
+                }
+            }
+            Self::Size => match item_unified_size(item) {
+                Some(size) => format!("{:>4}", file_size::fit_4(size)),
+                None => "????".to_string(),
+            },
+        }
+    }
+    pub fn const_width(self) -> bool {
+        match self {
+            Self::OriginalParent => false,
+            Self::Name => false,
+            Self::DeletionDate => true,
+            Self::Size => true,
+        }
+    }
+    pub fn optimal_width(
+        self,
+        items: &[TrashItem],
+        options: &TreeOptions,
+    ) -> usize {
+        match self {
+            Self::Size => 4,
+            _ => items
+                .iter()
+                .map(|m| self.value_of(m, options).width())
+                .max()
+                .unwrap_or(0),
+        }
+    }
+    pub fn column_constraints(
+        self,
+        items: &[TrashItem],
+        options: &TreeOptions,
+    ) -> flex_grow::Child<Self> {
+        let optimal_width = self.optimal_width(items, options);
+        let child = flex_grow::Child::new(self);
+        if self.const_width() {
+            child.with_size(optimal_width)
+        } else {
+            child.with_max(optimal_width)
+        }
+    }
+}
+
+pub fn get_cols(
+    items: &[TrashItem],
+    available_width: usize,
+    tree_options: &TreeOptions,
+) -> Vec<flex_grow::Child<TrashItemProperty>> {
+    let mut cols_builder = flex_grow::Container::builder_in(available_width).with_margin_between(1);
+    if tree_options.show_sizes {
+        cols_builder.add(
+            TrashItemProperty::Size
+                .column_constraints(items, tree_options)
+                .optional(),
+        );
+    }
+    if tree_options.show_dates {
+        cols_builder.add(
+            TrashItemProperty::DeletionDate
+                .column_constraints(items, tree_options)
+                .optional(),
+        );
+    }
+    cols_builder.add(
+        TrashItemProperty::OriginalParent
+            .column_constraints(items, tree_options)
+            .with_min(10)
+            .optional(),
+    );
+    cols_builder.add(
+        TrashItemProperty::Name
+            .column_constraints(items, tree_options)
+            .with_min(10)
+            .with_grow(2.0),
+    );
+    let Ok(cols) = cols_builder.build() else {
+        return Vec::new(); // should not happen
+    };
+    debug!("trash_state cols: {:?}", cols.sizes());
+    cols.to_children()
+}

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -45,7 +45,7 @@ pub fn new_state_on_path(
     con: &AppContext,
 ) -> CmdResult {
     let path = path::closest_dir(&path);
-    CmdResult::from_optional_state(
+    CmdResult::from_optional_browser_state(
         BrowserState::new(path, tree_options, screen, con, &Dam::unlimited()),
         None,
         false,

--- a/website/docs/css/extra.css
+++ b/website/docs/css/extra.css
@@ -13,6 +13,10 @@ body .col-md-9 p img {
 	background-color: transparent;
 }
 
+p img {
+	box-shadow: 1px 1px 2px #2229;
+}
+
 .sponsorship {
 	margin-top: 20px;
 	display: flex;

--- a/website/docs/css/extra.css
+++ b/website/docs/css/extra.css
@@ -13,7 +13,7 @@ body .col-md-9 p img {
 	background-color: transparent;
 }
 
-p img {
+p img:not(.vache) {
 	box-shadow: 1px 1px 2px #2229;
 }
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,6 +1,6 @@
 
 <p align=center style="max-width:600px">
-<img src="img/vache.svg" height=140px>
+<img class=vache src="img/vache.svg" height=140px>
 <br><a class=install-link href=install>Install Broot</a>
 </p>
 


### PR DESCRIPTION
Trash screen (which you obtain with `:open_trash` on compatible platforms) now has 2 optional columns: one for the size and one for the deletion date.

Those internals work as expected: `:toggle_date`, `:toggle_size`, `:sort_by_date`, `:sort_by_size`.