### PR TITLE
fix non-trash platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ termimad = "0.34"
 terminal-clipboard = { version = "0.4.1", optional = true }
 terminal-light = "1.8"
 toml = "0.9"
-trash = "5.2"
 umask = "2.1.0"
 unicode-width = "0.2"
 vte = "0.15"
@@ -73,6 +72,9 @@ xterm-query = { version = "0.5", optional = true }
 
 [dev-dependencies]
 glassbench = "0.4.4"
+
+[target.'cfg(any(target_os = "windows", all(unix, not(any(target_os = "ios", target_os = "android")))))'.dependencies]
+trash = "5.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 lfs-core = "0.14.1"

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,7 @@
 use {
     clap::CommandFactory,
     clap_complete::{Generator, Shell},
-    std::{
-        env,
-        ffi::OsStr,
-    },
+    std::{env, ffi::OsStr},
 };
 
 include!("src/cli/args.rs");
@@ -19,15 +16,14 @@ include!("src/cli/args.rs");
 /// so this generation is usually not needed
 pub const BUILD_MAN_PAGE: bool = false;
 
-fn write_completions_file<G: Generator + Copy, P: AsRef<OsStr>>(generator: G, out_dir: P) {
+fn write_completions_file<G: Generator + Copy, P: AsRef<OsStr>>(
+    generator: G,
+    out_dir: P,
+) {
     let mut args = Args::command();
     for name in &["broot", "br"] {
-        clap_complete::generate_to(
-            generator,
-            &mut args,
-            (*name).to_string(),
-            &out_dir,
-        ).expect("clap complete generation failed");
+        clap_complete::generate_to(generator, &mut args, (*name).to_string(), &out_dir)
+            .expect("clap complete generation failed");
     }
 }
 
@@ -57,10 +53,24 @@ fn build_man_page() -> std::io::Result<()> {
     Ok(())
 }
 
+fn detect_trash() -> std::io::Result<()> {
+    println!("cargo::rustc-check-cfg=cfg(trash, values(none()))");
+
+    if cfg!(any(
+        target_os = "windows",
+        all(unix, not(target_os = "ios"), not(target_os = "android"))
+    )) {
+        println!("cargo::rustc-cfg=trash");
+    }
+
+    Ok(())
+}
+
 fn main() -> std::io::Result<()> {
     build_completion_scripts();
     if BUILD_MAN_PAGE {
         build_man_page()?;
     }
+    detect_trash()?;
     Ok(())
 }

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -3,16 +3,10 @@ use {
         app::*,
         command::*,
         display::*,
-        errors::{
-            ProgramError,
-            TreeBuildError,
-        },
+        errors::{ProgramError, TreeBuildError},
         flag::Flag,
         git,
-        path::{
-            self,
-            PathAnchor,
-        },
+        path::{self, PathAnchor},
         pattern::*,
         print,
         stage::*,
@@ -22,10 +16,7 @@ use {
         verb::*,
     },
     opener,
-    std::path::{
-        Path,
-        PathBuf,
-    },
+    std::path::{Path, PathBuf},
 };
 
 /// An application state dedicated to displaying a tree.
@@ -685,6 +676,7 @@ impl PanelState for BrowserState {
                 let path = self.displayed_tree().selected_line().path.to_path_buf();
                 info!("trash {:?}", &path);
 
+                #[cfg(trash)]
                 match trash::delete(&path) {
                     Ok(()) => CmdResult::RefreshState { clear_cache: true },
                     Err(e) => {
@@ -692,6 +684,9 @@ impl PanelState for BrowserState {
                         CmdResult::DisplayError(format!("trash error: {:?}", &e))
                     }
                 }
+
+                #[cfg(not(trash))]
+                CmdResult::DisplayError("trash not supported on this platform".into())
             }
             Internal::up_tree => match self.displayed_tree().root().parent() {
                 Some(path) => internal_focus::on_path(

--- a/src/stage/stage_state.rs
+++ b/src/stage/stage_state.rs
@@ -3,11 +3,7 @@ use {
     crate::{
         app::*,
         command::*,
-        display::{
-            MatchedString,
-            Screen,
-            W,
-        },
+        display::{MatchedString, Screen, W},
         errors::ProgramError,
         pattern::*,
         skin::*,
@@ -15,20 +11,10 @@ use {
         tree::*,
         verb::*,
     },
-    crokey::crossterm::{
-        QueueableCommand,
-        cursor,
-    },
+    crokey::crossterm::{QueueableCommand, cursor},
     std::path::Path,
-    termimad::{
-        Area,
-        CropWriter,
-        SPACE_FILLING,
-    },
-    unicode_width::{
-        UnicodeWidthChar,
-        UnicodeWidthStr,
-    },
+    termimad::{Area, CropWriter, SPACE_FILLING},
+    unicode_width::{UnicodeWidthChar, UnicodeWidthStr},
 };
 
 static TITLE: &str = "Staging Area"; // no wide char allowed here
@@ -477,6 +463,7 @@ impl PanelState for StageState {
             Internal::trash => {
                 info!("trash {} staged files", app_state.stage.len());
 
+                #[cfg(trash)]
                 match trash::delete_all(app_state.stage.paths()) {
                     Ok(()) => {
                         debug!("trash success");
@@ -487,6 +474,9 @@ impl PanelState for StageState {
                         CmdResult::DisplayError(format!("trash error: {:?}", &e))
                     }
                 }
+
+                #[cfg(not(trash))]
+                CmdResult::DisplayError("trash not supported on this platform".into())
             }
             _ => self.on_internal_generic(
                 w,

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -1,21 +1,11 @@
 use {
-    super::{
-        Internal,
-        Verb,
-        VerbId,
-    },
+    super::{Internal, Verb, VerbId},
     crate::{
         app::*,
         command::Sequence,
-        conf::{
-            Conf,
-            VerbConf,
-        },
+        conf::{Conf, VerbConf},
         errors::ConfError,
-        keys::{
-            self,
-            KEY_FORMAT,
-        },
+        keys::{self, KEY_FORMAT},
         verb::*,
     },
     crokey::*,
@@ -69,10 +59,7 @@ impl VerbStore {
     }
 
     fn add_builtin_verbs(&mut self) -> Result<(), ConfError> {
-        use super::{
-            ExternalExecutionMode::*,
-            Internal::*,
-        };
+        use super::{ExternalExecutionMode::*, Internal::*};
         self.add_internal(escape).with_key(key!(esc));
 
         // input actions, not visible in doc, but available for
@@ -170,15 +157,7 @@ impl VerbStore {
         )
         .with_shortcut("cpp");
         self.add_internal(trash);
-        #[cfg(any(
-            target_os = "windows",
-            all(
-                unix,
-                not(target_os = "macos"),
-                not(target_os = "ios"),
-                not(target_os = "android")
-            )
-        ))]
+        #[cfg(trash)]
         {
             self.add_internal(open_trash).with_shortcut("ot");
             self.add_internal(restore_trashed_file).with_shortcut("rt");


### PR DESCRIPTION
279a4af removed the `trash` feature in favor of just using conditional compilation for supported platforms; but it didn't actually compile on platforms not supported by the `trash` crate.

This fixes compilation in these cases. Rather than compile out the trash command altogether, this prints an error message if trash is not supported on the platform. This way, key bindings and such can still work across platforms.
