### PR TITLE
fix: resolve #869 — Could not edit file in Kakoune by specifying client and server

### DIFF
--- a/resources/default-conf/verbs.hjson
+++ b/resources/default-conf/verbs.hjson
@@ -135,6 +135,17 @@ verbs: [
     #     from_shell: true
     # }
 
+    # A verb's execution is tokenized rather than interpreted by a shell,
+    #  so shell features like a pipe `|` or a redirection `>` need the
+    #  `from_shell: true` parameter too.
+    # This example pipes the selected file to a running Kakoune session:
+    # {
+    #     invocation: "to_kak {session}"
+    #     external: "echo edit {file} | kak -p {session}"
+    #     from_shell: true
+    #     leave_broot: false
+    # }
+
     # Here's an example of a shortcut bringing you to your home directory
     # {
     #     invocation: home


### PR DESCRIPTION
## Summary

Users reasonably expect a verb `execution` to behave like a shell line. Since broot historically tokenizes instead, we should document the correct pattern so users like the issue author can succeed even without relying on auto-detection. Add a commented example showing how to pipe into another program

Fixes #869

## Changes

- `resources/default-conf/verbs.hjson`

## Why

`resources/default-conf/verbs.hjson`: Users reasonably expect a verb `execution` to behave like a shell line. Since broot historically tokenizes instead, we should document the correct pattern so users like the issue author can succeed even without relying on auto-detection. Add a commented example showing how to pipe into another program.
