### PR TITLE
fix :focus with conf argument goes up if root selected

### DIFF
--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -349,19 +349,12 @@ impl PanelState for BrowserState {
             }
             Internal::focus => {
                 let tree = self.displayed_tree();
-                let mut path = &tree.selected_line().path;
-                let parent;
-                if tree.is_root_selected() {
-                    if let Some(parent_path) = path.parent() {
-                        parent = parent_path.to_path_buf();
-                        path = &parent;
-                    }
-                }
                 internal_focus::on_internal(
                     internal_exec,
                     input_invocation,
                     trigger_type,
-                    path,
+                    &tree.selected_line().path,
+                    tree.is_root_selected(),
                     tree.options.clone(),
                     app_state,
                     cc,

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -179,6 +179,7 @@ pub fn on_internal(
     input_invocation: Option<&VerbInvocation>,
     trigger_type: TriggerType,
     selected_path: &Path,
+    is_root_selected: bool,
     tree_options: TreeOptions,
     app_state: & AppState,
     cc: &CmdContext,
@@ -226,7 +227,15 @@ pub fn on_internal(
             } else {
                 // user only wants to open the selected path, either in the same panel or
                 // in a new one
-                on_path(selected_path.to_path_buf(), screen, tree_options, bang, con)
+                let mut path = selected_path.to_path_buf();
+                if !bang && is_root_selected {
+                    // the selected path is the root, focusing it would do nothing, so
+                    // we rather go up one level
+                    if let Some(parent_path) = selected_path.parent() {
+                        path = parent_path.to_path_buf();
+                    }
+                }
+                on_path(path, screen, tree_options, bang, con)
             }
         }
     }

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -496,14 +496,14 @@ impl VerbStore {
         &'v self,
         prefix: &str,
         sel_info: SelInfo<'_>,
-    ) -> PrefixSearchResult<'v, &Verb> {
+    ) -> PrefixSearchResult<'v, &'v Verb> {
         self.search(prefix, Some(sel_info))
     }
 
     pub fn search_prefix<'v>(
         &'v self,
         prefix: &str,
-    ) -> PrefixSearchResult<'v, &Verb> {
+    ) -> PrefixSearchResult<'v, &'v Verb> {
         self.search(prefix, None)
     }
 
@@ -524,7 +524,7 @@ impl VerbStore {
         &'v self,
         prefix: &str,
         sel_info: Option<SelInfo>,
-    ) -> PrefixSearchResult<'v, &Verb> {
+    ) -> PrefixSearchResult<'v, &'v Verb> {
         let mut found_index = 0;
         let mut nb_found = 0;
         let mut completions: Vec<&str> = Vec::new();


### PR DESCRIPTION
The fixed bug:

When a verb is defined with the `focus` internal and an argument (eg `execution: ":focus {git-root}"`) then the destination computation is done with starting path being the parent of the selected path.

Fix #1009