### PR TITLE
Adding `preview_layout`

### DIFF
--- a/resources/default-conf/conf.hjson
+++ b/resources/default-conf/conf.hjson
@@ -89,6 +89,15 @@ show_selection_mark: true
 # true_colors: false
 
 ###############################################################
+# Preview Layout
+# Set to "bottom" to stack the preview panel below the file
+# browser instead of beside it. This can be useful on wide
+# monitors or when you prefer a vertically split view.
+# Default is "right" (preview appears to the right).
+#
+# preview_layout: bottom
+
+###############################################################
 # Icons
 # If you want to display icons in broot, uncomment this line
 # (see https://dystroy.org/broot/icons for installation and

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -18,7 +18,10 @@ use {
         },
         path::SpecialPaths,
         pattern::SearchModeMap,
-        preview::PreviewTransformers,
+        preview::{
+            PreviewLayout,
+            PreviewTransformers,
+        },
         skin::ExtColorMap,
         syntactic::SyntaxTheme,
         tree::TreeOptions,
@@ -159,6 +162,9 @@ pub struct AppContext {
     /// layout modifiers, like divider moves
     pub layout_instructions: LayoutInstructions,
 
+    /// where to place the preview panel (right or bottom)
+    pub preview_layout: PreviewLayout,
+
     /// server name
     pub server_name: Option<String>,
 }
@@ -279,6 +285,7 @@ impl AppContext {
             lines_before_match_in_preview: config.lines_before_match_in_preview.unwrap_or(0),
             preview_transformers,
             layout_instructions,
+            preview_layout: config.preview_layout.unwrap_or_default(),
             server_name,
         })
     }

