### PR TITLE
Quote paths containing a backslash

### DIFF
--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -483,7 +483,7 @@ impl<'b> ExecutionBuilder<'b> {
         }
         // first we replace single quotes by `'"'"'` (close the single quote, add an escaped
         // single quote, and reopen the single quote)
-        let s = s.replace('\'', r#"'"'"#);
+        let s = s.replace('\'', r#"'"'"'"#);
         // then we wrap the whole thing in single quotes
         let s = format!("'{}'", s);
         s
@@ -608,5 +608,9 @@ mod execution_builder_test {
         assert_eq!(builder.path_to_string("/home/dys/dev"), "/home/dys/dev");
         assert_eq!(builder.path_to_string("/home/dys/my dev"), "'/home/dys/my dev'");
         assert_eq!(builder.path_to_string(r"C:\Users\dys\dev"), r"'C:\Users\dys\dev'");
+        assert_eq!(
+            builder.path_to_string("/home/dys/it's dev"),
+            r#"'/home/dys/it'"'"'s dev'"#,
+        );
     }
 }

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -475,7 +475,9 @@ impl<'b> ExecutionBuilder<'b> {
             // even if there are special characters
             return s.to_string();
         }
-        if !regex_is_match!(r#"[\s"']"#, &s) {
+        // backslashes must be in this set: on Windows the string may go to
+        // the launcher's outcmd file, whose eval would remove them
+        if !regex_is_match!(r#"[\s"'\\]"#, &s) {
             // if there's no special character, we don't need to escape or wrap
             return s.to_string();
         }
@@ -594,5 +596,17 @@ mod execution_builder_test {
             vec![],
             vec!["xterm", "-e", "kak /path/to/file"],
         );
+    }
+
+    #[test]
+    fn test_path_to_string_quoting() {
+        let app_state = AppState::new(PathBuf::from("/"));
+        let mut builder = ExecutionBuilder::without_invocation(SelInfo::None, &app_state);
+        // the String target is the one used for the launcher's outcmd file,
+        // whose content is passed to the shell's eval
+        builder.target = Target::String;
+        assert_eq!(builder.path_to_string("/home/dys/dev"), "/home/dys/dev");
+        assert_eq!(builder.path_to_string("/home/dys/my dev"), "'/home/dys/my dev'");
+        assert_eq!(builder.path_to_string(r"C:\Users\dys\dev"), r"'C:\Users\dys\dev'");
     }
 }


### PR DESCRIPTION
`path_to_string` only quotes when the path holds whitespace or a quote. A Windows path like `C:\Users\me\dev` has neither, so it reaches the outcmd file unquoted, and the `eval` in the `br` launcher strips the backslashes before `cd` sees them.

Putting the backslash in that character class gives it the same single quoting spaces already get. On Windows 11 with Git Bash the outcmd line goes from `cd C:\Users\me\dev` to `cd 'C:\Users\me\dev'`, and `:cd` works again.

The test checks `path_to_string` with the String target on three inputs: nothing special, a space, a backslash.

`test_path_normalization` fails on Windows on main, before and after this change.
