### PR TITLE
feat: detect iTerm for kitty terminal graphics protocol

### DIFF
--- a/src/kitty/detect_support.rs
+++ b/src/kitty/detect_support.rs
@@ -61,6 +61,19 @@ pub fn detect_kitty_graphics_protocol_display() -> KittyGraphicsDisplay {
         } else if term_program == "ghostty" {
             debug!("Ghostty implements Kitty Graphics protocol");
             return KittyGraphicsDisplay::Direct;
+        } else if term_program == "iTerm.app" {
+            if let Ok(version) = env::var("TERM_PROGRAM_VERSION") {
+                debug!("$TERM_PROGRAM_VERSION = {:?}", version);
+
+                if &*version < "3.6.6" {
+                    debug!("iTerm2's version predates Kitty Graphics protocol support");
+                } else {
+                    debug!("this looks like a compatible version");
+                    return KittyGraphicsDisplay::Direct;
+                }
+            } else {
+                warn!("$TERM_PROGRAM_VERSION unexpectedly missing");
+            }
         }
     }
 


### PR DESCRIPTION
iTerm2 added kitty image support for some time but it has been buggy until recently: https://gitlab.com/gnachman/iterm2/-/issues/12483

<img width="922" height="699" alt="Screenshot 2026-01-12 at 6 18 35 PM" src="https://github.com/user-attachments/assets/a4fbec37-1157-43a3-9e00-fef02542242b" />

Resolve #905