--- a/src/app/app_panels.rs
+++ b/src/app/app_panels.rs
@@ -60,7 +60,6 @@ pub struct AppPanels {
 }
 
 impl AppPanelsAndInputs {
-
     /// Create the appPanelsAndInputs which should be kept for the whole life of
     /// the application, starting with a single panel (it can't be empty), based on
     /// the initial_root
@@ -76,7 +75,7 @@ impl AppPanelsAndInputs {
         if let Some(path) = con.initial_file.as_ref() {
             browser_state.tree.try_select_path(path);
         }
-        let areas = Areas::create(&mut Vec::new(), &con.layout_instructions, 0, screen, false);
+        let areas = Areas::create(&mut Vec::new(), &con.layout_instructions, 0, screen, None);
         let input = PanelInput::new(areas.input.clone());
         let panel = Panel::new(
             PanelId::from(0),
@@ -127,12 +126,12 @@ impl AppPanelsAndInputs {
         con: &AppContext,
     ) {
         let screen = self.screen();
-        let has_preview = self.has_preview_panel();
+        let preview_layout = self.has_preview_panel().then_some(con.preview_layout);
         Areas::resize_all(
             self.panels.panels.as_mut_slice(),
             &con.layout_instructions,
             screen,
-            has_preview,
+            preview_layout,
         );
         for panel in &mut self.panels.panels {
             panel.mut_state().refresh(screen, con);
@@ -293,13 +292,15 @@ impl AppPanelsAndInputs {
         } else {
             self.active_panel_idx()
         };
-        let with_preview = purpose.is_preview() || self.panels.has_type(PanelStateType::Preview);
+        let preview_layout = (purpose.is_preview()
+            || self.panels.has_type(PanelStateType::Preview))
+        .then_some(con.preview_layout);
         let areas = Areas::create(
             self.panels.panels.as_mut_slice(),
             &con.layout_instructions,
             insertion_idx,
             screen,
-            with_preview,
+            preview_layout,
         );
         let mut input = PanelInput::new(areas.input.clone());
         input.set_content(&state.get_starting_input());
@@ -363,12 +364,15 @@ impl AppPanelsAndInputs {
         let active_panel_id = self.panels.panels[self.active_panel_idx()].id;
         self.panels.panels.remove(panel_idx);
         self.inputs.remove(panel_idx);
-        let has_preview = self.panels.has_type(PanelStateType::Preview);
+        let preview_layout = self
+            .panels
+            .has_type(PanelStateType::Preview)
+            .then_some(con.preview_layout);
         Areas::resize_all(
             &mut self.panels.panels,
             &con.layout_instructions,
             screen,
-            has_preview,
+            preview_layout,
         );
         self.panels.active_panel_idx = self
             .panels
@@ -419,16 +423,20 @@ impl AppPanelsAndInputs {
     // ----------------------------------------------------
     // event handling
 
-    /// get the index of the panel at x
+    /// get the index of the panel at (x, y)
     pub fn clicked_panel_index(
         &self,
         x: u16,
-        _y: u16,
+        y: u16,
     ) -> usize {
         let len = self.len();
         for (idx, panel) in self.panels.panels.iter().enumerate() {
             let area = &panel.areas.state;
-            if area.left <= x && x < area.left + area.width {
+            if area.left <= x
+                && x < area.left + area.width
+                && area.top <= y
+                && y < area.top + area.height
+            {
                 return idx;
             }
         }

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -8,6 +8,7 @@ use {
         git,
         path::{self, PathAnchor},
         pattern::*,
+        preview::PreviewLayout,
         print,
         stage::*,
         task_sync::Dam,
@@ -26,6 +27,7 @@ pub struct BrowserState {
     pub filtered_tree: Option<Tree>,
     mode: Mode,                        // whether we're in 'input' or 'normal' mode
     pending_task: Option<BrowserTask>, // note: there are some other pending task, see
+    panel_page_height: Option<usize>,  // effective page height, accounting for vertical stacking. fallback to screen height
 }
 
 /// A task that can be computed in background
@@ -71,6 +73,7 @@ impl BrowserState {
             filtered_tree: None,
             mode: con.initial_mode(),
             pending_task,
+            panel_page_height: None,
         })
     }
 
@@ -111,6 +114,17 @@ impl BrowserState {
 
     pub fn page_height(screen: Screen) -> usize {
         screen.height as usize - 2 // br shouldn't be displayed when the screen is smaller
+    }
+
+    /// return the effective page height for this panel, using the stored
+    /// panel area height if available (needed for vertical preview layout
+    /// where the browser panel is shorter than the full screen).
+    fn effective_page_height(
+        &self,
+        screen: Screen,
+    ) -> usize {
+        self.panel_page_height
+            .unwrap_or_else(|| Self::page_height(screen))
     }
 
     /// return a reference to the currently displayed tree, which
@@ -342,7 +356,11 @@ impl PanelState for BrowserState {
         debug!("browser_state on_internal {:?}", internal_exec);
         let con = &cc.app.con;
         let screen = cc.app.screen;
-        let page_height = BrowserState::page_height(cc.app.screen);
+        // use the panels actual area height, so scrolling works correctly
+        // in vertical preview layout (the browser is shorter than
+        // the full screen)
+        self.panel_page_height = Some(cc.panel.areas.state.height as usize);
+        let page_height = self.effective_page_height(screen);
         let bang = input_invocation
             .map(|inv| inv.bang)
             .unwrap_or(internal_exec.bang);
@@ -454,7 +472,9 @@ impl PanelState for BrowserState {
                 let areas = &cc.panel.areas;
                 let selected_path = &self.displayed_tree().selected_line().path;
                 if areas.is_last() && areas.nb_pos < con.max_panels_count {
-                    let purpose = if selected_path.is_file() && cc.app.preview_panel.is_none() {
+                    let purpose = if cc.app.preview_panel.is_none()
+                        && (selected_path.is_file() || con.preview_layout == PreviewLayout::Bottom)
+                    {
                         PanelPurpose::Preview
                     } else {
                         PanelPurpose::None
@@ -555,7 +575,7 @@ impl PanelState for BrowserState {
                 CmdResult::Keep
             }
             Internal::select_last => {
-                let page_height = BrowserState::page_height(screen);
+                let page_height = self.effective_page_height(screen);
                 self.displayed_tree_mut().try_select_last(page_height);
                 CmdResult::Keep
             }
@@ -573,7 +593,7 @@ impl PanelState for BrowserState {
                         let res = self.displayed_tree_mut().show_path(&path, con);
                         match res {
                             Ok(()) => {
-                                let page_height = BrowserState::page_height(screen);
+                                let page_height = self.effective_page_height(screen);
                                 self.displayed_tree_mut()
                                     .make_selection_visible(page_height);
                                 CmdResult::Keep
@@ -757,7 +777,7 @@ impl PanelState for BrowserState {
                     let mut options = self.tree.options.clone();
                     options.pattern = pattern;
                     let root = self.tree.root().clone();
-                    let page_height = BrowserState::page_height(screen);
+                    let page_height = self.effective_page_height(screen);
                     let builder = TreeBuilder::from(root, options, page_height, con)?;
                     let filtered_tree = time!(
                         Info,
@@ -767,7 +787,7 @@ impl PanelState for BrowserState {
                     );
                     if let Ok(mut ft) = filtered_tree {
                         ft.try_select_best_match();
-                        ft.make_selection_visible(BrowserState::page_height(screen));
+                        ft.make_selection_visible(self.effective_page_height(screen));
                         self.filtered_tree = Some(ft);
                     }
                 }
@@ -826,7 +846,7 @@ impl PanelState for BrowserState {
         screen: Screen,
         con: &AppContext,
     ) -> Command {
-        let page_height = BrowserState::page_height(screen);
+        let page_height = self.effective_page_height(screen);
         // refresh the base tree
         if let Err(e) = self.tree.refresh(page_height, con) {
             warn!("refreshing base tree failed : {:?}", e);

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -19,7 +19,10 @@ use {
             PathAnchor,
             path_from,
         },
-        preview::PreviewTransformerConf,
+        preview::{
+            PreviewLayout,
+            PreviewTransformerConf,
+        },
         skin::SkinEntry,
         syntactic::SyntaxTheme,
         verb::ExecPattern,
@@ -171,6 +174,9 @@ pub struct Conf {
 
     #[serde(alias = "layout-instructions")]
     pub layout_instructions: Option<LayoutInstructions>,
+
+    #[serde(alias = "preview-layout")]
+    pub preview_layout: Option<PreviewLayout>,
     // BEWARE: entries added here won't be usable unless also
     // added in read_file!
 }
@@ -269,6 +275,7 @@ impl Conf {
         overwrite!(self, lines_after_match_in_preview, conf);
         overwrite!(self, lines_before_match_in_preview, conf);
         overwrite!(self, layout_instructions, conf);
+        overwrite!(self, preview_layout, conf);
         self.verbs.append(&mut conf.verbs);
         // the following prefs are "additive": we can add entries from several
         // config files and they still make sense

--- a/src/display/areas.rs
+++ b/src/display/areas.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
     crate::app::Panel,
+    crate::preview::PreviewLayout,
     termimad::Area,
 };
 
@@ -33,7 +34,7 @@ impl Areas {
         layout_instructions: &LayoutInstructions,
         mut insertion_idx: usize,
         screen: Screen,
-        with_preview: bool, // slightly larger last panel
+        preview_layout: Option<PreviewLayout>,
     ) -> Self {
         if insertion_idx > present_panels.len() {
             insertion_idx = present_panels.len();
@@ -59,7 +60,7 @@ impl Areas {
             layout_instructions,
             &mut slots,
             screen,
-            with_preview,
+            preview_layout,
         );
         areas
     }
@@ -68,7 +69,7 @@ impl Areas {
         panels: &mut [Panel],
         layout_instructions: &LayoutInstructions,
         screen: Screen,
-        with_preview: bool, // slightly larger last panel
+        preview_layout: Option<PreviewLayout>,
     ) {
         let mut slots = Vec::new();
         for i in 0..panels.len() {
@@ -79,7 +80,7 @@ impl Areas {
             layout_instructions,
             &mut slots,
             screen,
-            with_preview,
+            preview_layout,
         );
     }
 
@@ -89,14 +90,57 @@ impl Areas {
         layout_instructions: &LayoutInstructions,
         slots: &mut [Slot],
         screen: Screen,
-        with_preview: bool, // slightly larger last panel
+        preview_layout: Option<PreviewLayout>,
     ) {
         let screen_height = screen.height.max(MINIMAL_PANEL_HEIGHT);
         let screen_width = screen.width.max(MINIMAL_SCREEN_WIDTH);
-        let n = slots.len() as u16;
+        let nb_pos = slots.len();
+
+        // when `preview_layout` is `Bottom` and we have exactly 2 panels with preview,
+        // stack them vertically: browser on top, preview below
+        if preview_layout == Some(PreviewLayout::Bottom) && nb_pos == 2 {
+            // available height for the two panel state areas (minus status + input rows)
+            let available = screen_height.saturating_sub(2);
+            let top_h = available / 2;
+            let bot_h = available - top_h;
+
+            // slot 0 = browser (top), slot 1 = preview (bottom)
+            #[allow(clippy::needless_range_loop)]
+            for slot_idx in 0..nb_pos {
+                let areas: &mut Areas = match &mut slots[slot_idx] {
+                    Slot::Panel(panel_idx) => &mut panels[*panel_idx].areas,
+                    Slot::New(areas) => areas,
+                };
+                // top vs bottom areas, y-start and heights
+                let (y_start, h) = if slot_idx == 0 {
+                    (0, top_h)
+                } else {
+                    (top_h, bot_h)
+                };
+                let state_y = y_start;
+                let status_y = screen_height - 2;
+                let input_y = screen_height - 1;
+                areas.state = Area::new(0, state_y, screen_width, h);
+                areas.status = Area::new(0, status_y, screen_width, 1);
+                areas.input = Area::new(0, input_y, screen_width, 1);
+                // both slots are full-width, so both touch the bottom-right
+                // terminal cell which must not be written to (causes flicker)
+                areas.input.width -= 1;
+                areas.purpose = if slot_idx > 0 {
+                    let area_width = screen_width / 2;
+                    Some(Area::new(0, input_y, area_width, 1))
+                } else {
+                    None
+                };
+                areas.pos_idx = slot_idx;
+                areas.nb_pos = nb_pos;
+            }
+            return;
+        }
 
         // compute auto/default panel widths
-        let mut panel_width = if with_preview {
+        let n = nb_pos as u16;
+        let mut panel_width = if preview_layout.is_some() {
             3 * screen_width / (3 * n + 1)
         } else {
             screen_width / n

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -28,3 +28,12 @@ pub enum PreviewMode {
     /// Show the content with ANSI escape codes
     Tty,
 }
+
+/// Where the preview panel is placed relative to the browser panel
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviewLayout {
+    #[default]
+    Right,
+    Bottom,
+}


### PR DESCRIPTION
I had a similar problem as @j-xella in #1059, where I used broot in a narrow-fashion

This was my attempted at adding a vertical-stacking mode as opposed to the only horizontal-tiling.

## _*PREFACE*_

* There is still a visual bug with the `areas.input` rendering (see video below)
* There is still a visual bug with the folder / entry-count and the filename / line count rendering (see video below)
* [`move_panel_divider` / `set_panel_width`](https://dystroy.org/broot/panels/#resize-panels) is not yet implemented

## Main changes

* Add `preview_layout` to config. Options include `right` (default) and `bottom`
* Renamed `has_preview: bool` -> `preview_layout: Option<PreviewLayout>`, where `None` is analogous to `false`
* Added `BrowserState::effective_page_height`
* Modified `Areas::compute_areas` to change the preview area to be vertically stacked, with an early return

## Help requested

In `Areas::compute_areas` is where the majority of the logic is for how the vertical stacking is implemented. 

I can't seem to wrap my head around how the `areas.input` is being rendered, since I tried many configurations and doesn't seem to work. In addition, this single conditional with early return is just my somewhat hacky attempt at this problem, but unsure if there are better alternative ways to structure the code. 

In addition, it is also in `Areas::compute_areas` where the `layout_instructions` are passed in and modified. However, I did not want to change the logic before getting any guidance on

1. Is this feature something worth pursuing?
2. Rename `set_panel_width` to something else, or keep the term as "width"?

##  Showcase

You can see that:

1. Without preview, the input line renders properly
2. With preview only, the input line _does not_ render properly
3. With preview and "entering" the preview, the input line renders properly

[Screencast from 2026-03-05 17-20-16.webm](https://github.com/user-attachments/assets/cd1c37e4-0500-4939-bd0a-d670b482af5c)
