### PR TITLE
Fix missing `--max-depth` argument in nushell install

### DIFF
--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -60,6 +60,7 @@ export def --env br [
     --no-sizes(-S)                  # Don't show sizes
     --set-install-state: path       # Where to write the produced cmd (if any) [possible values: undefined, refused, installed]
     --show-root-fs                  # Show filesystem info on top
+    --max-depth                     # Only show trees up to a certain depth
     --sort-by-count                 # Sort by count (only show one level of the tree)
     --sort-by-date                  # Sort by date (only show one level of the tree)
     --sort-by-size                  # Sort by size (only show one level of the tree)
@@ -158,6 +159,7 @@ export extern broot [
     --no-sizes(-S)                  # Don't show sizes
     --set-install-state: path       # Where to write the produced cmd (if any) [possible values: undefined, refused, installed]
     --show-root-fs                  # Show filesystem info on top
+    --max-depth                     # Only show trees up to a certain depth
     --sort-by-count                 # Sort by count (only show one level of the tree)
     --sort-by-date                  # Sort by date (only show one level of the tree)
     --sort-by-size                  # Sort by size (only show one level of the tree)


### PR DESCRIPTION
Without this you get errors upon loading:

```nu
Error: nu::parser::variable_not_found

  × Variable not found.
    ╭─[/Users/liz/.config/nushell/autoload/br.nu:76:8]
 75 │     if $show_root_fs { $args = ($args | append $'--show-root-fs') }
 76 │     if $max_depth != null { $args = ($args | append $'--max-depth=($max_depth)') }
    ·        ─────┬────
    ·             ╰── variable not found.
 77 │     if $sort_by_count { $args = ($args | append $'--sort-by-count') }
    ╰────
```