### PR TITLE
fix: remove extra `\e` for nested *Tmux*

### DIFF
--- a/src/kitty/terminal_esc.rs
+++ b/src/kitty/terminal_esc.rs
@@ -6,7 +6,7 @@ pub fn get_tmux_header(tmux_nest_count: u32) -> String {
     let mut header: String = "".into();
     for i in 0..tmux_nest_count {
         header.push_str(&"\u{1b}".repeat(2usize.pow(i)));
-        header.push_str("\u{1b}Ptmux;");
+        header.push_str("Ptmux;");
     }
     header
 }


### PR DESCRIPTION
I'm not sure why but it worked previously anyway, despite the extra `\e`.