### PR TITLE
high-res images in Rio terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- High-Res images in Rio (detect it to enable the Kitty image protocol) - Fix #1179
+
 ### v1.58.0 - 2026-07-10
 <a name="v1.58.0"></a>
 - change the way possible verb completions are listed, making it more readable when there are more than what fits the screen

--- a/src/kitty/detect_support.rs
+++ b/src/kitty/detect_support.rs
@@ -53,6 +53,15 @@ pub fn detect_kitty_graphics_protocol_display() -> KittyGraphicsDisplay {
         }
     }
 
+    // we detect rio by the $TERM_PROGRAM env var
+    if let Ok(term_program) = env::var("TERM_PROGRAM") {
+        debug!("$TERM_PROGRAM = {term_program:?}");
+        if term_program == "rio" {
+            debug!(" -> this terminal seems to be rio");
+            return KittyGraphicsDisplay::Direct;
+        }
+    }
+
     // we detect Wezterm with the $TERM_PROGRAM env var and we
     // check its version to be sure it's one with support
     if let Ok(term_program) = env::var("TERM_PROGRAM") {


### PR DESCRIPTION
Detect the Rio terminal to enable the Kitty Image protocol.

Fix #1179 