### PR TITLE
fix: resolve #963 — br error on Right/open of md associated editor (zsh/vscode)

### DIFF
--- a/src/launchable.rs
+++ b/src/launchable.rs
@@ -36,6 +36,7 @@ use {
         path::PathBuf,
         path::Path,
         process::Command,
+        process::Stdio,
     },
     which::which,
 };
@@ -94,6 +95,43 @@ fn resolve_env_variables(parts: Vec<String>) -> Vec<String> {
         resolved.push(part);
     }
     resolved
+}
+
+fn detach_standard_streams(command: &mut Command) {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn detached_background_program_with_stdin_reader_does_not_hang() {
+        let mut command = Command::new("cat");
+        detach_standard_streams(&mut command);
+        let status = command
+            .spawn()
+            .and_then(|mut child| child.wait())
+            .expect("cat should spawn");
+        assert!(status.success());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn detached_background_program_writing_stdout_succeeds() {
+        let mut command = Command::new("echo");
+        command.arg("broot");
+        detach_standard_streams(&mut command);
+        let status = command
+            .spawn()
+            .and_then(|mut child| child.wait())
+            .expect("echo should spawn");
+        assert!(status.success());
+    }
 }
 
 impl Launchable {
@@ -192,7 +230,11 @@ impl Launchable {
                         old_working_dir = None;
                     }
                 }
-                let exec_res = Command::new(exe)
+                let mut command = Command::new(exe);
+                if !*switch_terminal {
+                    detach_standard_streams(&mut command);
+                }
+                let exec_res = command
                     .args(args.iter())
                     .spawn()
                     .and_then(|mut p| p.wait())


### PR DESCRIPTION
## Summary

When broot opens a file with an associated GUI editor (e.g. VSCode on Windows/msys2), the editor is launched as a background program (switch_terminal = false). broot currently spawns this child without redirecting its stdin/stdout/stderr, so any diagnostic output the editor writes (deprecation warnings, jump-list privacy errors, extension host messages) is written straight into broot's terminal and surfaces as the "error" the user sees in this issue. The fix is to fully detach background programs from broot's terminal by piping their standard streams to null. This keeps broot's TUI clean and matches the intent that background launches should not share broot's console

Fixes #963

## Changes

- `src/launchable.rs`

## Why

`src/launchable.rs`: When broot opens a file with an associated GUI editor (e.g. VSCode on Windows/msys2), the editor is launched as a background program (switch_terminal = false). broot currently spawns this child without redirecting its stdin/stdout/stderr, so any diagnostic output the editor writes (deprecation warnings, jump-list privacy errors, extension host messages) is written straight into broot's terminal and surfaces as the "error" the user sees in this issue. The fix is to fully detach background programs from broot's terminal by piping their standard streams to null. This keeps broot's TUI clean and matches the intent that background launches should not share broot's console.
