### PR TITLE
Remove eval usage in fish launcher

### DIFF
--- a/src/shell_install/fish.rs
+++ b/src/shell_install/fish.rs
@@ -35,9 +35,8 @@ const FISH_FUNC: &str = r"
 function br --wraps=broot
     set -l cmd_file (mktemp)
     if broot --outcmd $cmd_file $argv
-        read --local --null cmd < $cmd_file
+        source $cmd_file
         rm -f $cmd_file
-        eval $cmd
     else
         set -l code $status
         rm -f $cmd_file


### PR DESCRIPTION
As stated in [fish documentation on eval](https://fishshell.com/docs/current/cmds/eval.html):

> If the command does not need access to stdin, consider using [source](https://fishshell.com/docs/current/cmds/source.html) instead.

This has been tested manually on latest fish, though it should be compatible with any relevant version.