### PR TITLE
fix(content_search): correct off-by-one in line_count_at_pos for line-start matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### next
+- fix content-exact match line number off-by-one when the match starts at the first byte of a line (broot jumped to the line above) - Thanks @YuriNachos
 - High-Res images in Rio (detect it to enable the Kitty image protocol) - Fix #1179
 
 ### v1.58.0 - 2026-07-10

--- a/src/content_search/mod.rs
+++ b/src/content_search/mod.rs
@@ -82,7 +82,7 @@ pub fn line_count_at_pos<P: AsRef<Path>>(
     let mut bytes_count = 0;
     while reader.read_line(&mut line)? > 0 {
         bytes_count += line.len();
-        if bytes_count >= pos {
+        if bytes_count > pos {
             return Ok(line_count);
         }
         line_count += 1;
@@ -92,4 +92,119 @@ pub fn line_count_at_pos<P: AsRef<Path>>(
         io::ErrorKind::UnexpectedEof,
         "too short".to_string(),
     ))
+}
+
+#[cfg(test)]
+mod line_count_at_pos_tests {
+    use {
+        super::line_count_at_pos,
+        std::io::Write,
+        tempfile::NamedTempFile,
+    };
+
+    /// Regression: a match whose first byte is exactly the first byte of a
+    /// line (here `T` of `TARGET`, the first byte of line 2) must report the
+    /// line it is actually on, not the line above. Before the fix,
+    /// `bytes_count >= pos` returned line 1 because `bytes_count` after
+    /// reading line 1 equals the byte index where line 2 begins.
+    #[test]
+    fn match_at_start_of_line_returns_that_line() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        // byte indices: xxx=0..2, \n=3, T=4 (first byte of line 2)
+        writeln!(tmp, "xxx\nTARGET\nrest").unwrap();
+        tmp.flush().unwrap();
+        // The exact-content search path passes the byte offset from Needle::search.
+        // "TARGET" starts at byte index 4.
+        let pos = "xxx\n".len(); // 4
+        assert_eq!(pos, 4);
+        let line = line_count_at_pos(tmp.path(), pos).unwrap();
+        assert_eq!(
+            line, 2,
+            "a match starting at the first byte of line 2 must report line 2, not line 1"
+        );
+    }
+
+    /// Guard against the opposite regression: a match in the MIDDLE of line 1
+    /// must still report line 1 after switching `>=` to `>`.
+    #[test]
+    fn match_mid_first_line_still_returns_one() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "hello TARGET world\nrest").unwrap();
+        tmp.flush().unwrap();
+        // "TARGET" starts at byte index 6, well inside line 1.
+        let pos = "hello ".len(); // 6
+        assert_eq!(pos, 6);
+        let line = line_count_at_pos(tmp.path(), pos).unwrap();
+        assert_eq!(line, 1);
+    }
+
+    /// Multi-line gap: a match at the first byte of line 4 must report 4,
+    /// exercising the off-by-one across more than one preceding line.
+    #[test]
+    fn match_at_start_of_deeper_line() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "a\nbb\nccc\nTARGET\nrest").unwrap();
+        tmp.flush().unwrap();
+        // bytes: 'a'=0 \n=1 'b'=2 'b'=3 \n=4 'c'=5 'c'=6 'c'=7 \n=8 'T'=9
+        let pos = "a\nbb\nccc\n".len(); // 9
+        assert_eq!(pos, 9);
+        let line = line_count_at_pos(tmp.path(), pos).unwrap();
+        assert_eq!(line, 4);
+    }
+
+    /// pos past EOF still yields the documented UnexpectedEof error (unchanged
+    /// by the fix — locks the error contract).
+    #[test]
+    fn pos_past_eof_is_error() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "short\n").unwrap();
+        tmp.flush().unwrap();
+        let err = line_count_at_pos(tmp.path(), 9999).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    /// A match at the first byte of a line that follows a BLANK line: the
+    /// `pos == bytes_count` fall-through must keep counting past empty lines.
+    /// `a\n\nTARGET\n` -> "TARGET" at byte 3 (first byte of line 3) -> 3.
+    #[test]
+    fn match_after_blank_line() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        // bytes: 'a'=0 \n=1 \n=2 'T'=3  (T is first byte of line 3)
+        writeln!(tmp, "a\n\nTARGET\n").unwrap();
+        tmp.flush().unwrap();
+        let pos = "a\n\n".len(); // 3
+        assert_eq!(pos, 3);
+        let line = line_count_at_pos(tmp.path(), pos).unwrap();
+        assert_eq!(line, 3);
+    }
+
+    /// The matching line is the last line and has NO trailing newline:
+    /// `read_line` still returns it (length without `\n`), so the boundary
+    /// holds. Uses `write!` to avoid `writeln!` appending a final `\n`.
+    #[test]
+    fn match_on_last_line_without_trailing_newline() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        // "xxx\nTARGET" with no final newline; T is first byte of line 2.
+        write!(tmp, "xxx\nTARGET").unwrap();
+        tmp.flush().unwrap();
+        let pos = "xxx\n".len(); // 4
+        assert_eq!(pos, 4);
+        let line = line_count_at_pos(tmp.path(), pos).unwrap();
+        assert_eq!(line, 2);
+    }
+
+    /// CRLF (`\r\n`) line endings: `read_line` includes the `\r` as line
+    /// content, so after reading line N `bytes_count` is still the start
+    /// offset of line N+1. Locks that the fix is CRLF-safe.
+    #[test]
+    fn match_at_start_of_line_with_crlf() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        // "xxx\r\nTARGET\r\n"; bytes: x0 x1 x2 \r3 \n4 T5 (T = first byte of line 2)
+        write!(tmp, "xxx\r\nTARGET\r\n").unwrap();
+        tmp.flush().unwrap();
+        let pos = "xxx\r\n".len(); // 5
+        assert_eq!(pos, 5);
+        let line = line_count_at_pos(tmp.path(), pos).unwrap();
+        assert_eq!(line, 2);
+    }
 }


