### PR TITLE
fix: unused dependencies in kitty/detect_support

### DIFF
--- a/src/kitty/detect_support.rs
+++ b/src/kitty/detect_support.rs
@@ -1,11 +1,7 @@
 use {
     crate::kitty::KittyGraphicsDisplay,
     cli_log::*,
-    lazy_regex::regex_captures,
-    std::{
-        env,
-        process::Command,
-    },
+    std::env,
 };
 
 /// Determine whether Kitty's graphics protocol is supported


### PR DESCRIPTION
Following revert in https://github.com/Canop/broot/commit/46be2cdb76c96b0e815575a63c520cc0edb928fc there were some lingering crate uses introduced by https://github.com/Canop/broot/commit/db4a05f387937ee41b976b9d305605bfeb122534 and not used anymore, triggering the following warning:

```
warning: unused imports: `lazy_regex::regex_captures` and `process::Command`
 --> src/kitty/detect_support.rs:4:5
  |
4 |     lazy_regex::regex_captures,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
...
7 |         process::Command,
  |         ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `broot` (lib) generated 1 warning (run `cargo fix --lib -p broot` to apply 1 suggestion)
```