### PR TITLE
Fix typos again

### DIFF
--- a/features.md
+++ b/features.md
@@ -9,7 +9,7 @@ Feature gating is usually temporary: they may be removed when a technical proble
 
 ## The "clipboard" feature
 
-This feature allows the `:copy_path` verb which copies the currently selected path into the clipboard, as well as copy-pasting from,to,whithin the input.
+This feature allows the `:copy_path` verb which copies the currently selected path into the clipboard, as well as copy-pasting from,to,within the input.
 
 Limits:
 

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -255,7 +255,7 @@ impl AppContext {
             layout_instructions,
         })
     }
-    /// Return the --cmd argument, coming from the launch arguments (prefered)
+    /// Return the --cmd argument, coming from the launch arguments (preferred)
     /// or from the default_flags parameter of a config file
     pub fn cmd(&self) -> Option<&str> {
         self.launch_args.cmd.as_ref().or(

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -1153,7 +1153,7 @@ pub trait PanelState {
                     );
                 }
             }
-            // right now there's no check for sequences but they're inherently dangereous
+            // right now there's no check for sequences but they're inherently dangerous
         }
         if let Some(err) = verb.check_args(sel_info, invocation, &app_state.other_panel_path) {
             Status::new(err, true)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,7 +73,7 @@ custom_error! {pub TreeBuildError
     NotADirectory { path: String } = "Not a directory: {path}",
     NotARootDescendant { path: String } = "Not a descendant of the root: {path}",
     TooManyMatches { max: usize } = "Too many matches (max allowed: {max})",
-    UnconsistentData { message:String } = "Unconsistent data: {message}", // maybe refresh ?
+    InconsistentData { message:String } = "Inconsistent data: {message}", // maybe refresh ?
 }
 
 custom_error! {pub ConfError

--- a/src/task_sync.rs
+++ b/src/task_sync.rs
@@ -144,7 +144,7 @@ impl Dam {
         }
     }
 
-    // or maybed return either Option<TimedEvent> or Option<T> ?
+    // or maybe return either Option<TimedEvent> or Option<T> ?
     pub fn next<T>(&mut self, other: &Receiver<T>) -> Either<Option<TimedEvent>, Option<T>> {
         if self.in_dam.is_some() {
             Either::First(self.in_dam.take())

--- a/website/docs/conf_file.md
+++ b/website/docs/conf_file.md
@@ -297,7 +297,7 @@ It's possible to define transformers to apply to some files before preview.
 
 This makes it possible for example to render a specific kind of files as images, or to beautify some text ones.
 
-Below are examples that you may adapt to your needs and prefered tools.
+Below are examples that you may adapt to your needs and preferred tools.
 They must be included in a `preview_transformers` array, as shown in the [default conf.hjson](https://github.com/Canop/broot/blob/main/resources/default-conf/conf.hjson).
 
 ### Render PDF using mutool:

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -381,7 +381,7 @@ You can override the default behavior of broot by giving your verb the same shor
 
 # Internals
 
-Here's a list of internals: builtin actions you can add an alternate shortcut or keyboard key for, without refering to an external program or command:
+Here's a list of internals: builtin actions you can add an alternate shortcut or keyboard key for, without referring to an external program or command:
 
 invocation | default key | default shortcut | behavior / details
 -|-|-|-


### PR DESCRIPTION
Found via `typos --hidden --format brief`