### PR TITLE
Climb path on missing working directory when restoring from terminal mode

### DIFF
--- a/src/launchable.rs
+++ b/src/launchable.rs
@@ -219,12 +219,15 @@ impl Launchable {
                             break;
                         };
 
-                        if err.kind() == std::io::ErrorKind::NotFound && dir.parent().is_some() {
-                            dir = dir.parent().unwrap();
-                            continue;
+                        if err.kind() != io::ErrorKind::NotFound {
+                            return Err(ProgramError::Io { source: err });
                         }
 
-                        panic!("Unable to restore the working directory: {}", err);
+                        let Some(parent_dir) = dir.parent() else {
+                            return Err(ProgramError::Internal { details: "could not restore from terminal mode".to_string() });
+                        }
+
+                        dir = parent_dir;
                     }
                 }
                 exec_res?; // we trigger the error display after restoration


### PR DESCRIPTION
Hi 👋🏻,


If you
- enter a directory in terminal mode
- delete this directory from somewhere else (e.g. a file explorer when tiding files)
- exit the terminal mode in the deleted directory

broot crashes while not having completely restored terminal capabilities.

This PR fixes this issue by trying to climb the path up.

e.g. you were in `/tmp/folder/i-should-delete-this/`, when the folder is deleted, br's cwd is set to `/tmp/folder` instead of crashing.

I restricted the error to `ErrorKind::NotFound` but maybe it should include `ErrorKind::PermissionDenied` too.

Thanks!