### PR TITLE
refresh_after verb parameter

### DIFF
--- a/src/conf/verb_conf.rs
+++ b/src/conf/verb_conf.rs
@@ -53,5 +53,7 @@ pub struct VerbConf {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub panels: Vec<PanelStateType>,
+
+    pub refresh_after: Option<bool>,
 }
 

--- a/src/verb/external_execution.rs
+++ b/src/verb/external_execution.rs
@@ -40,6 +40,9 @@ pub struct ExternalExecution {
     /// whether we need to switch to the normal terminal for
     /// the duration of the execution of the process
     pub switch_terminal: bool,
+
+    /// whether the tree must be refreshed after the verb is executed
+    pub refresh_after: bool,
 }
 
 impl ExternalExecution {
@@ -52,6 +55,7 @@ impl ExternalExecution {
             exec_mode,
             working_dir: None,
             switch_terminal: true, // by default we switch
+            refresh_after: true, // by default we refresh
         }
     }
 
@@ -197,6 +201,10 @@ impl ExternalExecution {
                 }
             }
         }
-        Ok(CmdResult::RefreshState { clear_cache: true })
+        if self.refresh_after {
+            Ok(CmdResult::RefreshState { clear_cache: true })
+        } else {
+            Ok(CmdResult::Keep)
+        }
     }
 }

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -474,7 +474,7 @@ impl VerbStore {
             }
             external_execution
         };
-        let execution = match (execution, internal, external, cmd) {
+        let mut execution = match (execution, internal, external, cmd) {
             // old definition with "execution": we guess whether it's an internal or
             // an external
             (Some(ep), None, None, None) => {
@@ -513,6 +513,13 @@ impl VerbStore {
                 return Ok(());
             }
         };
+        if let Some(refresh_after) = vc.refresh_after {
+            if let VerbExecution::External(external_execution) = &mut execution {
+                external_execution.refresh_after = refresh_after;
+            } else {
+                warn!("refresh_after is only relevant for external commands");
+            }
+        }
         let description = vc
             .description
             .clone()


### PR DESCRIPTION
By default, the tree is refreshed after execution of an external command because files are often modified by such command.
To prevent refresh, add this to the verb definition:

    refresh_after: false

Fix #987