### PR DESCRIPTION
## Summary

When opening a file from a content-exact search (`c/<needle>`), broot reports the 1-indexed
line of the first match via `Pattern::get_match_line_count` → `ContentExactPattern::get_match_line_count`
→ `line_count_at_pos`. For the common case where the match starts at the **first byte of a
line** (right after a `\n` — code identifiers, indented tokens, list markers),
`line_count_at_pos` returned the line **above** the match, so broot jumped to the wrong line.

This is a self-found bug (discovered while reading the content-search path); I’m happy to
open a separate issue for it if the maintainer prefers to track it there. The fix is a
single comparison operator and brings the exact path into agreement with the sibling
`ContentRegexPattern::try_get_match_line_count`, which already returned the correct line.

## Changes

- **`src/content_search/mod.rs`** — `line_count_at_pos`: change the line-number predicate
  from `if bytes_count >= pos` to `if bytes_count > pos` (one character). No signature,
  return-type, or error-variant change. Plus a new `#[cfg(test)] mod line_count_at_pos_tests`
  with 7 regression tests (the file previously had no tests at all).
- **`CHANGELOG.md`** — one bullet under `### next`, credited `@YuriNachos`.

Per-file diff is intentionally minimal: production delta is exactly the one comparison
operator; everything else is the new test module.

## Why

`BufReader::read_line` reads up to **and including** the trailing `\n`, so after reading
line `N`, `bytes_count` equals the byte index where line `N+1` **begins**. The old
`bytes_count >= pos` therefore returned `line_count` (= `N`) not only when `pos` was inside
line `N`, but also when `pos` was exactly the first byte of line `N+1` — attributing a
line-start match to the line above. With `>`, the `pos == bytes_count` case falls through
to the next iteration (which increments `line_count`) and returns the correct line.

Trace, `xxx\nTARGET\nrest`, `pos = 4` (`T` = first byte of line 2):
- before (`>=`): read `xxx\n` → `bytes_count = 4` → `4 >= 4` → return **1** (wrong);
- after (`>`): read `xxx\n` → `4 > 4` false → `line_count = 2` → read `TARGET\n` → `11 > 4` → return **2** (correct).

Reachability (the function is live, not dead):
`line_count_at_pos` (`content_search/mod.rs`)
← `ContentExactPattern::get_match_line_count` (`pattern/content_pattern.rs:67`, passes `pos` from `needle.search`)
← `Pattern::get_match_line_count` (`pattern/pattern.rs:172`, `ContentExact` arm)
← `CompositePattern::get_match_line_count` (`pattern/composite_pattern.rs:253`)
← `browser/browser_state.rs:248`, where the result sets `selection.line` (the line the file opens at).

## Test

Seven new tests in `line_count_at_pos_tests` (the file previously had no tests). The first
four prove the bug; the last three lock the exact `pos == bytes_count` boundary against
future refactors (added on an independent adversarial review’s recommendation):

1. `match_at_start_of_line_returns_that_line` — `pos` at the first byte of line 2 → expects `2` (the bug).
2. `match_mid_first_line_still_returns_one` — mid-line match on line 1 → expects `1` (guards the opposite regression).
3. `match_at_start_of_deeper_line` — first byte of line 4 → expects `4` (off-by-one across multiple preceding lines).
4. `pos_past_eof_is_error` — `pos` past EOF → `Err(UnexpectedEof)` (locks the error contract).
5. `match_after_blank_line` — first byte of line 3 after a blank line → expects `3`.
6. `match_on_last_line_without_trailing_newline` — last line, no final `\n` → expects `2`.
7. `match_at_start_of_line_with_crlf` — CRLF endings, first byte of line 2 → expects `2` (CRLF-safe).

Real red-before-green, run on this branch:

- **RED** (unfixed `>=`): the five line-start tests (1, 3, 5, 6, 7) **fail**; the mid-line and EOF tests (2, 4) pass.
- **GREEN** (fixed `>`): all **7 pass**.
- **MUTATION** (revert `>`→`>=`): the same five line-start tests **fail again** — they kill the `>=` mutant, so they genuinely guard the fix.

Full gate (`cargo build --verbose && cargo test --verbose`) is green: lib unit tests
**50 passed; 0 failed** (43 prior + 7 new), integration `search_strings` 7 passed, no
regressions. `cargo check --features clipboard,kitty-csi-check` compiles. The touched file
is `rustfmt`-clean against the repo’s nightly `rustfmt.toml`. An independent 3-lens
adversarial review (logic/edge-cases, reachability/contract, diff-hygiene) unanimously
confirmed the fix correct with no blocking findings.

## AI usage

Authored with AI assistance (Claude); every line of the diff was reviewed by the author and
validated with a real red-green-mutation cycle, the full CI gate, a nightly fmt check, an
opt-in-feature compile, and an independent 3-lens adversarial review. Following the repo
norm set by PR #1183.