### PR TITLE
open all staged files with :open_stay (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### next
 - fix control characters sometimes remaining in the terminal after broot exit
 - nushell: rename br module to avoid conflict in last nushell version - Fix #1138 - Thanks @paulhey
+- `:open_stay` on the staging area opens every staged file through the system opener - Fix #444
 
 ### v1.56.2 - 2026-03-26
 <a name="v1.56.2"></a>

--- a/src/stage/stage_state.rs
+++ b/src/stage/stage_state.rs
@@ -449,6 +449,25 @@ impl PanelState for StageState {
                 self.try_scroll(ScrollCommand::Pages(-1));
                 CmdResult::Keep
             }
+            Internal::open_stay => {
+                if app_state.stage.is_empty() {
+                    CmdResult::error("staging area is empty")
+                } else {
+                    info!("open {} staged files", app_state.stage.len());
+                    let mut errors: Vec<String> = Vec::new();
+                    for path in app_state.stage.paths() {
+                        if let Err(e) = opener::open(path) {
+                            warn!("open failed for {path:?}: {e:?}");
+                            errors.push(format!("{}: {e}", path.display()));
+                        }
+                    }
+                    if errors.is_empty() {
+                        CmdResult::Keep
+                    } else {
+                        CmdResult::error(format!("open errors: {}", errors.join("; ")))
+                    }
+                }
+            }
             Internal::stage => {
                 // shall we restage what we just unstaged ?
                 CmdResult::error("nothing to stage here")

--- a/website/src/staging-area.md
+++ b/website/src/staging-area.md
@@ -32,6 +32,12 @@ Some verbs aren't compatible with execution on the staging area:
 * Verbs which don't come back to broot after execution (for example `:cd` or any verb quitting broot)
 * [Sequences](../conf_verbs#cmd-execution)
 
+# Open all staged files
+
+When the staging area is focused, `:open_stay` opens every staged file through the system's default application, in one go. This is convenient when the goal is just "open these few files" rather than running a custom command.
+
+If you'd rather run a single external command receiving all the paths at once (for example `mpv video1.mp4 video2.mp4` or `nvim file1 file2 file3`), define a verb with a `space-separated` flag on its `{file}` argument; see [Single command on stage](../conf_verbs#single-command-on-stage).
+
 # Read the staging area
 
 The staging area can be opened or closed with the `:open_staging_area`, `:close_staging_area`, and `:toggle_staging_area` verbs, which have shortcuts `:osa`, `:csa`, and `:tsa`.


### PR DESCRIPTION
Fixes #444.

## What

When the staging area panel is focused, `:open_stay` now iterates over the staged paths and opens each one through the system opener. Previously it errored out because `StageState::selection()` returns `None`, so the generic handler had nothing to act on.

This matches the workflow the issue describes: stage some files, focus the stage panel, run `:open_stay`. The existing `:trash` handling on the stage panel works the same way (loops over `stage.paths()`), so the pattern fits.

## What it doesn't change

If a user wants a single external command invocation receiving all the paths at once (e.g. `mpv video1.mp4 video2.mp4`, or `nvim file1 file2 file3`), the existing `space-separated` / `comma-separated` arg flag (Fix #465) is still the way to go. The `staging-area` doc now points at that section so it's easier to find.

## Behaviour

- empty stage: shows "staging area is empty" status (same shape as the existing "nothing to stage here" message).
- per-path errors are collected and reported in one status line, so a single bad path doesn't drop the rest silently.
- on success, returns `CmdResult::Keep` so broot stays open and the stage stays as it was.

## Files

- `src/stage/stage_state.rs` — new `Internal::open_stay` arm before the `:stage` arm.
- `website/src/staging-area.md` — short section describing the behaviour and pointing at the `space-separated` recipe for the single-command case.
- `CHANGELOG.md` — under `### next`.

## Tested

- `cargo build` / `cargo build --release` clean.
- `cargo test` — 7 passed, no regressions.
- `cargo clippy --all-targets` — no new warnings on the touched file.
- Manual: stage several files in a tmp dir, focus stage panel, type `:open_stay`; each file opens with the system default app and broot stays.