### PR TITLE
Merge OR and AND NameMatch so highlight works in composite queries

### DIFF
--- a/src/pattern/composite_pattern.rs
+++ b/src/pattern/composite_pattern.rs
@@ -195,14 +195,14 @@ impl CompositePattern {
             // operator
             |op, a, b| match (op, a, b) {
                 (Not, Some(_), _) => None,
+                (Or, Some(ma), Some(Some(mb))) | (And, Some(ma), Some(Some(mb))) => {
+                    Some(ma.merge_with(mb))
+                },
                 (_, Some(ma), _) => Some(ma),
                 (_, None, Some(omb)) => omb,
                 _ => None,
             },
-            |op, a| match (op, a) {
-                (Or, Some(_)) => true,
-                _ => false,
-            },
+            |_op, _a| false,
         );
         // it's possible we didn't find a result because the composition
         composite_result.unwrap_or_else(|| {

--- a/src/pattern/name_match.rs
+++ b/src/pattern/name_match.rs
@@ -12,6 +12,38 @@ pub struct NameMatch {
 }
 
 impl NameMatch {
+    pub fn merge_with(self, other: Self) -> Self{
+        let mut merged = SmallVec::new();
+        let mut a_pos = self.pos.into_iter().peekable();
+        let mut b_pos = other.pos.into_iter().peekable();
+
+        loop {
+            let (val, winning_iter) = match (a_pos.peek(), b_pos.peek()){
+                (None, None) => break,
+                (Some(a), None) => (*a, &mut a_pos),
+                (None, Some(b)) => (*b, &mut b_pos),
+                (Some(a), Some(b)) => {
+                    if a < b {
+                        (*a, &mut a_pos)
+                    } else {
+                        (*b, &mut b_pos)
+                    }
+                }
+            };
+            winning_iter.next();
+            if let Some(last) = merged.last() {
+                if val <= *last {
+                    continue
+                }
+            }
+            merged.push(val);
+        }
+
+        Self{
+            score: self.score + other.score,
+            pos: merged,
+        }
+    }
     /// wraps any group of matching characters with match_start and match_end
     pub fn wrap(
         &self,


### PR DESCRIPTION
Hey, thank you for making broot, it's great stuff!

Using a `CompositePattern` only highlights the first match

<img width="848" height="144" alt="image" src="https://github.com/user-attachments/assets/b2fab35b-4047-4a9e-b52e-884e0a77ae27" />

This PR merges the atoms of a CompositePattern so that all of them are highlighted:

<img width="852" height="150" alt="image" src="https://github.com/user-attachments/assets/b4b9a78f-0187-496e-ba39-4f5e9d41ae3f" />
