### PR TITLE
Fix PowerShell profile path in installation

### DIFF
--- a/src/shell_install/powershell.rs
+++ b/src/shell_install/powershell.rs
@@ -7,7 +7,7 @@
 //! - a function declaration script in %APPDATA%/dystroy/broot/data/launcher/powershell/1
 //! - a link to that script in %APPDATA%/dystroy/broot/config/launcher/powershell/br.ps1
 //! - a line to source the link in the PowerShell profile (detected dynamically)
-//! 
+//!
 //! The profile is detected by running pwsh.exe first, then
 //! powershell.exe if pwsh is not found. If neither is found, it defaults to
 //! %USERPROFILE%/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
@@ -81,7 +81,7 @@ fn get_script_path() -> PathBuf {
 /// path or the call fails
 fn get_profile(exe: &str) -> Option<PathBuf> {
     let output = Command::new(exe)
-        .args(&["-NoProfile", "-NoLogo", "-Command", "Write-Output $profile"])
+        .args(["-NoProfile", "-NoLogo", "-Command", "Write-Output", "$profile"])
         .output()
         .ok()?;
 


### PR DESCRIPTION
Fixes #806, fixes #949

Implement `get_profile()`, just returning the output of `pwsh (or powershell) -NoProfile -NoLogo -Command Write-Output $profile` to get the profile path for PowerShell (default to PowerShell Core). It's not the ideal solution, but it works in both PowerShell Core (pwsh) and Windows PowerShell (powershell). 
Tested in Powershell Core; Windows PowerShell with the environment path to pwsh temporary removed; Windows PowerShell with the environment path to pwsh and powershell temporary removed (Windows 11, rustc and cargo 1.91.0、commit https://github.com/Canop/broot/commit/7727f8f0870bdf712d03028b278a75f1809cccea).

Falling back to the old `document_dir.join("WindowsPowerShell").join("Profile.ps1"))` might not be the best way (should return an error instead), but I wasn't sure if I could rewrite the whole thing safely.