### PR TITLE
fix: a single quote in a path produces an invalid shell command

### DIFF
--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -481,7 +481,7 @@ impl<'b> ExecutionBuilder<'b> {
         }
         // first we replace single quotes by `'"'"'` (close the single quote, add an escaped
         // single quote, and reopen the single quote)
-        let s = s.replace('\'', r#"'"'"#);
+        let s = s.replace('\'', r#"'"'"'"#);
         // then we wrap the whole thing in single quotes
         let s = format!("'{}'", s);
         s
@@ -594,5 +594,24 @@ mod execution_builder_test {
             vec![],
             vec!["xterm", "-e", "kak /path/to/file"],
         );
+    }
+
+    /// A path containing a single quote must be escaped so that the produced
+    /// shell command stays valid (this is what's written in the `--outcmd`
+    /// file, eg on `:cd`)
+    #[test]
+    fn test_shell_escaping_of_single_quote() {
+        let path = PathBuf::from("/home/dys/it's a dir");
+        let sel = Selection {
+            path: &path,
+            line: 0,
+            stype: SelectionType::Directory,
+            is_exe: false,
+        };
+        let app_state = AppState::new(PathBuf::from("/".to_owned()));
+        let mut builder = ExecutionBuilder::without_invocation(SelInfo::One(sel), &app_state);
+        let con = AppContext::default();
+        let exec_string = builder.shell_exec_string(&ExecPattern::from_string("cd {file}"), &con);
+        assert_eq!(exec_string, r#"cd '/home/dys/it'"'"'s a dir'"#);
     }
 }


### PR DESCRIPTION
A path containing a single quote produces a shell command with unbalanced
quotes, so `:cd` and every shell-targeted verb fail on it.

Directory `/tmp/brq/it's a dir`, driven in a real terminal under tmux, pressing
`:cd`:

```
before:  Hit enter to cd: cd '/tmp/brq/it'"'s a dir'
after:   Hit enter to cd: cd '/tmp/brq/it'"'"'s a dir'
```

Feeding each of those to a shell:

```
before:
bash: -c: line 1: unexpected EOF while looking for matching `"'

after:
/tmp/brq/it's a dir
```

Since that string is what `br` evaluates from the `--outcmd` file, the `cd` never
happens.

## Cause

`path_to_string` emits three characters where four are needed:

```rust
// first we replace single quotes by `'"'"'` (close the single quote, add an escaped
// single quote, and reopen the single quote)
let s = s.replace('\'', r#"'"'"#);
```

The comment directly above states the intended sequence, `'"'"'`, and the code
produces `'"'`. The reopening quote is missing, so everything after the
apostrophe stays inside a double-quoted string that is never closed.

## The fix

One character sequence, making the code do what its own comment says. This
affects the `--outcmd` file used by `:cd`, external verbs, and `terminal_title`.

## Verification

`test_shell_escaping_of_single_quote` asserts the produced command for a path
containing an apostrophe.

Reverting the escape sequence fails it:

```
assertion `left == right` failed
  left: "cd '/home/dys/it'\"'s a dir'"
 right: "cd '/home/dys/it'\"'\"'s a dir'"
```

The test uses `{file}` rather than `{directory}`, because `{directory}` resolves
through `closest_dir` against the real filesystem and would not survive a
synthetic path.

`cargo test` is 60 + 7 passed, 0 failed.

`cargo fmt --check` reports pre-existing diffs across the repo, since
`rustfmt.toml` uses nightly-only options and the toolchain here is stable 1.97.1.
My code matches the surrounding style and adds no new diff beyond that baseline.

*Disclosure: written with AI assistance (Claude Code). The before and after come from driving two binaries in a real terminal under tmux, and I confirmed the shell failure by evaluating both commands. I ran the mutation check myself.*
