### PR TITLE
Strip terminal escape sequences from displayed file/directory names

### DIFF
--- a/src/tree/tree_line.rs
+++ b/src/tree/tree_line.rs
@@ -31,6 +31,19 @@ use is_executable::IsExecutable;
 
 pub type TreeLineId = usize;
 
+/// Replace control characters, including ANSI/terminal escape sequences,
+/// with the Unicode replacement character in a value that will be
+/// displayed. File and directory names are fully controlled by whoever
+/// created them, so they must be sanitized before being written to the
+/// terminal, since an unprivileged local user could otherwise plant a
+/// name containing an escape sequence that gets interpreted by anyone
+/// else's terminal when they browse the same directory with broot.
+pub fn sanitize_display_name(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+        .collect()
+}
+
 /// a line in the representation of the file hierarchy
 #[derive(Debug, Clone)]
 pub struct TreeLine {
@@ -89,7 +102,7 @@ impl TreeLineBuilder {
         let line_type = TreeLineType::new(&path, metadata.file_type());
         let name = path
             .file_name()
-            .map(|os_str| os_str.to_string_lossy().replace('\n', "␤"))
+            .map(|os_str| sanitize_display_name(&os_str.to_string_lossy().replace('\n', "␤")))
             .unwrap_or_else(String::new);
         let icon = con.icons.as_ref().map(|icon_plugin| {
             let extension = TreeLine::extension_from_name(&name);
@@ -223,9 +236,34 @@ impl TreeLine {
     }
     pub fn unprune(&mut self) {
         self.line_type = TreeLineType::new(&self.path, self.metadata.file_type());
-        self.name = self
-            .path
-            .file_name()
-            .map_or_else(|| "???".to_string(), |n| n.to_string_lossy().to_string());
+        self.name = self.path.file_name().map_or_else(
+            || "???".to_string(),
+            |n| sanitize_display_name(&n.to_string_lossy()),
+        );
+    }
+}
+
+#[cfg(test)]
+mod sanitize_display_name_tests {
+    use super::*;
+
+    #[test]
+    fn strips_escape_sequences() {
+        // A crafted file name embedding a raw OSC 52 (clipboard-write)
+        // escape sequence, the same shape a malicious local file could
+        // use to inject terminal control sequences into another user's
+        // broot session. The ESC and BEL bytes must not survive
+        // sanitization.
+        let malicious = "\x1b]52;c;cGF5bG9hZA==\x07innocuous_file.txt";
+        let sanitized = sanitize_display_name(malicious);
+        assert!(!sanitized.contains('\u{1b}'));
+        assert!(!sanitized.contains('\u{7}'));
+        assert!(sanitized.contains("innocuous_file.txt"));
+    }
+
+    #[test]
+    fn preserves_normal_names() {
+        let normal = "some-normal_file.name (1).txt";
+        assert_eq!(sanitize_display_name(normal), normal);
     }
 }


### PR DESCRIPTION
Fixes #1188.

## Summary

`TreeLineBuilder::build` (the primary path constructing a `TreeLine`'s
displayable name) and `TreeLine::unprune` (a secondary path used when
un-collapsing a previously pruned node) both converted a file or
directory's OS-level name to a `String` with no filtering beyond an
existing newline replacement, despite the `name` field's own doc comment
already stating an intent to strip characters ("some chars may have been
stripped"). Since a file or directory name is fully controlled by
whoever created it, and browsing a directory with broot is a routine,
primary use of the tool rather than an action taken with awareness of
viewing untrusted content, any escape sequence embedded in a name was
written to the viewer's terminal unmodified and interpreted live.

## Fix

Adds `sanitize_display_name` (src/tree/tree_line.rs), which replaces
control characters (including the ESC byte, `0x1b`) with the Unicode
replacement character, and applies it at both places a `TreeLine`'s
`name` is constructed, after the existing newline-to-`␤` replacement so
newlines keep rendering as that more informative placeholder rather than
the generic replacement character.

## Testing

- `cargo test --release` passes in full (51 passed, up from 49 with the
  2 new tests, 0 failed).
- Added `sanitize_display_name_tests::strips_escape_sequences` and
  `::preserves_normal_names` to `src/tree/tree_line.rs`.
- Manually reproduced the issue against an unpatched build: created a
  file whose name contained a raw OSC 52 escape sequence, ran broot on
  it inside a `tmux` session, and captured the literal byte stream broot
  wrote to its pty via `tmux pipe-pane` (necessary since a plain
  `tmux capture-pane` reconstruction was ambiguous, as tmux's own OSC 52
  handling could independently explain the sequence's absence from the
  reconstructed screen text). The captured stream contained the exact
  injected sequence, unmodified. Repeated against this branch and
  confirmed the `ESC`/`BEL` bytes are replaced with the Unicode
  replacement character instead, with the surrounding filename text
  unaffected.
