### PR TITLE
Add image rendering support for Ghostty

### DIFF
--- a/src/kitty/detect_support.rs
+++ b/src/kitty/detect_support.rs
@@ -49,6 +49,9 @@ pub fn is_kitty_graphics_protocol_supported() -> bool {
             } else {
                 warn!("$TERM_PROGRAM_VERSION unexpectedly missing");
             }
+        } else if term_program == "ghostty" {
+            debug("Ghostty implements Kitty Graphics protocol");
+            return true;
         }
     }
 


### PR DESCRIPTION
## Problem

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/09d6e204-0145-475e-8e2f-ce4cb84a1193">

## PR description

This PR extends the existing approach which checks for WezTerm and Kitty terminals to also support Ghostty. Ghostty is a terminal (currently in closed beta, but ~600 stars) that also implements support for Kitty graphics protocol.

## Side-note

I have also adapted your terminal checking code and [ported my own CLI application](https://github.com/pls-rs/pls/blob/9ba7d88ef4765b0b3f4ce0a3ffede89dd7500895/src/gfx/kitty.rs#L24-L49), [`pls`](https://pls.cli.rs). Thank you!