### PR TITLE
fix focus with conf arg going up if root selected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
  "strict 0.1.4",
  "syntect-no-panic",
  "tempfile",
- "termimad",
+ "termimad 0.32.0",
  "terminal-clipboard",
  "terminal-light",
  "toml",
@@ -451,12 +451,12 @@ dependencies = [
 
 [[package]]
 name = "clap-help"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc01b70b5fd7e87b2ae778cfd151120355002f44ab1504e9943151a52cae8171"
+checksum = "4f8b550b4d08a1d8101f3260bef3166a82c74c613486b4d63705244849105255"
 dependencies = [
  "clap",
- "termimad",
+ "termimad 0.32.0",
  "terminal-light",
 ]
 
@@ -556,12 +556,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "coolor"
-version = "1.0.0"
+name = "convert_case"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691defa50318376447a73ced869862baecfab35f6aabaa91a4cd726b315bfe1a"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
- "crossterm",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm 0.29.0",
 ]
 
 [[package]]
@@ -590,12 +599,12 @@ dependencies = [
 
 [[package]]
 name = "crokey"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8feffa04ad7cd61543392bdf2e9642983fc5fe5097ef0126a9190db94c41c35b"
+checksum = "5282b45c96c5978c8723ea83385cb9a488b64b7d175733f48d07bf9da514a863"
 dependencies = [
  "crokey-proc_macros",
- "crossterm",
+ "crossterm 0.29.0",
  "once_cell",
  "serde",
  "strict 0.2.0",
@@ -603,11 +612,11 @@ dependencies = [
 
 [[package]]
 name = "crokey-proc_macros"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab3c5e1d5159a09369d1a45a30b6e35227b1beec91873e1acd2c2ab1a89a1d8"
+checksum = "2ea0218d3fedf0797fa55676f1964ef5d27103d41ed0281b4bbd2a6e6c3d8d28"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "proc-macro2",
  "quote",
  "strict 0.2.0",
@@ -687,6 +696,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.0.5",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +759,7 @@ dependencies = [
  "argh",
  "chrono",
  "cli-log",
- "crossterm",
+ "crossterm 0.28.1",
  "csv",
  "directories 5.0.1",
  "libc",
@@ -762,6 +789,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -830,6 +878,15 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "either"
@@ -1059,7 +1116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "termimad",
+ "termimad 0.31.3",
  "thiserror 1.0.69",
 ]
 
@@ -1595,6 +1652,12 @@ name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -2776,6 +2839,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "termimad"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6be8b522caa5efccf3212424ec550b57b2937206d8eefe16074fedcac50de1"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 2.0.12",
+ "unicode-width",
+]
+
+[[package]]
 name = "terminal-clipboard"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,12 +2869,12 @@ dependencies = [
 
 [[package]]
 name = "terminal-light"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9474484d1a0c031cd7d065c6f027a376859c9fedb32c94df3d7a797218bbb7"
+checksum = "a6f76be906d875a0ce764c52a055858c24847cb7dc674d3a5ad8cf7e3dd4ee9f"
 dependencies = [
  "coolor",
- "crossterm",
+ "crossterm 0.29.0",
  "thiserror 1.0.69",
  "xterm-query",
 ]
@@ -3051,6 +3130,12 @@ name = "unicode-script"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-vo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ bet = "1.0.4"
 char_reader = "0.1"
 chrono = "0.4"
 clap = { version = "4.4", features = ["derive", "cargo"] }
-clap-help = "1.3"
+clap-help = "1.4"
 cli-log = "2.1"
-crokey = "1.1.2"
+crokey = "1.2"
 custom_error = "1.6"
 deser-hjson = "2.2.3"
 directories = "4.0"
@@ -59,9 +59,9 @@ splitty = "1.0.2"
 strict = "0.1.4"
 syntect = { package = "syntect-no-panic", version = "6.0", default-features = false, features = ["default-fancy"] } # see https://github.com/Canop/broot/pull/968
 tempfile = "3.2"
-termimad = "0.31"
+termimad = "0.32"
 terminal-clipboard = { version = "0.4.1", optional = true }
-terminal-light = "1.7"
+terminal-light = "1.8"
 toml = "0.8"
 trash = { version = "3.1.2", optional = true }
 umask = "2.1.0"
@@ -108,9 +108,9 @@ harness = false
 
 [patch.crates-io]
 # bet = { path = "../bet" }
-# clap-help = { path = "../clap-help" }
-# coolor = { path = "../coolor" }
-# crokey = { path = "../crokey" }
+# clap-help = { path = "../clap-help" }
+# coolor = { path = "../coolor" }
+# crokey = { path = "../crokey" }
 # crossterm = { path = "../crossterm-rs/crossterm" }
 # csv2svg = { path = "../csv2svg" }
 # deser-hjson = { path = "../deser-hjson" }
@@ -125,6 +125,6 @@ harness = false
 # cli-log = { path = "../cli-log" }
 # lazy-regex-proc_macros = { path = "../lazy-regex/src/proc_macros" }
 # strict = { path = "../strict" }
-# termimad = { path = "../termimad" }
-# terminal-light = { path = "../terminal-light" }
+# termimad = { path = "../termimad" }
+# terminal-light = { path = "../terminal-light" }
 # xterm-query = { path = "../xterm-query" }

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -355,19 +355,12 @@ impl PanelState for BrowserState {
             }
             Internal::focus => {
                 let tree = self.displayed_tree();
-                let mut path = &tree.selected_line().path;
-                let parent;
-                if tree.is_root_selected() {
-                    if let Some(parent_path) = path.parent() {
-                        parent = parent_path.to_path_buf();
-                        path = &parent;
-                    }
-                }
                 internal_focus::on_internal(
                     internal_exec,
                     input_invocation,
                     trigger_type,
-                    path,
+                    &tree.selected_line().path,
+                    tree.is_root_selected(),
                     tree.options.clone(),
                     app_state,
                     cc,

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -177,11 +177,13 @@ pub fn get_status_markdown(
 
 /// general implementation for verbs based on the :focus internal with optionally
 /// a bang or an argument.
+#[allow(clippy::too_many_arguments)]
 pub fn on_internal(
     internal_exec: &InternalExecution,
     input_invocation: Option<&VerbInvocation>,
     trigger_type: TriggerType,
     selected_path: &Path,
+    is_root_selected: bool,
     tree_options: TreeOptions,
     app_state: & AppState,
     cc: &CmdContext,
@@ -234,8 +236,15 @@ pub fn on_internal(
             } else {
                 // user only wants to open the selected path, either in the same panel or
                 // in a new one
-                on_path(selected_path.to_path_buf(), screen, tree_options, bang, con)
-            }
+                let mut path = selected_path.to_path_buf();
+                if !bang && is_root_selected {
+                    // the selected path is the root, focusing it would do nothing, so
+                    // we rather go up one level
+                    if let Some(parent_path) = selected_path.parent() {
+                        path = parent_path.to_path_buf();
+                    }
+                }
+                on_path(path, screen, tree_options, bang, con)}
         }
     }
 }


### PR DESCRIPTION
The fixed bug:
    
When a verb is defined with the focus internal and an argument (eg execution: ":focus {git-root}") then the destination computation is done with starting path being the parent of the selected path.
    
    Fix #1009

