### PR TITLE
fallback to transparent background for text preview

### DIFF
--- a/src/syntactic/syntactic_view.rs
+++ b/src/syntactic/syntactic_view.rs
@@ -460,12 +460,12 @@ impl SyntacticView {
             .preview
             .get_fg()
             .or_else(|| styles.default.get_fg())
-            .unwrap_or(Color::AnsiValue(252));
+            .unwrap_or(Color::Reset);
         let normal_bg = styles
             .preview
             .get_bg()
             .or_else(|| styles.default.get_bg())
-            .unwrap_or(Color::AnsiValue(238));
+            .unwrap_or(Color::Reset);
         let selection_bg = styles
             .selected_line
             .get_bg()


### PR DESCRIPTION
Similar to #1042, but for text previews.

If the preview background/foreground is set to none in the skin file, it should render as transparent rather than defaulting to a specific color.

selection_bg and match_bg should remain visible though, so we can continue using Color::AnsiValue for those two.

What do you think ?

<img width="941" height="238" alt="transparent-text-bg" src="https://github.com/user-attachments/assets/bf647c0d-b7f4-42b5-aff0-599272c5ca7a" />

