### PR TITLE
patch nushell init script to fix $listen errors (swapped args)

### DIFF
--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -100,8 +100,8 @@ export def --env br [
     if $git_ignored { $args = ($args | append $'--git-ignored') }
     if $no_git_ignored { $args = ($args | append $'--no-git-ignored') }
     if $install { $args = ($args | append $'--install') }
-    if $listen { $args = ($args | append $'--listen') }
-    if $listen_auto != null { $args = ($args | append $'--listen-auto=($listen_auto)') }
+    if $listen != null { $args = ($args | append $'--listen=($listen)') }
+    if $listen_auto { $args = ($args | append $'--listen-auto') }
     if $no_sort { $args = ($args | append $'--no-sort') }
     if $permissions { $args = ($args | append $'--permissions') }
     if $no_permissions { $args = ($args | append $'--no-permissions') }


### PR DESCRIPTION
Hi there 👋 

I'm totally new to broot but I tried to set up shell integration with nushell manually (via `broot --print-shell-function nushell`) and ran into an issue with the nushell script.
It looks like the logic for `$listen` and `$listen_auto` got swapped.
As is, the script generated by broot doesn't run in nushell, with the error
```bash
broot on  main is 📦 v1.51.0 via 🦀 v1.90.0
❯ br
Error: nu::shell::cant_convert

  × Can't convert to boolean.
    ╭─[entry #0:71:8]
 70 │     if $install { $args = ($args | append $'--install') }
 71 │     if $listen { $args = ($args | append $'--listen') }
    ·        ───┬───
    ·           ╰── can't convert nothing to boolean
 72 │     if $listen_auto != null { $args = ($args | append $'--listen-auto=($listen_auto)') }
    ╰────
```

I've been running `br` for the past few days with this fix (it's awesome!) and with this fix it's been working fine.
I figure this is a trivial enough change to just put this PR here, but lmk if there's anything else you want/need me to do.