### PR TITLE
Export main function for br module

### DIFF
--- a/src/shell_install/nushell.rs
+++ b/src/shell_install/nushell.rs
@@ -40,7 +40,7 @@ const NU_FUNC: &str = r#"
 #   > br -hi -c "vacheblan.svg;:open_preview" ..
 #
 # See https://dystroy.org/broot/install-br/
-export def --env br [
+export def --env main [
     --cmd(-c): string               # Semicolon separated commands to execute
     --color: string = "auto"        # Whether to have styles and colors (auto is default and usually OK) [possible values: auto, yes, no]
     --conf: string                  # Semicolon separated paths to specific config files"),


### PR DESCRIPTION
Nushell module exports cannot have the same name as that of the module itself. See [here](https://www.nushell.sh/book/modules/creating_modules.html#main-exports). This just renames the default export of `br` to `main` to resolve #1138 .

I was able to test that this works as expected my directly editing the module file on my local system.