### PR TITLE
fix: disable `Internal::trash` on unsupported platforms

### DIFF
--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -681,6 +681,15 @@ impl PanelState for BrowserState {
                     CmdResult::Keep
                 }
             },
+            #[cfg(any(
+                target_os = "windows",
+                all(
+                    unix,
+                    not(target_os = "macos"),
+                    not(target_os = "ios"),
+                    not(target_os = "android")
+                )
+            ))]
             Internal::trash => {
                 let path = self.displayed_tree().selected_line().path.to_path_buf();
                 info!("trash {:?}", &path);

--- a/src/stage/stage_state.rs
+++ b/src/stage/stage_state.rs
@@ -474,6 +474,15 @@ impl PanelState for StageState {
                     CmdResult::error("you must select a path to unstage")
                 }
             }
+            #[cfg(any(
+                target_os = "windows",
+                all(
+                    unix,
+                    not(target_os = "macos"),
+                    not(target_os = "ios"),
+                    not(target_os = "android")
+                )
+            ))]
             Internal::trash => {
                 info!("trash {} staged files", app_state.stage.len());
 


### PR DESCRIPTION
This makes it build for *Termux*.