### PR TITLE
Fix total search impossible after refresh

### DIFF
--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -48,13 +48,13 @@ impl Tree {
             page_height,
             con,
         )?;
+        self.total_search = false; // on refresh we always do a non total search
         let mut tree = builder
             .build_tree(
-                false, // on refresh we always do a non total search
+                self.total_search,
                 &Dam::unlimited(),
             )
             .unwrap(); // should not fail
-                       // we save the old selection to try restore it
         let selected_path = self.selected_line().path.to_path_buf();
         mem::swap(&mut self.lines, &mut tree.lines);
         self.scroll = 0;


### PR DESCRIPTION
A refresh operation occurs on many cases, for example after execution of an external program (including an editor) because those programs often change files.
Refresh should be fast, which is why it's never doing a "total search". The bug is that the tree didn't know it wasn't anymore in total search mode, so it prevented a total search by pretending it wasn't needed.

Fix #985

With this fix, you can launch a total search after refresh (eg with <kbd>Ctrl</kbd>-<kbd>S</kbd>)