### PR TITLE
Fix extra empty line when printing a multi-item staging area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next
 - help: verb 'keys' and 'description' columns now searchable - Fix #1163
+- fix `:print_path` / `:print_relative_path` adding a trailing empty line when printing a multi-item staging area - Fix #1062
 
 ### v1.56.4 - 2026-05-14
 <a name="v1.56.4"></a>

--- a/src/print.rs
+++ b/src/print.rs
@@ -42,14 +42,12 @@ pub fn print_paths(
     let string = match sel_info {
         SelInfo::None => "".to_string(), // better idea ?
         SelInfo::One(sel) => sel.path.to_string_lossy().to_string(),
-        SelInfo::More(stage) => {
-            let mut string = String::new();
-            for path in stage.paths() {
-                string.push_str(&path.to_string_lossy());
-                string.push('\n');
-            }
-            string
-        }
+        SelInfo::More(stage) => stage
+            .paths()
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
     };
     print_string(string, con)
 }
@@ -78,14 +76,12 @@ pub fn print_relative_paths(
     let string = match sel_info {
         SelInfo::None => "".to_string(),
         SelInfo::One(sel) => relativize_path(sel.path, con)?,
-        SelInfo::More(stage) => {
-            let mut string = String::new();
-            for path in stage.paths() {
-                string.push_str(&relativize_path(path, con)?);
-                string.push('\n');
-            }
-            string
-        }
+        SelInfo::More(stage) => stage
+            .paths()
+            .iter()
+            .map(|path| relativize_path(path, con))
+            .collect::<io::Result<Vec<_>>>()?
+            .join("\n"),
     };
     print_string(string, con)
 }


### PR DESCRIPTION
### Problem

`:print_path` (`:pp`) and `:print_relative_path` add a trailing empty line when printing a **multi-item** staging area. Printing a single selection does not. Two reporters confirmed this via `od` in #1062.

### Root cause

In `src/print.rs`, the `SelInfo::More` arm of `print_paths` / `print_relative_paths` pushed a `'\n'` after **every** path, including the last one:

```rust
SelInfo::More(stage) => {
    let mut string = String::new();
    for path in stage.paths() {
        string.push_str(&path.to_string_lossy());
        string.push('\n');     // trailing newline even on the last entry
    }
    string
}
```

The single-selection arm (`SelInfo::One`) produces a string with **no** trailing newline. `print_string` then hands the string to `Launchable::printer`, and `Launchable::Printer` prints it with `println!("{to_print}")`, which appends a newline. So for the multi-item case you get the per-entry trailing `'\n'` *plus* the `println!` newline → a trailing empty line; the single-item case stays correct.

### Fix

Build the multi-path output by joining the per-path strings with `"\n"`, matching the single-selection contract, so `println!` supplies the single terminating newline:

```rust
SelInfo::More(stage) => stage
    .paths()
    .iter()
    .map(|path| path.to_string_lossy().to_string())
    .collect::<Vec<_>>()
    .join("\n"),
```

The same change is applied to `print_relative_paths` (collecting the fallible `relativize_path` results into `io::Result<Vec<_>>` before joining).

### Verification

- `cargo build` — clean
- `cargo test` — all tests pass
- `cargo clippy` — no findings on the changed code
- `cargo fmt` — the changed lines produce no diff (the repo's `rustfmt.toml` relies on nightly-only options, so stable rustfmt shows pre-existing repo-wide import-layout diffs unrelated to this change)

`print_paths`/`print_relative_paths` depend on `SelInfo`/app state with no clean unit-test seam, so there's no isolated unit test; the change is a minimal, behavior-preserving refactor of the string assembly. Added a CHANGELOG entry under `### next`.

Fixes #1062
