### PR TITLE
doc: fix markdown rendering

### DIFF
--- a/website/src/input.md
+++ b/website/src/input.md
@@ -32,7 +32,7 @@ fuzzy name | `n/abc` or `nf/abc` | `abac.txt` | search for "abc" in a fuzzy way 
 tokens name | `nt/ab,cd` | `dcdAbac.txt` | search for the "ab" and "cd" tokens, in whatever order (case and diacritics insensitive)
 exact name | `e/Bac` or `en/Bac` | `ABac.txt` | search for the string "Bac" in filenames
 regex name | `/[yz]{3}` or `/[yz]{3}/` | `fuzzy.rs` | search for the regular expression `[yz]{3}` in filenames
-regex name | `/(json|xml)$/i` | `thing.XML` | find files whose name ends in `json` or `xml`, case insensitive
+regex name | `/(json\|xml)$/i` | `thing.XML` | find files whose name ends in `json` or `xml`, case insensitive
 regex name | `/abc/i` | `aBc.txt` | search for the regular expression `abc` with flag `i` in filenames
 exact path | `ep/te\/d`  or `pe/te\/d/` | `website/docs` |  search for "te/d" in sub-paths from current tree root
 regex path | `rp/\d{3}.*txt` | `dir/a256/abc.txt` |  search for the `\d{3}.*txt` regex  in sub-paths from current tree root


### PR DESCRIPTION
How it's currently (incorrectly) rendered:

<img width="503" height="68" alt="Screenshot 2026-03-12 at 4 09 38 PM" src="https://github.com/user-attachments/assets/7ea28655-e3a1-4db8-90c2-f45f52a6caf2" />

`|` needs to be escaped to prevent being treated as Markdown table syntax.