### PR TITLE
focus_staging_area_no_open internal

### DIFF
--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -585,9 +585,16 @@ pub trait PanelState {
             Internal::escape => {
                 CmdResult::HandleInApp(Internal::escape)
             }
+            Internal::focus_staging_area_no_open => {
+                CmdResult::HandleInApp(Internal::focus_staging_area_no_open)
+            }
+            // panel_left depends on the kind of panel and is usually handled
+            // in a specific state, contrary to panel_left_no_open
             Internal::panel_left | Internal::panel_left_no_open => {
                 CmdResult::HandleInApp(Internal::panel_left_no_open)
             }
+            // panel_right depends on the kind of panel and is usually handled
+            // in a specific state, contrary to panel_right_no_open
             Internal::panel_right | Internal::panel_right_no_open => {
                 CmdResult::HandleInApp(Internal::panel_right_no_open)
             }

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -67,6 +67,7 @@ Internals! {
     escape: "escape from edition, completion, page, etc." false,
     filesystems: "list mounted filesystems" false,
     focus: "display the directory (mapped to *enter*)" true,
+    focus_staging_area_no_open: "focus the staging area if already open" false,
     help: "display broot's help" false,
     input_clear: "empty the input" false,
     input_del_char_below: "delete the char left at the cursor's position" false,

--- a/src/verb/verb.rs
+++ b/src/verb/verb.rs
@@ -261,11 +261,9 @@ impl Verb {
             )
         };
         if let VerbExecution::Sequence(seq_ex) = &self.execution {
-            let exec_desc = builder().shell_exec_string(
-                &ExecPattern::from_string(&seq_ex.sequence.raw),
-                con,
-            );
-            format!("Hit *enter* to **{}**: `{}`", name, &exec_desc)
+            // We can't determine before execution what will be the arguments, except
+            // for the first item of the sequence. It's cleaner to just not try expand it
+            format!("Hit *enter* to **{}**: `{}`", name, seq_ex.sequence.raw)
         } else if let VerbExecution::External(external_exec) = &self.execution {
             let exec_desc = builder().shell_exec_string(&external_exec.exec_pattern, con);
             format!("Hit *enter* to **{}**: `{}`", name, &exec_desc)

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -172,6 +172,7 @@ impl VerbStore {
         #[cfg(unix)]
         self.add_internal(filesystems)
             .with_shortcut("fs");
+        self.add_internal(focus_staging_area_no_open);
         // :focus is also hardcoded on Enter on directories
         // but ctrl-f is useful for focusing on a file's parent
         // (and keep the filter)


### PR DESCRIPTION
 This was requested in #926.
 
 This internal allows a verb which would work
 * on staged files when the staging area is open, even when it's not focused
 * on the selection when there's no open staging area 
 
    {
        invocation: rm
        cmd: ":focus_staging_area_no_open;:trash {file}"
    }



Fix #926