### PR TITLE
Fix documentation typo

### DIFF
--- a/website/src/conf_file.md
+++ b/website/src/conf_file.md
@@ -85,7 +85,7 @@ For example, if you want to see hidden files (the ones whose name starts with a 
 
     br -gh
 
-If you almost always want those flags, you may define them as default in the configuration file file, with the `default_flags` setting.
+If you almost always want those flags, you may define them as default in the configuration file, with the `default_flags` setting.
 
 ```Hjson
 default_flags: -gh


### PR DESCRIPTION
Small documentation typo noticed in the site docs:

- `website/src/conf_file.md`: "as default in the configuration file file, with" -> "... in the configuration file, with"

Documentation only; no code changes.
