### PR TITLE
Fix Bash launcher handling of Windows backslashes

### DIFF
--- a/src/shell_install/bash.rs
+++ b/src/shell_install/bash.rs
@@ -24,7 +24,10 @@ use {
     regex::Captures,
     std::{
         env,
-        path::PathBuf,
+        path::{
+            Path,
+            PathBuf,
+        },
     },
     termimad::mad_print_inline,
 };
@@ -118,6 +121,22 @@ fn get_sourcing_paths() -> Vec<PathBuf> {
         .collect()
 }
 
+fn bash_path_literal(path: &str) -> String {
+    if path
+        .chars()
+        .any(|c| matches!(c, '\\' | ' ' | '\t' | '\n' | '"' | '\''))
+    {
+        format!("'{}'", path.replace('\'', r#"'\''"#))
+    } else {
+        path.to_string()
+    }
+}
+
+fn source_line_for(link_path: &Path) -> String {
+    let link_path = link_path.to_string_lossy();
+    format!("source {}", bash_path_literal(&link_path))
+}
+
 /// check for bash and zsh shells.
 /// check whether the shell function is installed, install
 /// it if it wasn't refused before or if broot is launched
@@ -133,8 +152,7 @@ pub fn install(si: &mut ShellInstall) -> Result<(), ShellInstallError> {
         si.skin.print_text(MD_NO_SOURCING);
         return Ok(());
     }
-    let escaped_path = link_path.to_string_lossy().replace(' ', "\\ ");
-    let source_line = format!("source {}", &escaped_path);
+    let source_line = source_line_for(&link_path);
     for sourcing_path in &sourcing_paths {
         let sourcing_path_str = sourcing_path.to_string_lossy();
         if util::file_contains_line(sourcing_path, &source_line)? {
@@ -163,4 +181,18 @@ pub fn install(si: &mut ShellInstall) -> Result<(), ShellInstallError> {
     }
     si.done = true;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::source_line_for;
+    use std::path::Path;
+
+    #[test]
+    fn source_line_quotes_backslashes() {
+        assert_eq!(
+            source_line_for(Path::new(r"C:\Users\me\broot\launcher\bash\br")),
+            r"source 'C:\Users\me\broot\launcher\bash\br'",
+        );
+    }
 }

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -475,7 +475,7 @@ impl<'b> ExecutionBuilder<'b> {
             // even if there are special characters
             return s.to_string();
         }
-        if !regex_is_match!(r#"[\s"']"#, &s) {
+        if !regex_is_match!(r#"[\\\s"']"#, &s) {
             // if there's no special character, we don't need to escape or wrap
             return s.to_string();
         }
@@ -562,6 +562,25 @@ mod execution_builder_test {
         }
     }
 
+    fn check_build_shell_execution_from_sel(
+        exec_pattern: ExecPattern,
+        path: &str,
+        chk_shell_exec: &str,
+    ) {
+        let path = PathBuf::from(path);
+        let sel = Selection {
+            path: &path,
+            line: 0,
+            stype: SelectionType::File,
+            is_exe: false,
+        };
+        let app_state = AppState::new(PathBuf::from("/".to_owned()));
+        let mut builder = ExecutionBuilder::without_invocation(SelInfo::One(sel), &app_state);
+        let con = AppContext::default();
+        let shell_exec = builder.shell_exec_string(&exec_pattern, &con);
+        assert_eq!(shell_exec, chk_shell_exec);
+    }
+
     #[test]
     fn test_build_execution() {
         check_build_execution_from_sel(
@@ -593,6 +612,15 @@ mod execution_builder_test {
             "/path/to/file",
             vec![],
             vec!["xterm", "-e", "kak /path/to/file"],
+        );
+    }
+
+    #[test]
+    fn test_build_shell_execution_quotes_windows_paths() {
+        check_build_shell_execution_from_sel(
+            ExecPattern::from_string("cd {file}"),
+            r"C:\Users\me\directory",
+            r"cd 'C:\Users\me\directory'",
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1100.

Bash treats unquoted backslashes as escape characters, so Windows paths like `C:\Users\me\directory` were emitted as commands such as `cd C:\Users\me\directory` and then evaluated as `C:Usersmedirectory`.

This change:
- quotes generated shell command paths that contain backslashes before they are written to `--outcmd`
- quotes the installed Bash/Zsh `source` line when the launcher path contains backslashes, spaces, or quotes
- adds regressions for both the generated `cd` command and Bash launcher source line

## Verification

- `cargo test verb::execution_builder::execution_builder_test::test_build_shell_execution_quotes_windows_paths -- --nocapture`
- `cargo test shell_install::bash::tests::source_line_quotes_backslashes -- --nocapture`
- `cargo test`
- `git diff --check`

Note: `cargo fmt --check` reports repository-wide formatting diffs with the current rustfmt configuration, including files untouched by this change.
