### PR TITLE
Fix #1014

### DIFF
--- a/src/app/panel.rs
+++ b/src/app/panel.rs
@@ -86,7 +86,8 @@ impl Panel {
         };
         let result = self.states[state_idx].on_command(w, app_state, &cc);
         let has_previous_state = self.states.len() > 1;
-        self.status = self.state().get_status(app_state, &cc, has_previous_state, self.areas.status.width as usize);
+        self.status = self.state()
+            .get_status(app_state, &cc, has_previous_state, self.areas.status.width as usize);
         result
     }
 

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -43,7 +43,7 @@ impl Server {
                         let mut br = BufReader::new(&stream);
                         if let Some(sequence) = match Message::read(&mut br) {
                             Ok(Message::Command(command)) => {
-                                debug!("got single command {:?}", &command);
+                                info!("got single command {:?}", &command);
                                 // we convert it to a sequence
                                 Some(Sequence::new_single(command))
                             }

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -225,14 +225,19 @@ pub fn on_internal(
                     .unwrap_or(internal_exec.bang);
                 on_path(path, screen, tree_options, bang, con)
             } else if let Some(input_arg) = input_arg {
-                // the :focus internal was triggered by a key, and without internal arg,
-                // which means the user wants to explore the arg with purpose
-                // of selecting a path
                 let base_dir = selected_path.to_string_lossy();
                 let path = path::path_from(&*base_dir, PathAnchor::Unspecified, input_arg);
-                let arg_type = SelectionType::Any; // We might do better later
-                let purpose = PanelPurpose::ArgEdition { arg_type };
-                new_panel_on_path(path, screen, tree_options, purpose, con, HDir::Right)
+                if bang {
+                    // Unsure this special behavior is really needed. It was based
+                    // on the assumption that the user wanted to edit an argument
+                    // of a verb, and that the trigering was a key (but it can also
+                    // be another medium, like a command sequence or with the server)
+                    let arg_type = SelectionType::Any; // We might do better later
+                    let purpose = PanelPurpose::ArgEdition { arg_type };
+                    new_panel_on_path(path, screen, tree_options, purpose, con, HDir::Right)
+                } else {
+                    on_path(path, screen, tree_options, bang, con)
+                }
             } else {
                 // user only wants to open the selected path, either in the same panel or
                 // in a new one
@@ -244,7 +249,8 @@ pub fn on_internal(
                         path = parent_path.to_path_buf();
                     }
                 }
-                on_path(path, screen, tree_options, bang, con)}
+                on_path(path, screen, tree_options, bang, con)
+            }
         }
     }
 }


### PR DESCRIPTION
Fix #1014

The trigger_type handling isn't quite right, as the TriggerType enum, with only Input and Other, isn't precise enough to convey the information the verb was triggered eg by a sequence or the --listen mode. At some point a bigger refactor with a precise enum will probably be needed.
