### PR TITLE
Use package.metadata for binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,3 +128,8 @@ harness = false
 # termimad = { path = "../termimad" }
 # terminal-light = { path = "../terminal-light" }
 # xterm-query = { path = "../xterm-query" }
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }_{ version }{ archive-suffix }"
+bin-dir = "{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "zip"

--- a/release-for-binstall.sh
+++ b/release-for-binstall.sh
@@ -1,9 +1,0 @@
-version=$(./version.sh)
-mkdir -p releases/broot_${version}
-
-cd build
-# make one zip file for each architecture 
-# cargo binstall needs that
-# see default format https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md#defaults
-find . -maxdepth 1 -type d | grep -v -e "resources" -e "completion" -e "default-conf" -e '^\.$' | cut -c 3- |xargs -I {} zip -rj ../releases/broot_${version}/broot-{}-v${version}.zip {}
-cd -

--- a/release.sh
+++ b/release.sh
@@ -29,6 +29,3 @@ cd -
 # copy it to releases folder
 mkdir -p releases/broot_${version}
 cp "broot_$version.zip" releases/broot_${version}
-
-# create zip files for `cargo binstall broot`
-./release-for-binstall.sh


### PR DESCRIPTION
The zip files expected by binstall have not been uploaded since v1.36.1. This commit specifies the structure of the existing zip file in the Cargo.toml [package.metadata.binstall] section so binstall can extract it for targets built in release.sh.
Tested with `cargo binstall --manifest-path ./Cargo.toml broot`