### PR TITLE
fix: resolve #788 — `br` command fails on Windows

### DIFF
--- a/src/shell_install/powershell.rs
+++ b/src/shell_install/powershell.rs
@@ -41,7 +41,7 @@ Function br {
 
   try {
     $process = Start-Process -FilePath 'broot.exe' `
-                            -ArgumentList "--outcmd $($cmd_file.FullName) $args" `
+                            -ArgumentList "--outcmd `"$($cmd_file.FullName)`" $args" `
                             -NoNewWindow -PassThru -WorkingDirectory $PWD
 
     Wait-Process -InputObject $process #Faster than Start-Process -Wait
@@ -150,4 +150,21 @@ pub fn install(si: &mut ShellInstall) -> Result<(), ShellInstallError> {
     }
     si.done = true;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcmd_temp_path_is_quoted() {
+        let script = get_script();
+        assert!(script.contains("--outcmd `\"$($cmd_file.FullName)`\" $args"));
+    }
+
+    #[test]
+    fn outcmd_temp_path_is_not_unquoted() {
+        let script = get_script();
+        assert!(!script.contains("--outcmd $($cmd_file.FullName) $args"));
+    }
 }


### PR DESCRIPTION
## Summary

The generated PowerShell `br` function passes the temporary command file path to broot via a single interpolated `-ArgumentList` string. When the path contains a space (common when the Windows username contains a space, e.g. `C:\Users\First Second\AppData\Local\Temp\...`), `Start-Process` splits the string on whitespace. broot then receives a truncated `--outcmd` value and the trailing path segment as an unexpected extra argument, producing the reported `File not found` error. The temp path must be quoted so it survives argument tokenization

Fixes #788

## Changes

- `src/shell_install/powershell.rs`

## Why

`src/shell_install/powershell.rs`: The generated PowerShell `br` function passes the temporary command file path to broot via a single interpolated `-ArgumentList` string. When the path contains a space (common when the Windows username contains a space, e.g. `C:\Users\First Second\AppData\Local\Temp\...`), `Start-Process` splits the string on whitespace. broot then receives a truncated `--outcmd` value and the trailing path segment as an unexpected extra argument, producing the reported `File not found` error. The temp path must be quoted so it survives argument tokenization.
