### PR TITLE
Fix preview filter prefilling when negation is used

### DIFF
--- a/src/pattern/input_pattern.rs
+++ b/src/pattern/input_pattern.rs
@@ -67,6 +67,10 @@ impl InputPattern {
     /// from a pattern used to filter a tree, build a pattern
     /// which would make sense to filter a previewed file
     pub fn tree_to_preview(&self) -> Self {
+        // Don't prefill the preview filter when the pattern is negated
+        if self.raw.trim_start().starts_with('!') {
+            return InputPattern::none();
+        }
         let regex_parts: Option<(String, String)> = match &self.pattern {
             Pattern::ContentExact(cp) => Some(cp.to_regex_parts()),
             Pattern::ContentRegex(rp) => Some(rp.to_regex_parts()),


### PR DESCRIPTION
When using !cr/ (negated regex content filter), the preview filter should not be prefilled with the regex pattern. This fix adds a check in tree_to_preview() to return an empty pattern when the raw pattern starts with '!' (negation operator).

Fixes the issue where preview filter was incorrectly prefilled when using negated content regex filters like !cr/pattern/.

P.S. I know 0 of rust. Claude crafted this for me.