### PR TITLE
fix: panic on an empty content match at end of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix preview transformers extension matching not working with double extensions such as `.tar.gz` - Fix #1195
 - strip escape sequences from displayed names to prevent OSC injections - Fix #1188 - Thanks @carfeii
 - fall back to numeric uid/gid instead of `????` when the user or group name can't be resolved, which is always the case on statically linked musl builds - Fix #1075
+- fix panic on a content regex matching the empty string at the end of a line ending with a control char (eg `cr/$/` on a CRLF file)
 
 ### v1.58.0 - 2026-07-10
 <a name="v1.58.0"></a>

--- a/src/content_search/content_match.rs
+++ b/src/content_search/content_match.rs
@@ -35,7 +35,7 @@ impl ContentMatch {
             extract_start -= 1;
         }
         // left trimming
-        while (hay[extract_start] == 32) && extract_start < pos {
+        while extract_start < pos && hay[extract_start] == 32 {
             extract_start += 1;
         }
         loop {
@@ -57,5 +57,47 @@ impl ContentMatch {
             needle_start,
             needle_end: needle_start + needle.len(),
         }
+    }
+}
+
+#[cfg(test)]
+mod content_match_tests {
+    use super::*;
+
+    /// Regression: an empty match at the very end of a line (eg searching
+    /// `cr/$/` in a file whose line ends with a control char, such as a tab
+    /// or the `\r` of a CRLF line ending) gives `pos == hay.len()`. The left
+    /// trimming loop used to read `hay[extract_start]` before checking
+    /// `extract_start < pos`, panicking with "index out of bounds".
+    #[test]
+    fn empty_match_at_end_of_line_doesnt_panic() {
+        // line ending with a tab: the extract_start loop stops on the control
+        // char, leaving extract_start == pos == hay.len()
+        let m = ContentMatch::build(b"abc\t", 4, "", 30);
+        assert_eq!(m.extract, "");
+        assert_eq!(m.needle_start, 0);
+        assert_eq!(m.needle_end, 0);
+        // same with the `\r` of a CRLF line ending
+        let m = ContentMatch::build(b"hello\r", 6, "", 30);
+        assert_eq!(m.extract, "");
+    }
+
+    /// The left trimming must still drop the spaces before the needle.
+    #[test]
+    fn left_trimming_still_drops_leading_spaces() {
+        let m = ContentMatch::build(b"\t   needle here", 7, "needle", 30);
+        assert_eq!(m.extract, "needle here");
+        assert_eq!(m.needle_start, 0);
+        assert_eq!(m.needle_end, 6);
+    }
+
+    /// Trimming must not eat the needle itself when the needle starts with a
+    /// space: it stops at `pos`.
+    #[test]
+    fn left_trimming_stops_at_needle() {
+        // bytes: \t=0 ' '=1 ' '=2 'a'=3 ' '=4 'x'=5, needle " a" at pos 2
+        let m = ContentMatch::build(b"\t  a x", 2, " a", 30);
+        assert_eq!(m.extract, " a x");
+        assert_eq!(m.needle_start, 0);
     }
 }


### PR DESCRIPTION
Searching `cr/$/` in a directory containing a file with CRLF line endings kills broot.

`/tmp/brepro2` with `crlf.txt` (`hello\r\nworld\r\n`) and `tabend.txt` (`abc\t\n`), driven through the real TUI under tmux, typing `cr/$/`:

```
before:  EXIT=101
         panicked at src/content_search/content_match.rs:38:16:
         index out of bounds: the len is 4 but the index is 4

after:   no panic, session still alive, filter applied normally
```

## Cause

The left-trimming loop tests the two conditions in the wrong order:

```rust
while (hay[extract_start] == 32) && extract_start < pos {
```

`hay[extract_start]` is evaluated before the bound is checked. An empty match at the very end of a line gives `pos == hay.len()`, so the index read is out of range. `$` on a line ending in a control character (the `\r` of CRLF, or a trailing tab) is a natural way to produce that.

## The fix

Swap the two operands so the bound is checked first. That is the whole change; `&&` short-circuits, so nothing else needs to move.

## Verification

Three tests in `content_match.rs`: the empty-match-at-end regression, plus two that pin the existing trimming behaviour (leading spaces are still dropped, and trimming still stops at the needle) so the reorder cannot quietly change what the function does.

Reverting only the condition order fails the regression test with the original panic:

```
test empty_match_at_end_of_line_doesnt_panic ... FAILED
panicked at src/content_search/content_match.rs:38:16:
index out of bounds: the len is 4 but the index is 4
```

`cargo test` is 59 + 7 passed, `cargo clippy --all-targets` is clean. `cargo fmt --check` reports pre-existing diffs elsewhere in the repo (rustfmt.toml uses nightly-only options), but none in the file I touched.

*Disclosure: written with AI assistance (Claude Code). I reproduced the panic in a real terminal against a binary built from master, confirmed it is gone on the fixed binary, and ran the mutation check myself.*
