### PR TITLE
Update documentation with preferred name toggle_ignore

### DIFF
--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -455,9 +455,9 @@ invocation | default key | default shortcut | behavior / details
 :toggle_device_id | - | - | toggle display of device id (unix only)
 :toggle_files | - | - | toggle showing files (or just folders)
 :toggle_git_file_info | - | - | toggle display of git file information
-:toggle_git_ignore | - | - | toggle git ignore handling (auto, no or yes)
 :toggle_git_status | - | - | toggle showing only the file which would show up on `git status`
 :toggle_hidden | - | - | toggle display of hidden files (the ones whose name starts with a dot on linux)
+:toggle_ignore | - | - | toggle display of files in .gitignore and .ignore
 :toggle_perm | - | - | toggle display of permissions (not available on Windows)
 :toggle_preview | - | - | toggle display of the preview panel
 :toggle_root_fs | - | - | toggle showing filesystem info on top

--- a/website/docs/conf_verbs.md
+++ b/website/docs/conf_verbs.md
@@ -49,7 +49,7 @@ switch_terminal | `true` | whether to switch from alternate to normal terminal d
 The execution is defined either by `internal`, `external` or `cmd` so a verb must have exactly one of those (for compatibility with older versions broot still accepts `execution` for `internal` or `external` and guesses which one it is).
 
 !!!	Note
-	The `from_shell` attribute exists because some actions can't possibly be useful from a subshell. For example `cd` is a shell builtin which must be executed in the parent shell.
+	The `from_shell` attribute exists because some actions can't possibly be useful from a subshell. For example, `cd` is a shell builtin which must be executed in the parent shell.
 
 # Call shell scripts
 
@@ -118,7 +118,7 @@ external = ["xterm", "-e", "nvim {file}"]
 
 You may filter the execution of a verb with file extensions.
 
-For example, if you'd want <kbd>enter</kbd> to work as predefined in most cases but just choose a specific action for some files, you might add this verb definition:
+For example, if you want <kbd>enter</kbd> to work as predefined in most cases but just choose a specific action for some files, you might add this verb definition:
 
 ```hjson
 {
@@ -144,8 +144,8 @@ working_dir = "{root}"
 leave_broot = false
 ```
 
-Verbs are tried in order (the default ones after the user defined ones).
-You may thus define first verbs with extension filter and then a catching-all one.
+Verb definitions are tried in order until one has been executed, starting with user-defined verbs, then built-in verbs.
+Thus you may define both verbs with extension filters and a catch-all verb.
 
 # Shortcuts and Verb search
 
@@ -487,7 +487,7 @@ Some internal actions can be bound to a key shortcut but can't be called explici
 
 name | default binding | behavior
 -|-|-
-:input_clear | | empty the input,
+:input_clear | | empty the input
 :input_del_char_left | <kbd>delete</kbd> | delete the char left of the cursor
 :input_del_char_below | <kbd>suppr</kbd> | delete the char left at the cursor's position
 :input_del_word_left | - | delete the word left of the cursor
@@ -609,7 +609,7 @@ apply_to = "directory"
 This verb, which is only available when a directory is selected, copies this directory with a name partially composed from the command and focus the new directory in a new panel
 
 !!!	Note
-	The `cmd` execution type is still experimental in verbs and the precise behavior may change in future minor versions of broot
+	The `cmd` execution type is still experimental in verbs and the precise behavior may change in future minor versions of broot.
 
 
 

--- a/website/docs/tree_view.md
+++ b/website/docs/tree_view.md
@@ -27,7 +27,7 @@ If you don't want to hide those files, you may either
 2. set the flags directly in your config file: see [default flags](../conf_file/#default-flags)
 3. toggle hiding when in the application
 
-The toggle commands are `:toggle_hidden` (shortcut: `:h`)  and `:toggle_git_ignore` (shortcut: `:gi`).
+The toggle commands are `:toggle_hidden` (shortcut: `:h`)  and `:toggle_ignore` (shortcut: `:gi`).
 
 If you use those toggles frequently enough, you'll remember the <kbd>alt</kbd><kbd>h</kbd> <kbd>alt</kbd><kbd>i</kbd> key combinations.
 
@@ -140,7 +140,7 @@ Each of those toggles lets you alternate between 2 or 3 modes.
  | toggle_dates         | dates    |       | toggle showing last modified dates (deep computed)
  | toggle_files         | files    |       | toggle showing files (or just folders)
  | toggle_git_file_info | gf       |       | toggle display of git file information
- | toggle_git_ignore    | gi       | <kbd>alt</kbd><kbd>i</kbd> | toggle use of .gitignore and .ignore
+ | toggle_ignore        | gi       | <kbd>alt</kbd><kbd>i</kbd> | toggle use of .gitignore and .ignore
  | toggle_hidden        | h        | <kbd>alt</kbd><kbd>h</kbd> | toggle showing hidden files
  | toggle_perm          | perm     |       | toggle showing file permissions (Unix only)
  | toggle_sizes         | sizes    |       | toggle showing sizes


### PR DESCRIPTION
Hi, new user here. Thanks for the tool.

Replace references to the old verb `toggle_git_ignore` with the new verb `toggle_ignore` introduced in v1.42.0.

(Not covered here: I'm unable to execute the old verb `:toggle_git_ignore`. Not a big deal, and hopefully the documentation will resolve any confusion from new users.)

I also included a commit to clarify a sentence about verb execution. Let me know if you want that removed or split from the PR.