### PR TITLE
Add a shell attribute to run external verbs through a shell (#1145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### next
+- new `shell_command` verb attribute: run a command through a shell (`sh -c` / `cmd /C`) so `&&`, `;` and pipes work, without leaving broot - Fix #1145
 - fix invalid official Mac binary (duplicate linked dylib) with new build chain - Fix #1194
 - Sixel graphics support for image preview, auto-detected: works in iterm2, Windows Terminal 1.22+ and Sixel-capable Unix terminals (foot, mlterm, xterm built with Sixel, recent WezTerm). Kitty remains the preferred protocol when available - Fix #568 - Thanks @jamison-wilde
 - High-Res images in Rio terminal (detect it to enable the Kitty image protocol) - Fix #1179

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -834,7 +834,10 @@ pub trait PanelState {
                 cc,
             ),
             VerbExecution::External(external) => {
-                self.execute_external(w, verb, external, invocation, app_state, cc)
+                self.execute_external(w, verb, external, false, invocation, app_state, cc)
+            }
+            VerbExecution::ShellCommand(external) => {
+                self.execute_external(w, verb, external, true, invocation, app_state, cc)
             }
             VerbExecution::Sequence(seq_ex) => {
                 self.execute_sequence(w, verb, seq_ex, invocation, app_state, cc)
@@ -857,11 +860,13 @@ pub trait PanelState {
         res
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn execute_external(
         &mut self,
         w: &mut W,
         verb: &Verb,
         external_execution: &ExternalExecution,
+        through_shell: bool,
         invocation: Option<&VerbInvocation>,
         app_state: &mut AppState,
         cc: &CmdContext,
@@ -884,7 +889,7 @@ pub trait PanelState {
                 None
             },
         );
-        external_execution.to_cmd_result(w, exec_builder, cc.app.con)
+        external_execution.to_cmd_result(w, exec_builder, through_shell, cc.app.con)
     }
 
     fn execute_sequence(
@@ -1199,7 +1204,9 @@ pub trait PanelState {
         app_state: &AppState,
     ) -> Status {
         if sel_info.count_paths() > 1 {
-            if let VerbExecution::External(external) = &verb.execution {
+            if let VerbExecution::External(external) | VerbExecution::ShellCommand(external) =
+                &verb.execution
+            {
                 if external.exec_mode != ExternalExecutionMode::StayInBroot {
                     let coarity = external.exec_pattern.coarity();
                     info!("coarity of the command is {coarity:?}");

--- a/src/conf/verb_conf.rs
+++ b/src/conf/verb_conf.rs
@@ -21,6 +21,10 @@ pub struct VerbConf {
 
     pub external: Option<ExecPattern>,
 
+    /// like `external` but the command line is run through a shell
+    /// (`sh -c` / `cmd /C`) so that `&&`, `;`, pipes, etc. work
+    pub shell_command: Option<ExecPattern>,
+
     pub execution: Option<ExecPattern>,
 
     pub cmd: Option<String>,

--- a/src/launchable.rs
+++ b/src/launchable.rs
@@ -151,6 +151,31 @@ impl Launchable {
         }
     }
 
+    /// Create a launchable running the given command line through a shell, so that
+    /// shell features like `&&`, `;`, pipes and redirections work.
+    ///
+    /// The command is passed untouched to `sh -c` (or `cmd /C` on Windows), which is
+    /// why env variables aren't resolved here: the shell handles them.
+    pub fn shell_program(
+        command: String,
+        working_dir: Option<PathBuf>,
+        switch_terminal: bool,
+        con: &AppContext,
+    ) -> Launchable {
+        #[cfg(windows)]
+        let (exe, flag) = ("cmd".to_string(), "/C".to_string());
+        #[cfg(not(windows))]
+        let (exe, flag) = ("sh".to_string(), "-c".to_string());
+        Launchable::Program {
+            exe,
+            args: vec![flag, command],
+            working_dir,
+            switch_terminal,
+            capture_mouse: con.capture_mouse,
+            keyboard_enhanced: con.keyboard_enhanced,
+        }
+    }
+
     /// Execute the launchable, writing on the given writer if needed (for the tree printer).
     pub fn execute(
         &self,

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -599,6 +599,20 @@ mod execution_builder_test {
     }
 
     #[test]
+    fn test_shell_exec_string_keeps_chained_command() {
+        // a command with `&&` must survive tokenizing untouched so it can be
+        // handed to `sh -c` when the verb is a `shell_command` (issue #1145)
+        let app_state = AppState::new(PathBuf::from("/"));
+        let mut builder = ExecutionBuilder::without_invocation(SelInfo::None, &app_state);
+        let con = AppContext::default();
+        let ep = ExecPattern::from_string("mkdir foo && touch foo/bar");
+        assert_eq!(
+            builder.shell_exec_string(&ep, &con),
+            "mkdir foo && touch foo/bar",
+        );
+    }
+
+    #[test]
     fn test_path_to_string_quoting() {
         let app_state = AppState::new(PathBuf::from("/"));
         let mut builder = ExecutionBuilder::without_invocation(SelInfo::None, &app_state);

--- a/src/verb/external_execution.rs
+++ b/src/verb/external_execution.rs
@@ -73,20 +73,79 @@ impl ExternalExecution {
     /// goes from the external execution command to the CmdResult:
     /// - by executing the command if it can be executed from a subprocess
     /// - by building a command to be executed in parent shell in other cases
+    ///
+    /// When `through_shell` is set (which is the case for `shell_command`
+    /// verbs) the command line is run through a shell instead of being
+    /// exec'd as a single program, so that `&&`, `;`, pipes, etc. work.
     pub fn to_cmd_result(
         &self,
         w: &mut W,
         builder: ExecutionBuilder<'_>,
+        through_shell: bool,
         con: &AppContext,
     ) -> Result<CmdResult, ProgramError> {
         match self.exec_mode {
             ExternalExecutionMode::FromParentShell => {
                 self.cmd_result_exec_from_parent_shell(builder, con)
             }
-            ExternalExecutionMode::LeaveBroot => self.cmd_result_exec_leave_broot(builder, con),
-            ExternalExecutionMode::StayInBroot => {
-                self.cmd_result_exec_stay_in_broot(w, builder, con)
+            ExternalExecutionMode::LeaveBroot => {
+                self.cmd_result_exec_leave_broot(builder, through_shell, con)
             }
+            ExternalExecutionMode::StayInBroot => {
+                self.cmd_result_exec_stay_in_broot(w, builder, through_shell, con)
+            }
+        }
+    }
+
+    /// build a launchable for the whole (possibly merged) selection
+    fn merged_launchable(
+        &self,
+        builder: &mut ExecutionBuilder<'_>,
+        working_dir: Option<PathBuf>,
+        through_shell: bool,
+        con: &AppContext,
+    ) -> Result<Launchable, ProgramError> {
+        if through_shell {
+            Ok(Launchable::shell_program(
+                builder.shell_exec_string(&self.exec_pattern, con),
+                working_dir,
+                self.switch_terminal,
+                con,
+            ))
+        } else {
+            Ok(Launchable::program(
+                builder.exec_token(&self.exec_pattern, con),
+                working_dir,
+                self.switch_terminal,
+                con,
+            )?)
+        }
+    }
+
+    /// build a launchable for a single selection (used when executing once
+    /// per selection of a stage)
+    fn sel_launchable(
+        &self,
+        builder: &mut ExecutionBuilder<'_>,
+        sel: Option<Selection<'_>>,
+        working_dir: Option<PathBuf>,
+        through_shell: bool,
+        con: &AppContext,
+    ) -> Result<Launchable, ProgramError> {
+        if through_shell {
+            Ok(Launchable::shell_program(
+                builder.sel_shell_exec_string(&self.exec_pattern, sel, con),
+                working_dir,
+                self.switch_terminal,
+                con,
+            ))
+        } else {
+            Ok(Launchable::program(
+                builder.sel_exec_token(&self.exec_pattern, sel, con),
+                working_dir,
+                self.switch_terminal,
+                con,
+            )?)
         }
     }
 
@@ -139,7 +198,8 @@ impl ExternalExecution {
     /// launched by broot at end of broot
     fn cmd_result_exec_leave_broot(
         &self,
-        builder: ExecutionBuilder<'_>,
+        mut builder: ExecutionBuilder<'_>,
+        through_shell: bool,
         con: &AppContext,
     ) -> Result<CmdResult, ProgramError> {
         if builder.sel_info.count_paths() > 1 {
@@ -147,12 +207,8 @@ impl ExternalExecution {
                 return Ok(CmdResult::error(MULTI_SELECTION_ERROR));
             }
         }
-        let launchable = Launchable::program(
-            builder.exec_token(&self.exec_pattern, con),
-            self.working_dir_path(&builder, con),
-            self.switch_terminal,
-            con,
-        )?;
+        let working_dir = self.working_dir_path(&builder, con);
+        let launchable = self.merged_launchable(&mut builder, working_dir, through_shell, con)?;
         Ok(CmdResult::from(launchable))
     }
 
@@ -162,18 +218,15 @@ impl ExternalExecution {
         &self,
         w: &mut W,
         mut builder: ExecutionBuilder<'_>,
+        through_shell: bool,
         con: &AppContext,
     ) -> Result<CmdResult, ProgramError> {
         let working_dir_path = self.working_dir_path(&builder, con);
         match &builder.sel_info {
             SelInfo::None | SelInfo::One(_) => {
                 // zero or one selection -> only one execution
-                let launchable = Launchable::program(
-                    builder.exec_token(&self.exec_pattern, con),
-                    working_dir_path,
-                    self.switch_terminal,
-                    con,
-                )?;
+                let launchable =
+                    self.merged_launchable(&mut builder, working_dir_path, through_shell, con)?;
                 info!("Executing not leaving, launchable {:#?}", launchable);
                 if let Err(e) = launchable.execute(Some(w)) {
                     warn!("launchable failed : {:#?}", e);
@@ -195,10 +248,11 @@ impl ExternalExecution {
                         });
                         let n = sels.len();
                         for (i, sel) in sels.enumerate() {
-                            let launchable = Launchable::program(
-                                builder.sel_exec_token(&self.exec_pattern, Some(sel), con),
+                            let launchable = self.sel_launchable(
+                                &mut builder,
+                                Some(sel),
                                 working_dir_path.clone(),
-                                self.switch_terminal,
+                                through_shell,
                                 con,
                             )?;
                             let i = i + 1;
@@ -211,10 +265,10 @@ impl ExternalExecution {
                     }
                     CommandCoarity::Merged => {
                         // we execute once as the arguments are merging the selection
-                        let launchable = Launchable::program(
-                            builder.exec_token(&self.exec_pattern, con),
+                        let launchable = self.merged_launchable(
+                            &mut builder,
                             working_dir_path.clone(),
-                            self.switch_terminal,
+                            through_shell,
                             con,
                         )?;
                         info!("Executing not leaving, merged launchable {:#?}", launchable);

--- a/src/verb/verb.rs
+++ b/src/verb/verb.rs
@@ -105,7 +105,7 @@ impl Verb {
         }
         let (needs_selection, needs_another_panel) = match &execution {
             VerbExecution::Internal(ie) => (ie.needs_selection(), false),
-            VerbExecution::External(ee) => (
+            VerbExecution::External(ee) | VerbExecution::ShellCommand(ee) => (
                 ee.exec_pattern.has_selection_group(),
                 ee.exec_pattern.has_other_panel_group(),
             ),
@@ -284,7 +284,9 @@ impl Verb {
             // We can't determine before execution what will be the arguments, except
             // for the first item of the sequence. It's cleaner to just not try expand it
             format!("Hit *enter* to **{}**: `{}`", name, seq_ex.sequence.raw)
-        } else if let VerbExecution::External(external_exec) = &self.execution {
+        } else if let VerbExecution::External(external_exec)
+        | VerbExecution::ShellCommand(external_exec) = &self.execution
+        {
             let exec_desc = builder().shell_exec_string(&external_exec.exec_pattern, con);
             format!("Hit *enter* to **{}**: `{}`", name, exec_desc)
         } else if self.description.code {

--- a/src/verb/verb_execution.rs
+++ b/src/verb/verb_execution.rs
@@ -14,6 +14,11 @@ pub enum VerbExecution {
     /// outside of broot.
     External(ExternalExecution),
 
+    /// like `External` but the command line is run through a shell (`sh -c` /
+    /// `cmd /C`) instead of executing a single program, so that shell features
+    /// like `&&`, `;`, pipes and redirections work.
+    ShellCommand(ExternalExecution),
+
     /// the execution is a sequence similar to what can be given
     /// to broot with --cmd
     Sequence(SequenceExecution),
@@ -27,7 +32,7 @@ impl fmt::Display for VerbExecution {
     ) -> fmt::Result {
         match self {
             Self::Internal(ie) => ie.fmt(f),
-            Self::External(ee) => ee.exec_pattern.fmt(f),
+            Self::External(ee) | Self::ShellCommand(ee) => ee.exec_pattern.fmt(f),
             Self::Sequence(se) => se.sequence.raw.fmt(f),
         }
     }

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -459,6 +459,7 @@ impl VerbStore {
         let invocation = vc.invocation.clone().filter(|i| !i.is_empty());
         let internal = vc.internal.as_ref().filter(|i| !i.is_empty());
         let external = vc.external.as_ref().filter(|i| !i.is_empty());
+        let shell_command = vc.shell_command.as_ref().filter(|i| !i.is_empty());
         let cmd = vc.cmd.as_ref().filter(|i| !i.is_empty());
         let cmd_separator = vc.cmd_separator.as_ref().filter(|i| !i.is_empty());
         let execution = vc.execution.as_ref().filter(|i| !i.is_empty());
@@ -479,10 +480,10 @@ impl VerbStore {
             }
             external_execution
         };
-        let mut execution = match (execution, internal, external, cmd) {
+        let mut execution = match (execution, internal, external, shell_command, cmd) {
             // old definition with "execution": we guess whether it's an internal or
             // an external
-            (Some(ep), None, None, None) => {
+            (Some(ep), None, None, None, None) => {
                 if let Some(internal_pattern) = ep.to_internal_pattern() {
                     if let Some(previous_verb) =
                         self.verbs.iter().find(|&v| v.has_name(&internal_pattern))
@@ -496,7 +497,7 @@ impl VerbStore {
                 }
             }
             // "internal": the leading `:` or ` ` is optional
-            (None, Some(s), None, None) => {
+            (None, Some(s), None, None, None) => {
                 VerbExecution::Internal(if s.starts_with(':') || s.starts_with(' ') {
                     InternalExecution::try_from(&s[1..])?
                 } else {
@@ -504,11 +505,15 @@ impl VerbStore {
                 })
             }
             // "external": it can be about any form
-            (None, None, Some(ep), None) => {
+            (None, None, Some(ep), None, None) => {
                 VerbExecution::External(make_external_execution(ep.clone()))
             }
+            // "shell_command": like "external" but run through a shell
+            (None, None, None, Some(ep), None) => {
+                VerbExecution::ShellCommand(make_external_execution(ep.clone()))
+            }
             // "cmd": it's a sequence
-            (None, None, None, Some(s)) => VerbExecution::Sequence(SequenceExecution {
+            (None, None, None, None, Some(s)) => VerbExecution::Sequence(SequenceExecution {
                 sequence: Sequence::new(s, cmd_separator),
             }),
             _ => {
@@ -521,7 +526,9 @@ impl VerbStore {
             }
         };
         if let Some(refresh_after) = vc.refresh_after {
-            if let VerbExecution::External(external_execution) = &mut execution {
+            if let VerbExecution::External(external_execution)
+            | VerbExecution::ShellCommand(external_execution) = &mut execution
+            {
                 external_execution.refresh_after = refresh_after;
             } else {
                 warn!("refresh_after is only relevant for external commands");

--- a/website/src/conf_verbs.md
+++ b/website/src/conf_verbs.md
@@ -45,11 +45,12 @@ keys | | several keyboard shortcuts triggering execution (if you want to have th
 leave_broot | `true` | whether to quit broot on execution
 panels | *all* | optional list of panel types in which the verb can be called. Default is all panels: `[tree, fs, preview, help, stage]`
 set_working_dir | `false` | whether the working dir of the process must be set to the currently selected directory (it's equivalent to `workding_dir: "{directory}"`)
+shell_command | | execution through a shell (`sh -c` / `cmd /C`), so that operators like `&&`, `;` and pipes work (alternative to `external`)
 shortcut | | an alternate way to call the verb (without the arguments part)
 switch_terminal | `true` | whether to switch from alternate to normal terminal during execution
 working_dir | | the working directory of the external application, for example `"{directory}"` for the closest directory (the working dir isn't set if the directory doesn't exist)
 
-The execution is defined either by `internal`, `external` or `cmd` so a verb must have exactly one of those (for compatibility with older versions broot still accepts `execution` for `internal` or `external` and guesses which one it is).
+The execution is defined either by `internal`, `external`, `shell_command` or `cmd` so a verb must have exactly one of those (for compatibility with older versions broot still accepts `execution` for `internal` or `external` and guesses which one it is).
 
 **Note:**
 The `from_shell` attribute exists because some actions can't possibly be useful from a subshell. For example, `cd` is a shell builtin which must be executed in the parent shell.
@@ -59,6 +60,28 @@ The `from_shell` attribute exists because some actions can't possibly be useful 
 If you set `leave_broot = false`, broot won't quit when executing your command, but it will update the tree.
 
 This is useful for commands modifying the tree (like creating or moving files), or when you want to be back to broot after execution.
+
+# Chaining commands
+
+An `external` is run as a single program, so shell operators like `&&`, `;` or pipes are passed as plain arguments and don't do what you'd expect.
+
+Use `shell_command` instead of `external` to run the command line through a shell (`sh -c` on unix, `cmd /C` on Windows). This lets you chain commands:
+
+```hjson
+{
+    invocation: "mkfile {name}"
+    shell_command: "mkdir -p {directory}/foo && touch {directory}/foo/{name}"
+    leave_broot: false
+}
+```
+```toml
+[[verbs]]
+invocation = "mkfile {name}"
+shell_command = "mkdir -p {directory}/foo && touch {directory}/foo/{name}"
+leave_broot = false
+```
+
+Placeholders such as `{directory}` and `{file}` are still filled in by broot (and paths with special characters are quoted for the shell) before the line reaches the shell.
 
 # Call shell scripts
 


### PR DESCRIPTION
Adds a `shell` attribute for external verbs so a command can chain with `&&`, `;` or pipes without leaving broot, closing the gap in #1145.

Right now an `external` is tokenized and run as a single program via `Command::new`, so `mkdir foo && touch foo/bar` just passes `&&` as an argument to `mkdir`. The docs already show `&&` working, but only with `from_shell: true`, which needs the `br` function and quits broot. There was no way to chain when you want `leave_broot: false`.

With `shell: true` broot builds the command line the same way it does for the parent-shell case (placeholders filled, paths quoted) and hands it to `sh -c` on unix or `cmd /C` on Windows. Env vars are left for the shell to expand. Without the flag nothing changes, so existing verbs run byte-for-byte as before.

Example:

```hjson
{
    invocation: "mkfile {name}"
    external: "mkdir -p {directory}/foo && touch {directory}/foo/{name}"
    shell: true
    leave_broot: false
}
```

I added a `Launchable::shell_program` constructor, a `shell` field on `ExternalExecution` (default false), wired it through `VerbConf`/`verb_store`, and branched the three exec paths (leave-broot, stay-in-broot single, and per-selection/merged multi-selection). Docs get a new table row plus a "Chaining commands" section, and there's a changelog entry.

Executing through a real shell is hard to unit-test, so the added test covers the parse/build path — it asserts that a command with `&&` survives tokenizing and re-joining into the exact string that gets handed to `sh -c`. `cargo test` is green (147 passed). Formatting matches the tree (checked with nightly rustfmt, which the repo's `rustfmt.toml` targets) and clippy shows no new warnings on the touched code.

I picked an explicit opt-in over auto-detecting operators or the array/semicolon syntaxes floated in the issue, to keep it backward-compatible and predictable, but happy to switch to whatever spelling you prefer.
