### PR TITLE
fix: fall back to numeric uid/gid instead of "????"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fix: detect a duplicate broot server name instead of silently overtaking the running server - Fix #1065 - Thanks @YuriNachos
 - fix preview transformers extension matching not working with double extensions such as `.tar.gz` - Fix #1195
 - strip escape sequences from displayed names to prevent OSC injections - Fix #1188 - Thanks @carfeii
+- fall back to numeric uid/gid instead of `????` when the user or group name can't be resolved, which is always the case on statically linked musl builds - Fix #1075
 
 ### v1.58.0 - 2026-07-10
 <a name="v1.58.0"></a>

--- a/src/permissions/permissions_unix.rs
+++ b/src/permissions/permissions_unix.rs
@@ -13,8 +13,11 @@ pub fn user_name(uid: u32) -> String {
         Lazy::new(|| Mutex::new(FxHashMap::default()));
     let mut users_cache = USERS_CACHE_MUTEX.lock().unwrap();
     let name = users_cache.entry(uid).or_insert_with(|| {
+        // when the name can't be resolved (eg on statically linked musl
+        // builds, which have no NSS), we fall back to the numeric id,
+        // like `ls -n` does
         uzers::get_user_by_uid(uid).map_or_else(
-            || "????".to_string(),
+            || uid.to_string(),
             |u| u.name().to_string_lossy().to_string(),
         )
     });
@@ -26,8 +29,9 @@ pub fn group_name(gid: u32) -> String {
         Lazy::new(|| Mutex::new(FxHashMap::default()));
     let mut groups_cache = GROUPS_CACHE_MUTEX.lock().unwrap();
     let name = groups_cache.entry(gid).or_insert_with(|| {
+        // same fallback as in `user_name`
         uzers::get_group_by_gid(gid).map_or_else(
-            || "????".to_string(),
+            || gid.to_string(),
             |u| u.name().to_string_lossy().to_string(),
         )
     });


### PR DESCRIPTION
Fix #1075.

## The problem

On statically linked musl builds, every file's owner and group render as `????`:

```
????  ????   1.2K  some-file
```

`uzers::get_user_by_uid` needs NSS to map an id to a name, and a static musl binary has no NSS, so the lookup always fails. The `map_or_else` fallback in `src/permissions/permissions_unix.rs` then substitutes `"????"` for both columns, on every row, for every user.

## The fix

Fall back to the numeric id instead:

```rust
uzers::get_user_by_uid(uid).map_or_else(
    || uid.to_string(),
    |u| u.name().to_string_lossy().to_string(),
)
```

This is what `ls -n` prints, and a uid is strictly more useful than four question marks — you can at least tell two owners apart, and match against `id`.

It's a two-token change in the branch that already existed, so glibc builds are untouched: the closure only runs when resolution fails, which on glibc means the id genuinely has no passwd entry — and there, too, a number beats `????`.

## Things I checked before proposing it

- **Column alignment holds.** `src/display/permissions.rs:138-149` computes `max_user_len`/`max_group_len` by calling the same `user_name`/`group_name` functions used at render time (`:118`, `:124`), so a 5-digit uid simply widens the column. No hardcoded width anywhere.
- **Nothing depends on `"????"`.** The only other occurrence in `src/` is the size column in `trash_state_cols.rs:70`, unrelated. No test, fixture or doc asserts it for ownership.
- **The cache is unchanged in character.** Both functions memoize into a process-lifetime `FxHashMap`; it previously cached `"????"` forever and now caches the number forever. Same semantics.

## Testing

I could not build for musl here (no musl toolchain), so the fallback branch is verified by reading rather than by running on the affected platform — worth saying plainly. On this glibc host: `cargo build` clean, `cargo test` 54 + 7 passed, and `cargo clippy --all-targets` produces zero warnings mentioning `permissions_unix.rs`.

CHANGELOG entry added under `### next`.
