### PR TITLE
make image bg fallback to Color::Reset for nicer transparent look #1040

### DIFF
--- a/src/image/image_view.rs
+++ b/src/image/image_view.rs
@@ -89,7 +89,7 @@ impl ImageView {
         let styles = &disc.panel_skin.styles;
         let bg_color = styles.preview.get_bg()
             .or_else(|| styles.default.get_bg());
-        let bg = bg_color.unwrap_or(Color::AnsiValue(238));
+        let bg = bg_color.unwrap_or(Color::Reset);
 
         // we avoid drawing when we were just displayed
         // on the last drawing_count and the area is the same.


### PR DESCRIPTION
Fallback to a transparent background for images in image preview instead of a specific color.
This allows images to have a transparent background when 'none' is set as background in skin file.

```
skin: {
 default: rgb(255,0,0) none
 preview: rgb(255,0,0) none
 }
```