### PR TITLE
add the preview_tty verb, for text with ANSI codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "umask",
  "unicode-width",
  "uzers",
+ "vte",
  "which",
  "xterm-query",
 ]
@@ -3237,6 +3238,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ toml = "0.8"
 trash = { version = "3.1.2", optional = true }
 umask = "2.1.0"
 unicode-width = "0.1.10"
+vte = "0.15"
 which = "4.4.0"
 xterm-query = { version = "0.5", optional = true }
 

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -266,6 +266,7 @@ pub trait PanelState {
             Internal::open_preview => self.open_preview(None, false, cc),
             Internal::preview_image => self.open_preview(Some(PreviewMode::Image), false, cc),
             Internal::preview_text => self.open_preview(Some(PreviewMode::Text), false, cc),
+            Internal::preview_tty => self.open_preview(Some(PreviewMode::Tty), false, cc),
             Internal::preview_binary => self.open_preview(Some(PreviewMode::Hex), false, cc),
             Internal::toggle_preview => self.open_preview(None, true, cc),
             Internal::sort_by_count => self.with_new_options(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod task_sync;
 pub mod terminal;
 pub mod tree;
 pub mod tree_build;
+pub mod tty;
 pub mod verb;
 
 #[cfg(unix)]

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -25,4 +25,7 @@ pub enum PreviewMode {
 
     /// show the content of the file as hex
     Hex,
+
+    /// Show the content with ANSI escape codes
+    Tty,
 }

--- a/src/preview/preview.rs
+++ b/src/preview/preview.rs
@@ -11,6 +11,7 @@ use {
         skin::PanelSkin,
         syntactic::SyntacticView,
         task_sync::Dam,
+        tty::TtyView,
     },
     crokey::crossterm::{cursor, QueueableCommand},
     std::{
@@ -26,6 +27,7 @@ pub enum Preview {
     Image(ImageView),
     Syntactic(SyntacticView),
     Hex(HexView),
+    Tty(TtyView),
     ZeroLen(ZeroLenFileView),
     IoError(io::Error),
 }
@@ -43,6 +45,7 @@ impl Preview {
                 Some(PreviewMode::Hex) => Self::hex(path),
                 Some(PreviewMode::Image) => Self::image(path),
                 Some(PreviewMode::Text) => Self::unfiltered_text(path, con),
+                Some(PreviewMode::Tty) => Self::tty(path),
                 None => {
                     // automatic behavior: image, text, hex
                     ImageView::new(path)
@@ -68,6 +71,11 @@ impl Preview {
                 }
                 PreviewMode::Image => {
                     ImageView::new(path).map(Self::Image)
+                }
+                PreviewMode::Tty => {
+                    TtyView::new(path)
+                        .map(Self::Tty)
+                        .map_err(ProgramError::from)
                 }
                 PreviewMode::Text => {
                     Ok(
@@ -100,6 +108,15 @@ impl Preview {
             .unwrap_or_else(|| Self::hex(path))
 
     }
+
+    /// build an tty view, unless there's an IO error
+    pub fn tty(path: &Path) -> Self {
+        match TtyView::new(path) {
+            Ok(tv) => Self::Tty(tv),
+            Err(e) => Self::IoError(e),
+        }
+    }
+
     /// build a text preview (maybe with syntaxic coloring) if possible,
     /// a hex (binary) view if content isnt't UTF8, a ZeroLen file if there's
     /// no length (it's probably a linux pseudofile) or a IOError when
@@ -190,6 +207,7 @@ impl Preview {
             Self::Syntactic(_) => Some(PreviewMode::Text),
             Self::ZeroLen(_) => Some(PreviewMode::Text),
             Self::Hex(_) => Some(PreviewMode::Hex),
+            Self::Tty(_) => Some(PreviewMode::Tty),
             Self::IoError(_) => None,
             Self::Dir(_) => None,
         }
@@ -209,6 +227,7 @@ impl Preview {
             Self::Dir(dv) => dv.try_scroll(cmd),
             Self::Syntactic(sv) => sv.try_scroll(cmd),
             Self::Hex(hv) => hv.try_scroll(cmd),
+            Self::Tty(v) => v.try_scroll(cmd),
             _ => false,
         }
     }
@@ -235,15 +254,17 @@ impl Preview {
         }
     }
     pub fn unselect(&mut self) {
-        // it's not possible to unselect in a dir_view
-        if let Self::Syntactic(sv) = self {
-            sv.unselect();
+        match self {
+            Self::Syntactic(sv) => sv.unselect(),
+            Self::Tty(tv) => tv.unselect(),
+            _ => {}
         }
     }
     pub fn try_select_y(&mut self, y: u16) -> bool {
         match self {
             Self::Dir(dv) => dv.try_select_y(y),
             Self::Syntactic(sv) => sv.try_select_y(y),
+            Self::Tty(v) => v.try_select_y(y),
             _ => false,
         }
     }
@@ -251,6 +272,7 @@ impl Preview {
         match self {
             Self::Dir(dv) => dv.move_selection(dy, cycle),
             Self::Syntactic(sv) => sv.move_selection(dy, cycle),
+            Self::Tty(v) => v.move_selection(dy, cycle),
             Self::Hex(hv) => {
                 hv.try_scroll(ScrollCommand::Lines(dy));
             }
@@ -278,6 +300,7 @@ impl Preview {
             Self::Dir(dv) => dv.select_first(),
             Self::Syntactic(sv) => sv.select_first(),
             Self::Hex(hv) => hv.select_first(),
+            Self::Tty(v) => v.select_first(),
             _ => {}
         }
     }
@@ -285,6 +308,7 @@ impl Preview {
         match self {
             Self::Syntactic(sv) => sv.select_last(),
             Self::Hex(hv) => hv.select_last(),
+            Self::Tty(v) => v.select_last(),
             _ => {}
         }
     }
@@ -303,6 +327,7 @@ impl Preview {
             Self::Syntactic(sv) => sv.display(w, screen, panel_skin, area, con),
             Self::ZeroLen(zlv) => zlv.display(w, screen, panel_skin, area),
             Self::Hex(hv) => hv.display(w, screen, panel_skin, area),
+            Self::Tty(v) => v.display(w, screen, panel_skin, area),
             Self::IoError(err) => {
                 let mut y = area.top;
                 w.queue(cursor::MoveTo(area.left, y))?;

--- a/src/preview/preview_state.rs
+++ b/src/preview/preview_state.rs
@@ -421,6 +421,7 @@ impl PanelState for PreviewState {
             }
             Internal::preview_image => self.set_mode(PreviewMode::Image, con),
             Internal::preview_text => self.set_mode(PreviewMode::Text, con),
+            Internal::preview_tty => self.set_mode(PreviewMode::Tty, con),
             Internal::preview_binary => self.set_mode(PreviewMode::Hex, con),
             _ => self.on_internal_generic(
                 w,

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -1,0 +1,41 @@
+mod tline;
+mod tline_builder;
+mod trange;
+mod tstring;
+mod tty_view;
+
+pub const CSI_RESET: &str = "\u{1b}[0m";
+pub const CSI_BOLD: &str = "\u{1b}[1m";
+pub const CSI_ITALIC: &str = "\u{1b}[3m";
+
+
+static TAB_REPLACEMENT: &str = "    ";
+
+use {
+    crate::{
+        display::W,
+        errors::ProgramError,
+    },
+    std::io::Write,
+};
+
+pub use {
+    tline::*,
+    tline_builder::*,
+    trange::*,
+    tstring::*,
+    tty_view::*,
+};
+
+fn draw(
+    w: &mut W,
+    csi: &str,
+    raw: &str,
+) -> Result<(), ProgramError> {
+    if csi.is_empty() {
+        write!(w, "{}", raw)?;
+    } else {
+        write!(w, "{}{}{}", csi, raw, CSI_RESET,)?;
+    }
+    Ok(())
+}

--- a/src/tty/tline.rs
+++ b/src/tty/tline.rs
@@ -1,0 +1,166 @@
+use {
+    super::*,
+    crate::display::W,
+    serde::{
+        Deserialize,
+        Serialize,
+    },
+};
+
+/// a simple representation of a line made of homogeneous parts.
+///
+/// Note that this only manages CSI and SGR components
+/// and isn't a suitable representation for an arbitrary
+/// terminal input or output.
+/// I recommend you to NOT try to reuse this hack in another
+/// project unless you perfectly understand it.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TLine {
+    pub strings: Vec<TString>,
+}
+
+impl TLine {
+    pub fn change_range_style(
+        &mut self,
+        trange: TRange,
+        new_csi: String,
+    ) {
+        let TRange {
+            mut string_idx,
+            start_byte_in_string,
+            end_byte_in_string,
+        } = trange;
+        if string_idx >= self.strings.len() {
+            return;
+        }
+
+        let has_before = start_byte_in_string > 0;
+        let has_after = end_byte_in_string < self.strings[string_idx].raw.len();
+
+        if has_after {
+            self.strings.insert(
+                string_idx + 1,
+                TString {
+                    csi: self.strings[string_idx].csi.clone(),
+                    raw: self.strings[string_idx].raw[end_byte_in_string..].to_string(),
+                },
+            );
+        }
+        if has_before {
+            self.strings.insert(
+                string_idx,
+                TString {
+                    csi: self.strings[string_idx].csi.clone(),
+                    raw: self.strings[string_idx].raw[..start_byte_in_string].to_string(),
+                },
+            );
+            string_idx += 1;
+        }
+        self.strings[string_idx].csi = new_csi;
+        if has_before {
+            self.strings[string_idx].raw =
+                self.strings[string_idx].raw[start_byte_in_string..end_byte_in_string].to_string();
+        } else {
+            // we can just truncate the string
+            self.strings[string_idx].raw.truncate(end_byte_in_string);
+        }
+    }
+    pub fn from_tty(tty: &str) -> Self {
+        let tty_str: String;
+        let tty = if tty.contains('\t') {
+            tty_str = tty.replace('\t', TAB_REPLACEMENT);
+            &tty_str
+        } else {
+            tty
+        };
+        let mut builder = TLineBuilder::default();
+        builder.read(tty);
+        builder.build()
+    }
+    pub fn from_raw(raw: String) -> Self {
+        Self {
+            strings: vec![TString {
+                csi: " ".to_string(),
+                raw,
+            }],
+        }
+    }
+    pub fn to_raw(&self) -> String {
+        let mut s = String::new();
+        for ts in &self.strings {
+            s.push_str(&ts.raw);
+        }
+        s
+    }
+    pub fn bold(raw: String) -> Self {
+        Self {
+            strings: vec![TString {
+                csi: CSI_BOLD.to_string(),
+                raw,
+            }],
+        }
+    }
+    pub fn italic(raw: String) -> Self {
+        Self {
+            strings: vec![TString {
+                csi: CSI_ITALIC.to_string(),
+                raw,
+            }],
+        }
+    }
+    pub fn add_tstring<C: Into<String>, R: Into<String>>(
+        &mut self,
+        csi: C,
+        raw: R,
+    ) {
+        self.strings.push(TString {
+            csi: csi.into(),
+            raw: raw.into(),
+        });
+    }
+    pub fn draw(
+        &self,
+        w: &mut W,
+    ) -> Result<(), ProgramError> {
+        for ts in &self.strings {
+            ts.draw(w)?;
+        }
+        Ok(())
+    }
+    /// draw the line but without taking more than cols_max cols.
+    /// Return the number of cols written
+    pub fn draw_in(
+        &self,
+        w: &mut W,
+        cols_max: usize,
+    ) -> Result<usize, ProgramError> {
+        let mut cols = 0;
+        for ts in &self.strings {
+            if cols >= cols_max {
+                break;
+            }
+            cols += ts.draw_in(w, cols_max - cols)?;
+        }
+        Ok(cols)
+    }
+    pub fn is_blank(&self) -> bool {
+        self.strings.iter().all(|s| s.raw.trim().is_empty())
+    }
+    // if this line has no style, return its content
+    pub fn if_unstyled(&self) -> Option<&str> {
+        if self.strings.len() == 1 {
+            self.strings
+                .first()
+                .filter(|s| s.csi.is_empty())
+                .map(|s| s.raw.as_str())
+        } else {
+            None
+        }
+    }
+    pub fn has(
+        &self,
+        part: &str,
+    ) -> bool {
+        self.strings.iter().any(|s| s.raw.contains(part))
+    }
+}

--- a/src/tty/tline_builder.rs
+++ b/src/tty/tline_builder.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+/// A builder consuming a string assumed to contain TTY sequences and building a TLine.
+#[derive(Debug, Default)]
+pub struct TLineBuilder {
+    cur: Option<TString>,
+    strings: Vec<TString>,
+}
+impl TLineBuilder {
+    pub fn read(
+        &mut self,
+        s: &str,
+    ) {
+        let mut parser = vte::Parser::new();
+        parser.advance(self, s.as_bytes());
+    }
+    pub fn build(mut self) -> TLine {
+        self.take_tstring();
+        TLine {
+            strings: self.strings,
+        }
+    }
+    fn take_tstring(&mut self) {
+        if let Some(cur) = self.cur.take() {
+            self.push_tstring(cur);
+        }
+    }
+    fn push_tstring(
+        &mut self,
+        tstring: TString,
+    ) {
+        if let Some(last) = self.strings.last_mut() {
+            if last.csi == tstring.csi {
+                last.raw.push_str(&tstring.raw);
+                return;
+            }
+        }
+        self.strings.push(tstring);
+    }
+}
+impl vte::Perform for TLineBuilder {
+    fn print(
+        &mut self,
+        c: char,
+    ) {
+        self.cur.get_or_insert_with(TString::default).raw.push(c);
+    }
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        _intermediates: &[u8],
+        _ignore: bool,
+        action: char,
+    ) {
+        if params.len() == 1 && params.iter().next() == Some(&[0]) {
+            self.take_tstring();
+            return;
+        }
+        if let Some(cur) = self.cur.as_mut() {
+            if cur.raw.is_empty() {
+                cur.push_csi(params, action);
+                return;
+            }
+        }
+        self.take_tstring();
+        let mut cur = TString::default();
+        cur.push_csi(params, action);
+        self.cur = Some(cur);
+    }
+    fn execute(
+        &mut self,
+        _byte: u8,
+    ) {
+    }
+    fn hook(
+        &mut self,
+        _params: &vte::Params,
+        _intermediates: &[u8],
+        _ignore: bool,
+        _action: char,
+    ) {
+    }
+    fn put(
+        &mut self,
+        _byte: u8,
+    ) {
+    }
+    fn unhook(&mut self) {}
+    fn osc_dispatch(
+        &mut self,
+        _params: &[&[u8]],
+        _bell_terminated: bool,
+    ) {
+    }
+    fn esc_dispatch(
+        &mut self,
+        _intermediates: &[u8],
+        _ignore: bool,
+        _byte: u8,
+    ) {
+    }
+}

--- a/src/tty/trange.rs
+++ b/src/tty/trange.rs
@@ -1,0 +1,7 @@
+/// A position in a tline
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TRange {
+    pub string_idx: usize,
+    pub start_byte_in_string: usize,
+    pub end_byte_in_string: usize,
+}

--- a/src/tty/tstring.rs
+++ b/src/tty/tstring.rs
@@ -1,0 +1,94 @@
+use {
+    super::*,
+    crate::display::W,
+    serde::{
+        Deserialize,
+        Serialize,
+    },
+    std::{
+        fmt::Write as _,
+        io::Write,
+    },
+    termimad::StrFit,
+};
+
+/// a simple representation of a colored and styled string.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TString {
+    pub csi: String,
+    pub raw: String,
+}
+impl TString {
+    pub fn new<S1: Into<String>, S2: Into<String>>(
+        csi: S1,
+        raw: S2,
+    ) -> Self {
+        Self {
+            csi: csi.into(),
+            raw: raw.into(),
+        }
+    }
+    pub fn push_csi(
+        &mut self,
+        params: &vte::Params,
+        action: char,
+    ) {
+        self.csi.push('\u{1b}');
+        self.csi.push('[');
+        for (idx, param) in params.iter().enumerate() {
+            for p in param {
+                let _ = write!(self.csi, "{}", p);
+            }
+            if idx < params.len() - 1 {
+                self.csi.push(';');
+            }
+        }
+        self.csi.push(action);
+    }
+    pub fn draw(
+        &self,
+        w: &mut W,
+    ) -> Result<(), ProgramError> {
+        draw(w, &self.csi, &self.raw)
+    }
+    /// draw the string but without taking more than cols_max cols.
+    /// Return the number of cols written
+    pub fn draw_in(
+        &self,
+        w: &mut W,
+        cols_max: usize,
+    ) -> Result<usize, ProgramError> {
+        let fit = StrFit::make_cow(&self.raw, cols_max);
+        if self.csi.is_empty() {
+            write!(w, "{}", &fit.0)?;
+        } else {
+            write!(w, "{}{}{}", &self.csi, &fit.0, CSI_RESET)?;
+        }
+        Ok(fit.1)
+    }
+    pub fn starts_with(
+        &self,
+        csi: &str,
+        raw: &str,
+    ) -> bool {
+        self.csi == csi && self.raw.starts_with(raw)
+    }
+    pub fn split_off(
+        &mut self,
+        at: usize,
+    ) -> Self {
+        Self {
+            csi: self.csi.clone(),
+            raw: self.raw.split_off(at),
+        }
+    }
+    pub fn is_blank(&self) -> bool {
+        self.raw.chars().all(char::is_whitespace)
+    }
+    pub fn is_styled(&self) -> bool {
+        !self.csi.is_empty()
+    }
+    pub fn is_unstyled(&self) -> bool {
+        self.csi.is_empty()
+    }
+}

--- a/src/tty/tty_view.rs
+++ b/src/tty/tty_view.rs
@@ -1,0 +1,240 @@
+use {
+    super::*,
+    crate::{
+        command::{ScrollCommand, move_sel},
+        display::{Screen, W},
+        errors::*,
+        skin::PanelSkin,
+    },
+    crokey::crossterm::{
+        cursor,
+        style::{Color, Print, SetBackgroundColor, SetForegroundColor},
+        QueueableCommand,
+    },
+    memmap2::Mmap,
+    std::{
+        fs::File,
+        io::{self, BufRead, BufReader},
+        path::{Path, PathBuf},
+    },
+    termimad::Area,
+};
+
+
+
+pub struct TtyView {
+    pub path: PathBuf,
+    lines: Vec<TLine>,
+    scroll: usize,
+    page_height: usize,
+    selection_idx: Option<usize>, // index in lines of the selection, if any
+    total_lines_count: usize,
+}
+
+impl TtyView {
+
+    pub fn new(
+        path: &Path,
+    ) -> Result<Self, io::Error> {
+        let mut sv = Self {
+            path: path.to_path_buf(),
+            lines: Vec::new(),
+            scroll: 0,
+            page_height: 0,
+            selection_idx: None,
+            total_lines_count: 0,
+        };
+        sv.read_lines()?;
+        sv.select_first();
+        Ok(sv)
+    }
+
+    fn read_lines(
+        &mut self,
+    ) -> Result<(), io::Error> {
+        let f = File::open(&self.path)?;
+        {
+            // if we detect the file isn't mappable, we'll
+            // let the ZeroLenFilePreview try to read it
+            let mmap = unsafe { Mmap::map(&f) };
+            if mmap.is_err() {
+                return Err(io::Error::other("unmappable file"))
+            }
+        }
+        let md = f.metadata()?;
+        if md.len() == 0 {
+            return Err(io::Error::other("zero length file"))
+        }
+        let mut reader = BufReader::new(f);
+        self.lines.clear();
+        let mut line = String::new();
+        self.total_lines_count = 0;
+        while reader.read_line(&mut line)? > 0 {
+            self.total_lines_count += 1;
+            let tline = TLine::from_tty(&line);
+            self.lines.push(tline);
+            line.clear();
+        }
+        Ok(())
+    }
+
+    fn ensure_selection_is_visible(&mut self) {
+        if self.page_height >= self.lines.len() {
+            self.scroll = 0;
+        } else if let Some(idx) = self.selection_idx {
+            let padding = self.padding();
+            if idx < self.scroll + padding || idx + padding > self.scroll + self.page_height {
+                if idx <= padding {
+                    self.scroll = 0;
+                } else if idx + padding > self.lines.len() {
+                    self.scroll = self.lines.len() - self.page_height;
+                } else if idx < self.scroll + self.page_height / 2 {
+                    self.scroll = idx - padding;
+                } else {
+                    self.scroll = idx + padding - self.page_height;
+                }
+            }
+        }
+    }
+
+    fn padding(&self) -> usize {
+        (self.page_height / 4).min(4)
+    }
+
+    pub fn unselect(&mut self) {
+        self.selection_idx = None;
+    }
+    pub fn try_select_y(&mut self, y: u16) -> bool {
+        let idx = y as usize + self.scroll;
+        if idx < self.lines.len() {
+            self.selection_idx = Some(idx);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn select_first(&mut self) {
+        if !self.lines.is_empty() {
+            self.selection_idx = Some(0);
+            self.scroll = 0;
+        }
+    }
+    pub fn select_last(&mut self) {
+        self.selection_idx = Some(self.lines.len() - 1);
+        if self.page_height < self.lines.len() {
+            self.scroll = self.lines.len() - self.page_height;
+        }
+    }
+
+    pub fn move_selection(&mut self, dy: i32, cycle: bool) {
+        if let Some(idx) = self.selection_idx {
+            self.selection_idx = Some(move_sel(idx, self.lines.len(), dy, cycle));
+        } else if !self.lines.is_empty() {
+            self.selection_idx = Some(0)
+        }
+        self.ensure_selection_is_visible();
+    }
+
+    pub fn try_scroll(
+        &mut self,
+        cmd: ScrollCommand,
+    ) -> bool {
+        let old_scroll = self.scroll;
+        self.scroll = cmd.apply(self.scroll, self.lines.len(), self.page_height);
+        if let Some(idx) = self.selection_idx {
+            if self.scroll == old_scroll {
+                let old_selection = self.selection_idx;
+                if cmd.is_up() {
+                    self.selection_idx = Some(0);
+                } else {
+                    self.selection_idx = Some(self.lines.len() - 1);
+                }
+                return self.selection_idx == old_selection;
+            } else  if idx >= old_scroll && idx < old_scroll + self.page_height {
+                if idx + self.scroll < old_scroll {
+                    self.selection_idx = Some(0);
+                } else if idx + self.scroll - old_scroll >= self.lines.len() {
+                    self.selection_idx = Some(self.lines.len() - 1);
+                } else {
+                    self.selection_idx = Some(idx + self.scroll - old_scroll);
+                }
+            }
+        }
+        self.scroll != old_scroll
+    }
+
+    pub fn display(
+        &mut self,
+        w: &mut W,
+        _screen: Screen,
+        panel_skin: &PanelSkin,
+        area: &Area,
+    ) -> Result<(), ProgramError> {
+        if area.height as usize != self.page_height {
+            self.page_height = area.height as usize;
+            self.ensure_selection_is_visible();
+        }
+        let line_count = area.height as usize;
+        let styles = &panel_skin.styles;
+        let bg = styles.preview.get_bg()
+            .or_else(|| styles.default.get_bg())
+            .unwrap_or(Color::AnsiValue(238));
+        let content_width = area.width as usize - 1; // 1 char left for scrollbar
+        let scrollbar = area.scrollbar(self.scroll, self.lines.len());
+        let scrollbar_fg = styles.scrollbar_thumb.get_fg()
+            .or_else(|| styles.preview.get_fg())
+            .unwrap_or(Color::White);
+        for y in 0..line_count {
+            let line_idx = self.scroll + y;
+            let mut allowed = content_width;
+            w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
+            if let Some(tline) = self.lines.get(line_idx) {
+                w.queue(SetBackgroundColor(bg))?;
+                allowed -= tline.draw_in(w, allowed)?;
+            }
+            w.queue(SetBackgroundColor(bg))?;
+            for _ in 0..allowed {
+                w.queue(Print(' '))?;
+            }
+            if is_thumb(y + area.top as usize, scrollbar) {
+                w.queue(SetForegroundColor(scrollbar_fg))?;
+                w.queue(Print('▐'))?;
+            } else {
+                w.queue(Print(' '))?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn display_info(
+        &mut self,
+        w: &mut W,
+        _screen: Screen,
+        panel_skin: &PanelSkin,
+        area: &Area,
+    ) -> Result<(), ProgramError> {
+        let width = area.width as usize;
+        let mut s = format!("{}", self.total_lines_count);
+        if s.len() > width {
+            return Ok(());
+        }
+        if s.len() + "lines: ".len() < width {
+            s = format!("lines: {s}");
+        }
+        w.queue(cursor::MoveTo(
+            area.left + area.width - s.len() as u16,
+            area.top,
+        ))?;
+        panel_skin.styles.default.queue(w, s)?;
+        Ok(())
+    }
+}
+
+fn is_thumb(y: usize, scrollbar: Option<(u16, u16)>) -> bool {
+    scrollbar.map_or(false, |(sctop, scbottom)| {
+        let y = y as u16;
+        sctop <= y && y <= scbottom
+    })
+}
+

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -110,6 +110,7 @@ Internals! {
     preview_binary: "preview the selection as binary" true,
     preview_image: "preview the selection as image" true,
     preview_text: "preview the selection as text" true,
+    preview_tty: "preview the selection as tty" true,
     previous_dir: "select the previous directory" false,
     previous_match: "select the previous match" false,
     previous_same_depth: "select the previous file at the same depth" false,

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -119,6 +119,8 @@ impl VerbStore {
             .with_shortcut("txt");
         self.add_internal(preview_binary)
             .with_shortcut("hex");
+        self.add_internal(preview_tty)
+            .with_shortcut("tty");
         self.add_internal(close_panel_ok);
         self.add_internal(close_panel_cancel)
             .with_key(key!(ctrl-w));

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -422,6 +422,7 @@ invocation | default key | default shortcut | behavior / details
 :preview_binary | - | - | preview the selection as binary
 :preview_image | - | - | preview the selection as image
 :preview_text | - | - | preview the selection as text
+:preview_tty | - | - | preview the selection as tty (with ANSI escape codes)
 :previous_dir | - | - | select the previous directory
 :previous_match | - | - | select the previous match
 :previous_same_depth | - | - | select the previous file at the same depth


### PR DESCRIPTION
Allows previewing a file containing ANSI escape codes for styling.


Fix #1019