### PR TITLE
Fix small screen height underflows

### DIFF
--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -110,7 +110,7 @@ impl BrowserState {
     }
 
     pub fn page_height(screen: Screen) -> usize {
-        screen.height as usize - 2 // br shouldn't be displayed when the screen is smaller
+        (screen.height as usize).saturating_sub(2) // br shouldn't be displayed when the screen is smaller
     }
 
     /// return a reference to the currently displayed tree, which
@@ -862,6 +862,19 @@ impl PanelState for BrowserState {
             pattern.raw.clone()
         } else {
             self.displayed_tree().options.pattern.raw.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_height_accounts_for_application_rows() {
+        for (height, expected) in [(0, 0), (1, 0), (2, 0), (10, 8)] {
+            let screen = Screen { width: 80, height };
+            assert_eq!(BrowserState::page_height(screen), expected);
         }
     }
 }

--- a/src/launchable.rs
+++ b/src/launchable.rs
@@ -124,7 +124,7 @@ impl Launchable {
             skin: Box::new(style_map),
             ext_colors,
             width: screen.width,
-            height: (tree.lines.len() as u16).min(screen.height - 1),
+            height: tree_print_height(tree.lines.len(), screen.height),
         }
     }
     /// Create a launchable to execute the given program.
@@ -244,6 +244,13 @@ impl Launchable {
     }
 }
 
+fn tree_print_height(
+    tree_height: usize,
+    screen_height: u16,
+) -> u16 {
+    tree_height.min(screen_height.saturating_sub(1) as usize) as u16
+}
+
 /// Try set the current dir to the given path, and if it fails, try to climb the path until an
 /// existing folder is found. Return true if the current dir has been changed, false otherwise.
 pub fn try_set_current_dir(mut dir: &Path) -> bool {
@@ -256,5 +263,19 @@ pub fn try_set_current_dir(mut dir: &Path) -> bool {
             return false;
         };
         dir = parent_dir;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn printed_tree_height_leaves_the_last_screen_row_free() {
+        for (tree_height, screen_height, expected) in
+            [(20, 0, 0), (20, 1, 0), (20, 2, 1), (20, 10, 9), (5, 10, 5)]
+        {
+            assert_eq!(tree_print_height(tree_height, screen_height), expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- preserve `--height` as the total application height while saturating the two rows reserved for status and input
- avoid the related deferred tree-printer underflow when the screen height is zero
- cover application heights 0, 1, 2, and normal-height layout behavior with regression tests

Fixes #1020.

Claim: https://github.com/Canop/broot/issues/1020#issuecomment-5018627583

## Validation

- `cargo test page_height_accounts_for_application_rows`
- `cargo test printed_tree_height_leaves_the_last_screen_row_free`
- `cargo check --all-targets`
- `cargo test -- --skip path::normalize::path_normalize_tests::test_path_normalization` (51 passed; the skipped existing test expects Unix separators and fails on Windows)
- `cargo clippy --all-targets` (passes with existing repository warnings)
- `git diff --check`

`cargo fmt --check` was also run, but the repository's nightly-only rustfmt settings aren't honored by the installed stable formatter and it reports repository-wide pre-existing diffs. Installing nightly rustfmt was attempted but timed out while downloading.

## AI Assistance

This change was implemented and reviewed with AI assistance. The contributor inspected the resulting code and ran the validation listed above.