### PR TITLE
Update verbs.hjson to match website documentation

### DIFF
--- a/resources/default-conf/verbs.hjson
+++ b/resources/default-conf/verbs.hjson
@@ -29,7 +29,7 @@ verbs: [
         shortcut: e
         key: ctrl-e
         apply_to: text_file
-        execution: "$EDITOR {file}"
+        execution: "$EDITOR +{line} {file}"
         leave_broot: false
     }
 


### PR DESCRIPTION
See #1082 for discussion of website documentation not matching default configs.  This might not be an appropriate default as the `+{line}` argument will likely break many user's default $EDITOR