### PR TITLE
remove temp files used by kitty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +251,7 @@ dependencies = [
  "lazy-regex",
  "lfs-core",
  "libc",
+ "lru",
  "memmap2 0.9.4",
  "once_cell",
  "opener",
@@ -836,6 +843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,12 +980,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1091,7 +1115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1275,6 +1299,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.0",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -1807,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ image = "0.24"
 include_dir = "0.7"
 lazy-regex = "3.3"
 libc = "0.2"
+lru = "0.12"
 memmap2 = "0.9"
 once_cell = "1.18" # waiting for https://github.com/rust-lang/rust/issues/109736
 opener = "0.6"
@@ -51,7 +52,7 @@ pathdiff = "0.2"
 phf = { version = "0.11", features = ["macros"] }
 rayon = "1.9"
 resvg = "0.36" # several options behind, as it's always a PITA to upgrade
-rustc-hash = "1" 
+rustc-hash = "2" 
 secular = { version = "1.0", features = ["normalization", "bmp"] }
 serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.11" # version 2 is still alpha

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -886,7 +886,7 @@ impl App {
                 Either::First(Some(event)) => {
                     //info!("event: {:?}", &event);
                     if let Some(key_combination) = event.key_combination {
-                        info!("key combination: {}", key_combination);
+                        debug!("key combination: {}", key_combination);
                     }
                     let mut handled = false;
 

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -22,6 +22,7 @@ use {
     std::{
         convert::{TryFrom, TryInto},
         io,
+        num::NonZeroUsize,
         path::{Path, PathBuf},
     },
 };
@@ -124,6 +125,8 @@ pub struct AppContext {
 
     pub kitty_graphics_transmission: TransmissionMedium,
 
+    pub kept_kitty_temp_files: NonZeroUsize,
+
     /// Number of lines to display after a match in the preview
     pub lines_after_match_in_preview: usize,
 
@@ -206,6 +209,9 @@ impl AppContext {
         let terminal_title_pattern = config.terminal_title.clone();
         let preview_transformers = PreviewTransformers::new(&config.preview_transformers)?;
         let layout_instructions = config.layout_instructions.clone().unwrap_or_default();
+        let kept_kitty_temp_files = config.kept_kitty_temp_files.unwrap_or(
+            std::num::NonZeroUsize::new(500).unwrap(),
+        );
 
         Ok(Self {
             is_tty,
@@ -237,6 +243,7 @@ impl AppContext {
             keyboard_enhanced: false,
             kitty_graphics_transmission: config.kitty_graphics_transmission
                 .unwrap_or_default(),
+            kept_kitty_temp_files,
             lines_after_match_in_preview: config.lines_after_match_in_preview.unwrap_or(0),
             lines_before_match_in_preview: config.lines_before_match_in_preview.unwrap_or(0),
             preview_transformers,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -166,7 +166,13 @@ pub fn run() -> Result<Option<Launchable>, ProgramError> {
     w.queue(cursor::Show)?;
     w.queue(LeaveAlternateScreen)?;
     w.flush()?;
+    clear_resources();
     r
+}
+
+fn clear_resources() {
+    info!("clearing resources");
+    crate::kitty::manager().lock().unwrap().delete_temp_files();
 }
 
 /// wait for user input, return `true` if they didn't answer 'n'

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -20,8 +20,11 @@ use {
     rustc_hash::FxHashMap,
     crokey::crossterm::style::Attribute,
     serde::Deserialize,
-    std::collections::HashMap,
-    std::path::PathBuf,
+    std::{
+        collections::HashMap,
+        num::NonZeroUsize,
+        path::PathBuf,
+    },
 };
 
 macro_rules! overwrite {
@@ -94,6 +97,9 @@ pub struct Conf {
 
     #[serde(alias="kitty-graphics-transmission")]
     pub kitty_graphics_transmission: Option<TransmissionMedium>,
+
+    #[serde(default, alias="kept-kitty-temp-files")]
+    pub kept_kitty_temp_files: Option<NonZeroUsize>,
 
     #[serde(default, alias="preview-transformers")]
     pub preview_transformers: Vec<PreviewTransformerConf>,
@@ -233,6 +239,7 @@ impl Conf {
         overwrite!(self, update_work_dir, conf);
         overwrite!(self, enable_kitty_keyboard, conf);
         overwrite!(self, kitty_graphics_transmission, conf);
+        overwrite!(self, kept_kitty_temp_files, conf);
         overwrite!(self, lines_after_match_in_preview, conf);
         overwrite!(self, lines_before_match_in_preview, conf);
         overwrite!(self, layout_instructions, conf);

--- a/src/image/image_view.rs
+++ b/src/image/image_view.rs
@@ -119,7 +119,7 @@ impl ImageView {
         }
 
         self.kitty_image_id = kitty_manager
-            .try_print_image(w, &self.source_img, area, bg, disc.count, disc.con)?;
+            .try_print_image(w, &self.source_img, &self.path, area, bg, disc.count, disc.con)?;
 
         if self.kitty_image_id.is_some() {
             return Ok(());

--- a/src/kitty/image_renderer.rs
+++ b/src/kitty/image_renderer.rs
@@ -225,7 +225,7 @@ impl KittyImageRenderer {
         if !is_kitty_graphics_protocol_supported() {
             return None;
         }
-        let hasher = FxBuildHasher::default();
+        let hasher = FxBuildHasher;
         let temp_files = LruCache::with_hasher(options.kept_temp_files, hasher);
         cell_size_in_pixels()
             .ok()
@@ -240,7 +240,7 @@ impl KittyImageRenderer {
     pub fn delete_temp_files(&mut self) {
         for (_, temp_file_path) in self.temp_files.into_iter() {
             debug!("removing temp file: {:?}", temp_file_path);
-            if let Err(e) = std::fs::remove_file(&temp_file_path) {
+            if let Err(e) = std::fs::remove_file(temp_file_path) {
                 error!("failed to remove temp file: {:?}", e);
             }
         }

--- a/src/kitty/image_renderer.rs
+++ b/src/kitty/image_renderer.rs
@@ -24,9 +24,14 @@ use {
         RgbImage,
         RgbaImage,
     },
+    lru::LruCache,
+    rustc_hash::FxBuildHasher,
     serde::Deserialize,
     std::{
+        fs::File,
         io::{self, Write},
+        num::NonZeroUsize,
+        path::{Path, PathBuf},
     },
     tempfile,
     termimad::{fill_bg, Area},
@@ -55,8 +60,10 @@ pub enum TransmissionMedium {
     Chunks,
 }
 
+#[derive(Debug, Clone)]
 pub struct KittyImageRendererOptions {
     pub transmission_medium: TransmissionMedium,
+    pub kept_temp_files: NonZeroUsize,
 }
 
 enum ImageData<'i> {
@@ -110,7 +117,10 @@ pub struct KittyImageRenderer {
     cell_width: u32,
     cell_height: u32,
     next_id: usize,
-    transmission_medium: TransmissionMedium,
+    options: KittyImageRendererOptions,
+    /// paths of temp files which have been written, with key
+    /// being the input image path
+    temp_files: LruCache<String, PathBuf, FxBuildHasher>,
 }
 
 /// An image prepared for a precise area on screen
@@ -176,18 +186,15 @@ impl<'i> KittyImage<'i> {
     pub fn print_with_temp_file(
         &self,
         w: &mut W,
+        temp_file: Option<File>, // if None, no need to write it
+        temp_file_path: &Path,
     ) -> Result<(), ProgramError> {
-        let (mut temp_file, path) = tempfile::Builder::new()
-            .prefix("broot-img-preview")
-            .tempfile()?
-            .keep()
-            .map_err(|_| io::Error::new(
-                io::ErrorKind::Other,
-                "temp file can't be kept",
-            ))?;
-        temp_file.write_all(self.data.bytes())?;
-        temp_file.flush()?;
-        let path = path.to_str()
+        if let Some(mut temp_file) = temp_file {
+            temp_file.write_all(self.data.bytes())?;
+            temp_file.flush()?;
+            debug!("file len: {}", temp_file.metadata().unwrap().len());
+        }
+        let path = temp_file_path.to_str()
             .ok_or_else(|| io::Error::new(
                 io::ErrorKind::Other,
                 "Path can't be converted to UTF8",
@@ -206,25 +213,37 @@ impl<'i> KittyImage<'i> {
             self.area.height,
             encoded_path,
         )?;
-        debug!("file len: {}", temp_file.metadata().unwrap().len());
         Ok(())
     }
 }
 
 impl KittyImageRenderer {
     /// Called only once (at most) by the KittyManager
-    pub fn new(options: &KittyImageRendererOptions) -> Option<Self> {
+    pub fn new(
+        options: KittyImageRendererOptions,
+    ) -> Option<Self> {
         if !is_kitty_graphics_protocol_supported() {
             return None;
         }
+        let hasher = FxBuildHasher::default();
+        let temp_files = LruCache::with_hasher(options.kept_temp_files, hasher);
         cell_size_in_pixels()
             .ok()
             .map(|(cell_width, cell_height)| Self {
                 cell_width,
                 cell_height,
                 next_id: 1,
-                transmission_medium: options.transmission_medium,
+                options,
+                temp_files,
             })
+    }
+    pub fn delete_temp_files(&mut self) {
+        for (_, temp_file_path) in self.temp_files.into_iter() {
+            debug!("removing temp file: {:?}", temp_file_path);
+            if let Err(e) = std::fs::remove_file(&temp_file_path) {
+                error!("failed to remove temp file: {:?}", e);
+            }
+        }
     }
     /// return a new image id
     fn new_id(&mut self) -> usize {
@@ -238,6 +257,7 @@ impl KittyImageRenderer {
         &mut self,
         w: &mut W,
         src: &DynamicImage,
+        src_path: &Path,
         area: &Area,
         bg: Color,
     ) -> Result<usize, ProgramError> {
@@ -249,10 +269,48 @@ impl KittyImageRenderer {
         }
 
         let img = KittyImage::new(src, area, self);
-        debug!("transmission medium: {:?}", self.transmission_medium);
+        debug!("transmission medium: {:?}", self.options.transmission_medium);
         w.flush()?;
-        match self.transmission_medium {
-            TransmissionMedium::TempFile => img.print_with_temp_file(w)?,
+        match self.options.transmission_medium {
+            TransmissionMedium::TempFile => {
+                let temp_file_key = format!(
+                    "{:?}-{}x{}",
+                    src_path,
+                    img.img_width,
+                    img.img_height,
+                );
+                let mut old_path = None;
+                if let Some(cached_path) = self.temp_files.pop(&temp_file_key) {
+                    if cached_path.exists() {
+                        old_path = Some(cached_path);
+                    }
+                }
+                let temp_file_path = if let Some(temp_file_path) = old_path {
+                    // the temp file is still there
+                    img.print_with_temp_file(w, None, &temp_file_path)?;
+                    temp_file_path
+                } else {
+                    // either the temp file itself has been removed (unlikely), the temp
+                    // cache entry has been removed, or we just never viewed this image
+                    // with this size before
+                    let (temp_file, path) = tempfile::Builder::new()
+                        .prefix("broot-img-preview")
+                        .tempfile()?
+                        .keep()
+                        .map_err(|_| io::Error::new(
+                            io::ErrorKind::Other,
+                            "temp file can't be kept",
+                        ))?;
+                    img.print_with_temp_file(w, Some(temp_file), &path)?;
+                    path
+                };
+                if let Some((_, old_path)) = self.temp_files.push(temp_file_key, temp_file_path) {
+                    debug!("removing temp file: {:?}", &old_path);
+                    if let Err(e) = std::fs::remove_file(&old_path) {
+                        error!("failed to remove temp file: {:?}", e);
+                    }
+                }
+            }
             TransmissionMedium::Chunks => img.print_with_chunks(w)?,
         }
         Ok(img.id)

--- a/src/kitty/mod.rs
+++ b/src/kitty/mod.rs
@@ -67,9 +67,8 @@ impl KittyManager {
         }
     }
     pub fn delete_temp_files(&mut self) {
-        match &mut self.renderer {
-            MaybeRenderer::Enabled { renderer } => renderer.delete_temp_files(),
-            _ => {}
+        if let MaybeRenderer::Enabled { renderer } = &mut self.renderer {
+            renderer.delete_temp_files();
         }
     }
     pub fn renderer(
@@ -108,6 +107,7 @@ impl KittyManager {
             }
         }
     }
+    #[allow(clippy::too_many_arguments)] // yes, I know
     pub fn try_print_image(
         &mut self,
         w: &mut W,


### PR DESCRIPTION
In order to display images with the Kitty protocol, broot creates temp files at the optimal dimensions and gives them to the terminal.

A problem with this approach is that those images may take a lot of space, especially if you're on linux and never reboot, as the `/tmp` folder is usually emptied on reboot.

With this commit:
- broot, on quitting, deletes all the temp files it created
- broot has a maximum number of temp files (defined with the `kept_kitty_temp_files` config entry) and removes the least recently used one when the max is reached