### PR TITLE
`git::ignore`: skip files that don't exist

### DIFF
--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -154,11 +154,11 @@ pub fn find_global_ignore() -> Option<PathBuf> {
         .and_then(|global_config| global_config.get_path("core.excludesfile"))
         .ok()
         .or_else(|| {
-            directories::BaseDirs::new().map(|base_dirs| base_dirs.config_dir().join("git/ignore"))
+            directories::BaseDirs::new().map(|base_dirs| base_dirs.config_dir().join("git/ignore")).filter(|path| path.exists())
         })
         .or_else(|| {
             directories::UserDirs::new()
-                .map(|user_dirs| user_dirs.home_dir().join(".config/git/ignore"))
+                .map(|user_dirs| user_dirs.home_dir().join(".config/git/ignore")).filter(|path| path.exists())
         })
 }
 


### PR DESCRIPTION
Ignore the config file returned by the `directories` crate if it doesn't exist. This allows `broot` to load `~/.config/git/ignore` if it exists.

Fixes: #1032