### PR TITLE
"Fix: Return non-zero exit code when --send fails to connect to socket"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ fn main() {
                 warn!("Failed to launch {:?}", &launchable);
                 warn!("Error: {:?}", e);
                 eprintln!("{e}");
+                std::process::exit(1);
             }
         }
         Ok(None) => {}
@@ -17,6 +18,7 @@ fn main() {
             // this usually happens when the passed path isn't of a directory
             warn!("Error: {}", e);
             eprintln!("{e}");
+            std::process::exit(1);
         }
     };
     log_mem(Level::Info);


### PR DESCRIPTION
## Summary
Returns a non-zero exit code (1) when `broot --send` fails to connect to a socket, instead of exiting with code 0.

## Changes
- Modified `src/main.rs` to call `std::process::exit(1)` when errors occur
- Now properly reflects failure conditions when used in scripting contexts

## Example
Before:
```bash
$ broot --send NONEXISTENT-SOCKET -c ':focus /home'; echo $?
error on the socket: No such file or directory (os error 2)
0
After:
$ broot --send NONEXISTENT-SOCKET -c ':focus /home'; echo $?
error on the socket: No such file or directory (os error 2)
1
