### PR TITLE
Replace libgit2 with gix, making broot pure rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - git status: an untracked directory gets the `N` mark too
 - the status line shows how many commits the branch is ahead (`↑`) or behind (`↓`) its upstream
 - `{git-root}` and `{git-name}` now work when the selection is a file
+- alt-g toggles the git status filter (`:toggle_git_status`)
+- `-gg` shows only the files with a git status (same as `--git-status`), `-G` removes one level of git information
+- tab and shift-tab go to the next/previous file with a git status, when git statuses are displayed
 
 <a name="v1.59.0"></a>
 ### v1.59.0 - 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ A unified diff preview is now the default preview of a file with a git change (m
 - git status: an untracked directory gets the `N` mark too
 - the status line shows how many commits the branch is ahead (`↑`) or behind (`↓`) its upstream
 - `{git-root}` and `{git-name}` now work when the selection is a file
-- alt-g toggles the git status filter (`:toggle_git_status`)
+- alt-g toggles the git status filter (`:toggle_git_status`). Status line suggests using it in git repo.
 - `-gg` shows only the files with a git status (same as `--git-status`), `-G` removes one level of git information
 
 <a name="v1.59.0"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 ### next
-- git status now computed with gix (pure Rust) instead of libgit2: no more C dependency, faster on big repositories
+#### Major Feature: git diff preview, and many git related enhancements
+The `libgit2` library has been replaced by `gix`. With this change, broot becomes pure Rust, which simplifies compilation (no C compiler needed anymore).
+A unified diff preview is now the default preview of a file with a git change (modified, staged, added, renamed or in conflict) when git statuses are displayed. `:preview_diff` shows it for any file.
+- tab and shift-tab navigate between git-interesting files and diff chunks just like for content search matches
+- ctrl-→ opens the file at the selected chunk, and ctrl-← brings you back to the diff
+- new skin entries: `diff_added`, `diff_removed`, `diff_line_number`
 - in detached HEAD state, the status line shows the short commit id instead of `HEAD`
 - git status: staged files are shown (`A` added, `S` staged modification, `R` renamed); new `git_status_staged` skin entry
-- git status of a subdirectory of a big repository is computed on that subdirectory only, which is much faster
+- git status of a subdirectory of a big repository is computed on that subdirectory only, which is faster
 - git status: an untracked directory gets the `N` mark too
 - the status line shows how many commits the branch is ahead (`↑`) or behind (`↓`) its upstream
 - `{git-root}` and `{git-name}` now work when the selection is a file
 - alt-g toggles the git status filter (`:toggle_git_status`)
 - `-gg` shows only the files with a git status (same as `--git-status`), `-G` removes one level of git information
-- tab and shift-tab go to the next/previous file with a git status, when git statuses are displayed
 
 <a name="v1.59.0"></a>
 ### v1.59.0 - 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### next
+- git status now computed with gix (pure Rust) instead of libgit2: no more C dependency, faster on big repositories
+- in detached HEAD state, the status line shows the short commit id instead of `HEAD`
+- git status: staged files are shown (`A` added, `S` staged modification, `R` renamed); new `git_status_staged` skin entry
+- git status of a subdirectory of a big repository is computed on that subdirectory only, which is much faster
+- git status: an untracked directory gets the `N` mark too
+- the status line shows how many commits the branch is ahead (`↑`) or behind (`↓`) its upstream
+- `{git-root}` and `{git-name}` now work when the selection is a file
+
 <a name="v1.59.0"></a>
 ### v1.59.0 - 2026-08-22
 - new `shell_command` verb attribute: run a command through a shell (`sh -c` / `cmd /C`) so `&&`, `;` and pipes work, without leaving broot - Fix #1145

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ A unified diff preview is now the default preview of a file with a git change (m
 - `{git-root}` and `{git-name}` now work when the selection is a file
 - alt-g toggles the git status filter (`:toggle_git_status`). Status line suggests using it in git repo.
 - `-gg` shows only the files with a git status (same as `--git-status`), `-G` removes one level of git information
+- the Kitty keyboard protocol is now used by default when the terminal supports it, which notably makes `alt` combinations work on macOS terminals; multi-key combinations without modifier still need `enable_kitty_keyboard: true`
 
 <a name="v1.59.0"></a>
 ### v1.59.0 - 2026-08-22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,6 @@ dependencies = [
  "qoi",
  "ravif",
  "rayon",
- "rgb",
  "tiff",
  "zune-core 0.5.3",
  "zune-jpeg 0.5.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -123,6 +123,15 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -324,6 +333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +370,7 @@ dependencies = [
  "file-size",
  "flate2",
  "flex-grow",
- "git2",
+ "gix",
  "glassbench",
  "glob",
  "icy_sixel",
@@ -446,10 +464,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -482,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -611,6 +641,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +694,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -806,6 +854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,10 +912,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8a51dd197fa6ba5b4dc98a990a43cc13693c23eb0089ebb0fcc1f04152bca6"
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "deranged"
@@ -897,6 +1000,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d49a923edd92dc1ca5819822f540ea83f094ab5ac6940e4044e03c1d8e6576"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -961,10 +1074,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equator"
@@ -999,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1061,6 +1189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1224,16 @@ name = "file-size"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9544f10105d33957765016b8a9baea7e689bf1f0f2f32c2fa2f568770c38d2b3"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1207,6 +1355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1433,817 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.87.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdefc1465d8631807deaf504dacdeff628b978de515653b47976ca7c28ab2a7a"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-note",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-quote",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-stream",
+ "gix-zlib",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37efa99929ac62f980fb1a7dcd09dea85b3aa6ead6ba0498362add3f4e698de"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b83782ac69ae28921a6e8fbcf2e24069613f1518030b97ae622b079abffa54"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "smallvec",
+ "thiserror 2.0.20",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17013c7ef5cb95ebb4bf4978201e6a8a42ffea9d666fd5388f1b7e742307d80"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e32f938b3745ac93d73bc7490b6a15a661b2fc81973bfe90e275cc53c908e1"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d96b8e8423ce2665232bda1b682a62541f07ab801ffad69a034ef962bed3244"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b93c9fb1f5be01bba54a7a3b7455d359efc68555539c75ef74b8021bb6db497"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f973c28c0a4871a7926fc90c8377d4458fd6cbb19692f56582b4d2022313ae90"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.20",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6af5321bfd3711a279d6b244d58532ba1cfabf9eb6374791f19929d8970082"
+dependencies = [
+ "bitflags 2.13.1",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d9aa18f29facd571c8953e66224ee0075b9e16622024794555ed4acceea85"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.67.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1689ff5ddeee4acfb2a43e875a1072a76d208624b15a9065c938b39cb0da2a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8342d5eb0ea054ed6ef807e628e38f06dd51eceeec9529767d8b23e33eff9c09"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec32a30ec2934735599c2545f30067e80bd255fd3454b52a5d59bc02b52874a3"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73b2794a6a746953c24d4ed51e4d408b83d8d599ed4e5c39a47736d75687cf0"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c0e59d9d253dcccc38c3a46b91bfb9b46bd63eed54fe1a719e12194884d52a"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c30b28d957e2e6f1e1bbfbfd26b8e0bb0aab68d8a5e730fb4fd3049943575e3"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcfa9fd253f25350a3b21b3dd74034a446098e373c6123d4cee3519894f12ef"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b417cf515fd8c91468b578071f76d6cba716f8a1eccd853906bff4908b2c1413"
+dependencies = [
+ "bitflags 2.13.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b9c423a54f0821064b954b5a5ab25c660812f6a91da03c3f1cb4b10762aa5"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78fccd6fea3bcf0b39c076bae60ae49b08daaf538b950202101a981f9d3c01d3"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.17.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65859a2f7de5e159d4344a5486ebf53b6bac22d5ec6afa836e47c10ae88a7f0f"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c91d8cffac8849493a82233811bd02b2b183b8cf39bf704de0fa0841b737595"
+dependencies = [
+ "bstr",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632e16cb48b0e88a747e106924cb2765194105d8070a7a961b0d080ed806c632"
+dependencies = [
+ "bitflags 2.13.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.17.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix 1.1.4",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-lock"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-macros"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3836b4b051393464a753c5a08fe19c7ce0d8b77574a92bd558972941d4553cb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "gix-note"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af6bbdb3f3c62b4920407c479af1cc0beb27fd75a762782d48baed53d330958"
+dependencies = [
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.64.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56fef799ca40cdeab4de5a3e74a696d8fa9b9c6264592646bf022e026f13ce2c"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-command",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.84.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf45d195b71cb6363886e7b466821bf4dffd7aba1b6b814ff75488e0061d72a7"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "gix-zlib",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d199d515cbdcf05f531f3859be9771fc12acac7b7fe0f5b581b2c1ab1c3a61e"
+dependencies = [
+ "clru",
+ "crossbeam-deque",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-zlib",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.20",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "792bd92bea390087e6223b18d4d023decc36467de31e6b066b69b94beea1b9e2"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92e44c63ba53bb55aa88ee48847664beae9446417621582fb14dfc69b2f8c72"
+dependencies = [
+ "bitflags 2.13.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68878c37ae168b474c762d70adc8a8e0f9323ed0d80444a672e2eb561fa16691"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-macros",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "nonempty",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74795eb76eab8313063849f9cbd2bbcdc6e4692f71c1d7d0244ab11cd777329"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.67.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8328387e7ab354e1dc3afb63e6b4d1866f82d7ce035222bc9d5baaf36bc88020"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de280d46e8fd9e4d3e7e2ab4276b965e377ba68b2b9a8fce56371015e8bb059"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577b864c3e134697e91564553e43230c2e401bb1bcc51cfa998edca21c95078"
+dependencies = [
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248823eefe405e2c0754b74f6f43ab6faab68670cdbf2d6e114cb0471f766450"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
+dependencies = [
+ "bitflags 2.13.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecc9f4b40537043e4bbd7d3d1760e74fb8e7b07a546166b558acaa73ad97f4a"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1401d871c01d82add5a9f654439b00722d0c632b332cd2cb63193f94327c8458"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.20",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da85564d6725c483b8d95d7b31d1db0b78c29e462a2b481949e2f18e1ed55a6a"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b675b920bd5a61d17ad542772f03ec34c60feb8ff683e1560c03ae967363731e"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
+
+[[package]]
+name = "gix-transport"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1295b6ada647b5b4ac6eb123d95a82ee80aef11a7d9db6ea9cb38dcbd411362"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af3503668739f4de5dba57fe15cfd9adc443b08bcbbf195e5de16b648872245"
+dependencies = [
+ "bitflags 2.13.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bda80ccb4bc81fb9fb07a975916eb0c7a889bcbcb0c8a239c3f82a9cc2abdda"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-utils",
+ "percent-encoding",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "getrandom 0.4.3",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed36b627476e2072c129900a17c977a38052b5497e27308159bc881fbf4eecf"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5ec0ccbab39c9994656ea031ded8ffd90b370a3cc8e360fbe3c4ebe7c64964"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-zlib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c"
+dependencies = [
+ "thiserror 2.0.20",
+ "zlib-rs",
+]
+
+[[package]]
 name = "glassbench"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,12 +2293,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -1350,6 +2339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1630,7 +2629,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1653,6 +2652,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -2038,6 +3090,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "noop_proc_macro"
@@ -2491,6 +3549,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +3603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62081f34d4a69433189c4d5a862c3f6243d68789c449e981189a458cdfde079c"
 dependencies = [
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2969,7 +4051,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3074,6 +4156,33 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3317,10 +4426,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3564,6 +4673,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "umask"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,6 +4701,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
@@ -3844,7 +4974,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4433,6 +5563,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ directories = "4.0"
 file-size = "1.0.3"
 flate2 = "1.0"
 flex-grow = "0.1"
-git2 = { version = "0.20", default-features = false } # waiting for a good pure-rust alternative
+gix = { version = "0.87", default-features = false, features = ["sha1", "status", "blob-diff", "max-performance-safe"] }
 glob = "0.3"
 icy_sixel = { version = "0.5", optional = true }
 id-arena = "2.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ git2 = { version = "0.20", default-features = false } # waiting for a good pure-
 glob = "0.3"
 icy_sixel = { version = "0.5", optional = true }
 id-arena = "2.2.1"
-image = "0.25"
+# decoders only: `avif` is left out, in image 0.25 it's just an AV1 encoder
+image = { version = "0.25", default-features = false, features = ["rayon", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "tiff", "webp"] }
 zune-core = "0.4.12"
 # jpeg-xl is left out: it pulls jxl-oxide 0.4, whose out-of-bounds bugs are only fixed
 # in zune-image 0.5, which needs rustc 1.87

--- a/resources/default-conf/conf.hjson
+++ b/resources/default-conf/conf.hjson
@@ -199,13 +199,17 @@ content_search_max_file_size: 10MB
 ###############################################################
 # Kitty Keyboard extension
 #
-# If you want to use advanced keyboard shortcuts in Kitty
-# compatible terminals (Kitty, Wezterm), set this to true.
-# 
-# This makes it possible to use shortcuts like 'space-n', 
-# 'ctrl-alt-a-b', 'shift-space', etc.
+# When the terminal supports the Kitty keyboard protocol (Kitty,
+# Wezterm, Ghostty, iTerm2, foot...), broot uses it by default,
+# which makes shortcuts like 'shift-space' or 'ctrl-alt-a-b'
+# possible, and lets alt combinations reach broot on macOS.
 #
-enable_kitty_keyboard: false
+# Set this to true to also allow multi-key shortcuts without
+# modifier, like 'space-n' or 'a-b' (then simple keys are handled
+# on release instead of press).
+# Set this to false to disable the protocol.
+#
+# enable_kitty_keyboard: true
 
 ###############################################################
 # lines around matching line in filtered preview

--- a/resources/default-conf/conf.hjson
+++ b/resources/default-conf/conf.hjson
@@ -24,7 +24,7 @@
 # you can launch broot with `br -H`).
 # A popular flag is the `g` one which displays git related info.
 #
-# default_flags:
+# default_flags: g
 
 ###############################################################
 # Terminal's title

--- a/resources/default-conf/skins/catppuccin-macchiato.hjson
+++ b/resources/default-conf/skins/catppuccin-macchiato.hjson
@@ -81,6 +81,7 @@ skin: {
     git_deletions: rgb(245, 169, 127) none
     git_status_current: rgb(245, 169, 127) none
     git_status_modified: rgb(245, 169, 127) none
+    git_status_staged: rgb(245, 169, 127) none
     git_status_new: rgb(245, 169, 127) none Bold
     git_status_ignored: rgb(245, 169, 127) none
     git_status_conflicted: rgb(245, 169, 127) none

--- a/resources/default-conf/skins/catppuccin-macchiato.hjson
+++ b/resources/default-conf/skins/catppuccin-macchiato.hjson
@@ -67,6 +67,9 @@ skin: {
     char_match: rgb(238, 212, 159) rgb(73, 77, 100) Bold Italic
     content_match: rgb(238, 212, 159) rgb(73, 77, 100) Bold Italic
     preview_match: rgb(238, 212, 159) rgb(73, 77, 100) Bold Italic
+    diff_line_number: rgb(110, 115, 141) rgb(54, 58, 79)
+    diff_added: rgb(202, 211, 245) rgb(40, 68, 52)
+    diff_removed: rgb(202, 211, 245) rgb(82, 42, 54)
 
     # children count
     # fg:$yellow bg:none

--- a/resources/default-conf/skins/catppuccin-mocha.hjson
+++ b/resources/default-conf/skins/catppuccin-mocha.hjson
@@ -81,6 +81,7 @@ skin: {
     git_deletions: rgb(250, 179, 135) none
     git_status_current: rgb(250, 179, 135) none
     git_status_modified: rgb(250, 179, 135) none
+    git_status_staged: rgb(250, 179, 135) none
     git_status_new: rgb(250, 179, 135) none Bold
     git_status_ignored: rgb(250, 179, 135) none
     git_status_conflicted: rgb(250, 179, 135) none

--- a/resources/default-conf/skins/catppuccin-mocha.hjson
+++ b/resources/default-conf/skins/catppuccin-mocha.hjson
@@ -67,6 +67,9 @@ skin: {
     char_match: rgb(249, 226, 175) rgb(69, 71, 90) Bold Italic
     content_match: rgb(249, 226, 175) rgb(69, 71, 90) Bold Italic
     preview_match: rgb(249, 226, 175) rgb(69, 71, 90) Bold Italic
+    diff_line_number: rgb(108, 112, 134) rgb(49, 50, 68)
+    diff_added: rgb(205, 214, 244) rgb(38, 66, 50)
+    diff_removed: rgb(205, 214, 244) rgb(80, 40, 52)
 
     # children count
     # fg:$yellow bg:none

--- a/resources/default-conf/skins/dark-blue.hjson
+++ b/resources/default-conf/skins/dark-blue.hjson
@@ -82,6 +82,9 @@ skin: {
     preview_line_number: gray(12) gray(3) 
     preview_separator: gray(5) None
     preview_match: None ansi(29) 
+    diff_line_number: gray(12) gray(3)
+    diff_added: gray(22) rgb(28, 68, 40)
+    diff_removed: gray(22) rgb(88, 34, 34)
     hex_null: gray(8) None 
     hex_ascii_graphic: gray(18) None 
     hex_ascii_whitespace: ansi(143) None 

--- a/resources/default-conf/skins/dark-blue.hjson
+++ b/resources/default-conf/skins/dark-blue.hjson
@@ -47,6 +47,7 @@ skin: {
     git_deletions: ansi(160) None 
     git_status_current: gray(5) None 
     git_status_modified: ansi(28) None 
+    git_status_staged: ansi(34) None
     git_status_new: ansi(94) None bold
     git_status_ignored: gray(17) None 
     git_status_conflicted: ansi(88) None 

--- a/resources/default-conf/skins/dark-gruvbox.hjson
+++ b/resources/default-conf/skins/dark-gruvbox.hjson
@@ -69,6 +69,9 @@ skin: {
     preview_line_number: rgb(124, 111, 100) rgb(40, 40, 40) / rgb(124, 111, 100) None
     preview_separator: rgb(70, 70, 80) None / rgb(60, 60, 60) None
     preview_match: None ansi(29) Bold
+    diff_line_number: rgb(146, 131, 116) rgb(50, 48, 47)
+    diff_added: rgb(235, 219, 178) rgb(50, 70, 42)
+    diff_removed: rgb(235, 219, 178) rgb(90, 40, 36)
     hex_null: rgb(189, 174, 147) None
     hex_ascii_graphic: rgb(213, 196, 161) None
     hex_ascii_whitespace: rgb(152, 151, 26) None

--- a/resources/default-conf/skins/dark-gruvbox.hjson
+++ b/resources/default-conf/skins/dark-gruvbox.hjson
@@ -34,6 +34,7 @@ skin: {
     git_deletions: rgb(190, 15, 23) None
     git_status_current: rgb(60, 56, 54) None
     git_status_modified: rgb(152, 151, 26) None
+    git_status_staged: rgb(142, 192, 124) None
     git_status_new: rgb(104, 187, 38) None Bold
     git_status_ignored: rgb(213, 196, 161) None
     git_status_conflicted: rgb(204, 36, 29) None

--- a/resources/default-conf/skins/dark-orange.hjson
+++ b/resources/default-conf/skins/dark-orange.hjson
@@ -44,6 +44,7 @@ skin: {
     git_deletions: ansi(160) None
     git_status_current: gray(5) None
     git_status_modified: ansi(28) None
+    git_status_staged: ansi(34) None
     git_status_new: ansi(94) None Bold
     git_status_ignored: gray(17) None
     git_status_conflicted: ansi(88) None

--- a/resources/default-conf/skins/dark-orange.hjson
+++ b/resources/default-conf/skins/dark-orange.hjson
@@ -78,6 +78,9 @@ skin: {
     preview_line_number: gray(12) gray(3)
     preview_separator: ansi(94) None / gray(3) None
     preview_match: None ansi(29)
+    diff_line_number: gray(12) gray(3)
+    diff_added: gray(22) rgb(28, 68, 40)
+    diff_removed: gray(22) rgb(88, 34, 34)
     hex_null: gray(11) None
     hex_ascii_graphic: gray(18) None
     hex_ascii_whitespace: ansi(143) None

--- a/resources/default-conf/skins/native-16.hjson
+++ b/resources/default-conf/skins/native-16.hjson
@@ -56,6 +56,7 @@ skin: {
     git_status_current: ansi(6)
     git_status_ignored: ansi(8)
     git_status_modified: ansi(3)
+    git_status_staged: ansi(2)
     git_status_new: ansi(2) none bold
     git_status_other: ansi(5)
 

--- a/resources/default-conf/skins/native-16.hjson
+++ b/resources/default-conf/skins/native-16.hjson
@@ -102,6 +102,9 @@ skin: {
     # preview_line_number: none
     # preview_match: none
     # preview_title: none
+    diff_line_number: ansi(8)
+    diff_added: ansi(0) ansi(2)
+    diff_removed: ansi(0) ansi(1)
 
     # Used for displaying errors
     file_error: ansi(1)

--- a/resources/default-conf/skins/solarized-dark.hjson
+++ b/resources/default-conf/skins/solarized-dark.hjson
@@ -26,6 +26,7 @@ skin: {
 	git_deletions: "rgb(211, 1, 2) none"                                              // red default
 	git_status_current: "none none"                                                   // default default
 	git_status_modified: "rgb(181, 137, 0) none"                                      // yellow default
+	git_status_staged: "rgb(42, 161, 152) none"                                     // cyan default
 	git_status_new: "rgb(133, 153, 0) none"                                           // green default
 	git_status_ignored: "rgb(88, 110, 117) none"                                      // base01 default
 	git_status_conflicted: "rgb(211, 1, 2) none"                                      // red default

--- a/resources/default-conf/skins/solarized-dark.hjson
+++ b/resources/default-conf/skins/solarized-dark.hjson
@@ -53,6 +53,9 @@ skin: {
 	help_headers: "rgb(181, 137, 0) none"                                             // yellow default
 	help_table_border: "none none"                                                    // default default
 	preview_title: "gray(20) rgb(0, 43, 54)"
+	diff_line_number: "rgb(88, 110, 117) rgb(7, 54, 66)"
+	diff_added: "rgb(238, 232, 213) rgb(20, 70, 50)"
+	diff_removed: "rgb(238, 232, 213) rgb(90, 30, 40)"
 	staging_area_title: "gray(22) rgb(0, 43, 54)"
  	good_to_bad_0: "ansi(28)"														  // green
  	good_to_bad_1: "ansi(29)"

--- a/resources/default-conf/skins/solarized-light.hjson
+++ b/resources/default-conf/skins/solarized-light.hjson
@@ -49,6 +49,8 @@ skin: {
 	git_status_current: "none none"
 	// yellow default
 	git_status_modified: "rgb(181, 137, 0) none"
+	// cyan default
+	git_status_staged: "rgb(42, 161, 152) none"
 	// green default
 	git_status_new: "rgb(133, 153, 0) none"
 	// base1 default

--- a/resources/default-conf/skins/solarized-light.hjson
+++ b/resources/default-conf/skins/solarized-light.hjson
@@ -106,6 +106,9 @@ skin: {
 	preview_line_number: "rgb(147, 161, 161) rgb(238, 232, 213)"
 	preview_separator: "rgb(147, 161, 161) rgb(238, 232, 213)"
 	preview_match: "None ansi(29)"
+	diff_line_number: "rgb(147, 161, 161) rgb(238, 232, 213)"
+	diff_added: "rgb(0, 43, 54) rgb(213, 232, 199)"
+	diff_removed: "rgb(0, 43, 54) rgb(246, 210, 200)"
 	staging_area_title: "gray(22) rgb(253, 246, 227)"
 	good_to_bad_0: ansi(28)
 	good_to_bad_1: ansi(29)

--- a/resources/default-conf/skins/tokyo-night.hjson
+++ b/resources/default-conf/skins/tokyo-night.hjson
@@ -87,6 +87,9 @@ skin: {
     preview_line_number: rgb(81, 89, 125) rgb(16, 16, 20) / rgb(81, 89, 125) None
     preview_separator: rgb(54, 59, 84) None / rgb(43, 43, 59) None
     preview_match: None rgb(224, 175, 104) Bold
+    diff_line_number: rgb(120, 124, 153) rgb(31, 35, 53)
+    diff_added: rgb(192, 202, 245) rgb(32, 62, 52)
+    diff_removed: rgb(192, 202, 245) rgb(75, 38, 52)
 
     hex_null: rgb(120, 124, 153) None
     hex_ascii_graphic: rgb(169, 177, 214) None

--- a/resources/default-conf/skins/tokyo-night.hjson
+++ b/resources/default-conf/skins/tokyo-night.hjson
@@ -40,6 +40,7 @@ skin: {
     git_deletions: rgb(247, 118, 142) None
     git_status_current: rgb(120, 124, 153) None
     git_status_modified: rgb(224, 175, 104) None
+    git_status_staged: rgb(158, 206, 106) None
     git_status_new: rgb(115, 218, 202) None Bold
     git_status_ignored: rgb(81, 86, 112) None
     git_status_conflicted: rgb(219, 75, 75) None

--- a/resources/default-conf/skins/white.hjson
+++ b/resources/default-conf/skins/white.hjson
@@ -30,6 +30,7 @@ skin: {
 	git_deletions: ansi(160) None
 	git_status_current: gray(5) None
 	git_status_modified: ansi(28) None
+	git_status_staged: ansi(34) None
 	git_status_new: ansi(94) None Bold
 	git_status_ignored: gray(17) None
 	git_status_conflicted: ansi(88) None

--- a/resources/default-conf/skins/white.hjson
+++ b/resources/default-conf/skins/white.hjson
@@ -65,6 +65,9 @@ skin: {
 	preview_line_number: gray(6) gray(20)
 	preview_separator: gray(7) None / gray(18) None
 	preview_match: None ansi(29) Underlined
+	diff_line_number: gray(12) gray(3)
+	diff_added: gray(2) rgb(198, 242, 209)
+	diff_removed: gray(2) rgb(252, 209, 209)
 	hex_null: gray(15) None
 	hex_ascii_graphic: gray(2) None
 	hex_ascii_whitespace: ansi(143) None

--- a/resources/default-conf/verbs.hjson
+++ b/resources/default-conf/verbs.hjson
@@ -177,13 +177,6 @@ verbs: [
     #     execution: ":page_down"
     # }
 
-    # If you develop using git, you might like to often switch
-    # to the git status filter:
-    # {
-    #     key: alt-g
-    #     execution: ":toggle_git_status"
-    # }
-
     # You can reproduce the bindings of Norton Commander
     # on copying or moving to the other panel:
     # {

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -461,9 +461,17 @@ impl App {
             graphics::prepare_renderer(con)?;
         }
 
-        let combine_keys = conf.enable_kitty_keyboard.unwrap_or(false) && con.is_tty;
+        // unset: keyboard enhancements if supported, multi-key combos need a modifier
+        // true: also modifier-less multi-key combos (eg "a-b")
+        // false: standard keyboard
+        let (combine_keys, mandate_modifier_for_multiple_keys) = match conf.enable_kitty_keyboard {
+            None => (con.is_tty, true),
+            Some(true) => (con.is_tty, false),
+            Some(false) => (false, true),
+        };
         let event_source = EventSource::with_options(EventSourceOptions {
             combine_keys,
+            mandate_modifier_for_multiple_keys,
             ..Default::default()
         })?;
         con.keyboard_enhanced = event_source.supports_multi_key_combinations();

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -79,6 +79,7 @@ impl App {
             // open initial_file in preview
             let preview_state = Box::new(PreviewState::new(
                 path.clone(),
+                None,
                 InputPattern::none(),
                 None,
                 con.initial_tree_options.clone(),

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -158,6 +158,9 @@ pub struct AppContext {
     /// Number of lines to display before a match in the preview
     pub lines_before_match_in_preview: usize,
 
+    /// Number of unchanged lines to display around the hunks of a diff
+    pub lines_around_diff_hunks: usize,
+
     /// The set of transformers called before previewing a file
     pub preview_transformers: PreviewTransformers,
 
@@ -281,6 +284,7 @@ impl AppContext {
             kept_kitty_temp_files,
             lines_after_match_in_preview: config.lines_after_match_in_preview.unwrap_or(0),
             lines_before_match_in_preview: config.lines_before_match_in_preview.unwrap_or(0),
+            lines_around_diff_hunks: config.lines_around_diff_hunks.unwrap_or(3),
             preview_transformers,
             layout_instructions,
             server_name,

--- a/src/app/app_panels.rs
+++ b/src/app/app_panels.rs
@@ -604,12 +604,15 @@ impl AppPanelsAndInputs {
             return;
         };
         if let Some(path) = self.state().selected_path() {
-            let old_path = self.panels.panels[preview_idx].state().selected_path();
-            if refresh || Some(path) != old_path {
+            let git_status = self.state().selection().and_then(|sel| sel.git_status);
+            let preview_state = self.panels.panels[preview_idx].state();
+            let old_path = preview_state.selected_path();
+            let old_git_status = preview_state.selection().and_then(|sel| sel.git_status);
+            if refresh || Some(path) != old_path || git_status != old_git_status {
                 let path = path.to_path_buf();
                 self.panels.panels[preview_idx]
                     .mut_state()
-                    .set_selected_path(path, con);
+                    .set_selected(path, git_status, con);
             }
         }
     }

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -5,6 +5,7 @@ use {
         display::*,
         errors::ProgramError,
         flag::Flag,
+        git::LineGitStatus,
         help::HelpState,
         pattern::*,
         preview::*,
@@ -286,6 +287,7 @@ pub trait PanelState {
             Internal::preview_text => self.open_preview(Some(PreviewMode::Text), false, cc),
             Internal::preview_tty => self.open_preview(Some(PreviewMode::Tty), false, cc),
             Internal::preview_binary => self.open_preview(Some(PreviewMode::Hex), false, cc),
+            Internal::preview_diff => self.open_preview(Some(PreviewMode::Diff), false, cc),
             Internal::toggle_preview => self.open_preview(None, true, cc),
             Internal::sort_by_count => self.with_new_options(
                 screen,
@@ -712,12 +714,7 @@ pub trait PanelState {
                         let pattern = ExecPattern::from_string(pattern);
                         debug!("write_output executed once per selection");
                         // we execute once per selection (may be zero if the stage is empty)
-                        let sels = stage.paths().iter().map(|path| Selection {
-                            path,
-                            line: 0,
-                            stype: SelectionType::from(path),
-                            is_exe: false,
-                        });
+                        let sels = stage.paths().iter().map(|path| Selection::from_path(path));
                         for sel in sels {
                             content.push_str(&exec_builder.sel_shell_exec_string(&pattern, Some(sel), con));
                         }
@@ -1016,9 +1013,11 @@ pub trait PanelState {
                 CmdResult::Keep
             }
         } else if let Some(path) = self.selected_path() {
+            let git_status = self.selection().and_then(|sel| sel.git_status);
             CmdResult::NewPanel {
                 state: Box::new(PreviewState::new(
                     path.to_path_buf(),
+                    git_status,
                     InputPattern::none(),
                     preferred_mode,
                     self.tree_options(),
@@ -1114,9 +1113,12 @@ pub trait PanelState {
         String::new()
     }
 
-    fn set_selected_path(
+    /// Set the file to preview, with its git status when displayed
+    /// in the source panel
+    fn set_selected(
         &mut self,
         _path: PathBuf,
+        _git_status: Option<LineGitStatus>,
         _con: &AppContext,
     ) {
         // this function is useful for preview states

--- a/src/app/sel_info.rs
+++ b/src/app/sel_info.rs
@@ -29,12 +29,7 @@ impl<'a> SelInfo<'a> {
             SelInfo::More(stage) => stage
                 .paths()
                 .iter()
-                .map(|path| Selection {
-                    path,
-                    line: 0,
-                    stype: SelectionType::from(path),
-                    is_exe: false, // OK, I don't know
-                })
+                .map(|path| Selection::from_path(path))
                 .collect(),
         }
     }
@@ -47,12 +42,7 @@ impl<'a> SelInfo<'a> {
     }
     #[must_use]
     pub fn from_path(path: &'a Path) -> Self {
-        Self::One(Selection {
-            stype: SelectionType::from(path),
-            line: 0,
-            path,
-            is_exe: false, // OK, I don't know
-        })
+        Self::One(Selection::from_path(path))
     }
     #[must_use]
     pub fn count_paths(&self) -> usize {
@@ -107,12 +97,7 @@ impl<'a> SelInfo<'a> {
     pub fn first_sel(self) -> Option<Selection<'a>> {
         match self {
             SelInfo::One(sel) => Some(sel),
-            SelInfo::More(stage) => stage.paths().first().map(|path| Selection {
-                path,
-                line: 0,
-                stype: SelectionType::from(path),
-                is_exe: false,
-            }),
+            SelInfo::More(stage) => stage.paths().first().map(|path| Selection::from_path(path)),
             SelInfo::None => None,
         }
     }

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -5,6 +5,7 @@ use {
     },
     crate::{
         errors::ProgramError,
+        git::LineGitStatus,
         launchable::Launchable,
     },
     std::{
@@ -33,6 +34,49 @@ pub struct Selection<'s> {
     pub line: LineNumber, // the line number in the file (0 if none selected)
     pub stype: SelectionType,
     pub is_exe: bool,
+    /// the git status of the file, when displayed
+    pub git_status: Option<LineGitStatus>,
+}
+
+impl<'s> Selection<'s> {
+    /// Build a selection with no line, not executable, and no git status
+    pub fn new(
+        path: &'s Path,
+        stype: SelectionType,
+    ) -> Self {
+        Self {
+            path,
+            line: 0,
+            stype,
+            is_exe: false,
+            git_status: None,
+        }
+    }
+    /// Build a selection whose type is read from the filesystem
+    pub fn from_path(path: &'s Path) -> Self {
+        Self::new(path, SelectionType::from(path))
+    }
+    pub fn with_line(
+        mut self,
+        line: LineNumber,
+    ) -> Self {
+        self.line = line;
+        self
+    }
+    pub fn with_exe(
+        mut self,
+        is_exe: bool,
+    ) -> Self {
+        self.is_exe = is_exe;
+        self
+    }
+    pub fn with_git_status(
+        mut self,
+        git_status: Option<LineGitStatus>,
+    ) -> Self {
+        self.git_status = git_status;
+        self
+    }
 }
 
 impl SelectionType {

--- a/src/app/standard_status.rs
+++ b/src/app/standard_status.rs
@@ -21,6 +21,7 @@ pub struct StandardStatus {
     preview_restorable_filter: Option<String>,
     not_first_state: String, // "esc to go back"
     help: String,
+    git_status: Option<String>,
     no_verb: String,
     pub all_files_hidden: Option<String>,
     pub all_files_ignored: Option<String>,
@@ -55,6 +56,9 @@ impl StandardStatus {
             .map(|k| format!("*{k}* to restore the filter"));
         let not_first_state = "*esc* to go back".to_string();
         let help = "*?* for help".to_string();
+        let git_status = verb_store
+            .key_desc_of_internal(Internal::toggle_git_status)
+            .map(|k| format!("*{k}* for git status"));
         let no_verb = "a space then a verb".to_string();
         let all_files_hidden = verb_store
             .key_desc_of_internal(Internal::toggle_hidden)
@@ -78,6 +82,7 @@ impl StandardStatus {
             preview_restorable_filter,
             not_first_state,
             help,
+            git_status,
             no_verb,
             all_files_hidden,
             all_files_ignored,
@@ -157,6 +162,7 @@ pub struct StandardStatusBuilder<'s> {
     pub is_filtered: bool,
     pub has_removed_pattern: bool,
     pub on_tree_root: bool, // should this be part of the Selection struct ?
+    pub in_git_repo: bool,  // root in a git repo, git status filter not active
     pub width: usize,       // available width
 }
 impl<'s> StandardStatusBuilder<'s> {
@@ -174,6 +180,7 @@ impl<'s> StandardStatusBuilder<'s> {
             is_filtered: false,
             has_removed_pattern: false,
             on_tree_root: false,
+            in_git_repo: false,
             width,
         }
     }
@@ -208,6 +215,9 @@ impl<'s> StandardStatusBuilder<'s> {
                 }
                 if parts.len() < 3 {
                     parts.add(&ss.help);
+                }
+                if self.in_git_repo && parts.len() < 4 {
+                    parts.addo(ss.git_status.as_deref());
                 }
                 if parts.len() < 4 {
                     if self.on_tree_root && !self.is_filtered {

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -746,6 +746,8 @@ impl PanelState for BrowserState {
         ssb.is_filtered = self.filtered_tree.is_some();
         ssb.has_removed_pattern = false;
         ssb.on_tree_root = tree.selection == 0;
+        ssb.in_git_repo = !tree.options.filter_by_git_status
+            && git::closest_repo_dir(tree.root()).is_some();
         ssb.status()
     }
 

--- a/src/browser/browser_state.rs
+++ b/src/browser/browser_state.rs
@@ -405,8 +405,12 @@ impl PanelState for BrowserState {
                 CmdResult::Keep
             }
             Internal::next_match => {
-                self.displayed_tree_mut()
-                    .try_select_next_filtered(|line| line.direct_match, page_height);
+                let tree = self.displayed_tree_mut();
+                if tree.options.pattern.is_some() {
+                    tree.try_select_next_filtered(|line| line.direct_match, page_height);
+                } else if tree.options.show_git_file_info || tree.options.filter_by_git_status {
+                    tree.try_select_next_filtered(|line| line.git_status.is_some(), page_height);
+                }
                 CmdResult::Keep
             }
             Internal::next_same_depth => {
@@ -482,8 +486,12 @@ impl PanelState for BrowserState {
                 CmdResult::Keep
             }
             Internal::previous_match => {
-                self.displayed_tree_mut()
-                    .try_select_previous_filtered(|line| line.direct_match, page_height);
+                let tree = self.displayed_tree_mut();
+                if tree.options.pattern.is_some() {
+                    tree.try_select_previous_filtered(|line| line.direct_match, page_height);
+                } else if tree.options.show_git_file_info || tree.options.filter_by_git_status {
+                    tree.try_select_previous_filtered(|line| line.git_status.is_some(), page_height);
+                }
                 CmdResult::Keep
             }
             Internal::previous_same_depth => {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,7 @@
 // Warning: this module can't import broot's stuff due to its use in build.rs
 use {
     clap::{
+        ArgAction,
         Parser,
         ValueEnum,
     },
@@ -50,16 +51,16 @@ pub struct Args {
     #[arg(long)]
     pub max_depth: Option<u16>,
 
-    /// Show git statuses on files and stats on repo
-    #[arg(short = 'g', long)]
-    pub show_git_info: bool,
+    /// Show git statuses on files and stats on repo; repeat (-gg) to only show files with a git status
+    #[arg(short = 'g', long, action = ArgAction::Count)]
+    pub show_git_info: u8,
 
-    /// Don't show git statuses on files and stats on repo
-    #[arg(short = 'G', long)]
-    pub no_show_git_info: bool,
+    /// Show less git information (undoes one -g)
+    #[arg(short = 'G', long, action = ArgAction::Count)]
+    pub no_show_git_info: u8,
 
     #[arg(long)]
-    /// Only show files having an interesting git status, including hidden ones
+    /// Only show files having an interesting git status, including hidden ones (same as -gg)
     pub git_status: bool,
 
     #[arg(short = 'h', long)]

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -122,6 +122,9 @@ pub struct Conf {
     #[serde(alias = "lines-before-match-in-preview")]
     pub lines_before_match_in_preview: Option<usize>,
 
+    #[serde(alias = "lines-around-diff-hunks")]
+    pub lines_around_diff_hunks: Option<usize>,
+
     pub max_panels_count: Option<usize>,
 
     #[serde(alias = "max_staged_count")]
@@ -267,6 +270,7 @@ impl Conf {
         overwrite!(self, kept_kitty_temp_files, conf);
         overwrite!(self, lines_after_match_in_preview, conf);
         overwrite!(self, lines_before_match_in_preview, conf);
+        overwrite!(self, lines_around_diff_hunks, conf);
         overwrite!(self, layout_instructions, conf);
         self.verbs.append(&mut conf.verbs);
         // the following prefs are "additive": we can add entries from several

--- a/src/display/displayable_tree.rs
+++ b/src/display/displayable_tree.rs
@@ -13,6 +13,7 @@ use {
         content_search::ContentMatch,
         errors::ProgramError,
         file_sum::FileSum,
+        git::LineGitStatus,
         pattern::PatternObject,
         skin::{
             ExtColorMap,
@@ -36,7 +37,6 @@ use {
         cursor,
     },
     file_size,
-    git2::Status,
     std::io::Write,
     termimad::{
         CompoundStyle,
@@ -236,14 +236,16 @@ impl<'a, 's, 't> DisplayableTree<'a, 's, 't> {
         selected: bool,
     ) -> Result<usize, termimad::Error> {
         let (style, char) = if line.is_selectable() {
-            match line.git_status.map(|s| s.status) {
-                Some(Status::CURRENT) => (&self.skin.git_status_current, ' '),
-                Some(Status::WT_NEW) => (&self.skin.git_status_new, 'N'),
-                Some(Status::CONFLICTED) => (&self.skin.git_status_conflicted, 'C'),
-                Some(Status::WT_MODIFIED) => (&self.skin.git_status_modified, 'M'),
-                Some(Status::IGNORED) => (&self.skin.git_status_ignored, 'I'),
+            match line.git_status {
+                Some(LineGitStatus::New) => (&self.skin.git_status_new, 'N'),
+                Some(LineGitStatus::Added) => (&self.skin.git_status_staged, 'A'),
+                Some(LineGitStatus::Staged) => (&self.skin.git_status_staged, 'S'),
+                Some(LineGitStatus::Conflicted) => (&self.skin.git_status_conflicted, 'C'),
+                Some(LineGitStatus::Modified) => (&self.skin.git_status_modified, 'M'),
+                Some(LineGitStatus::Renamed) => (&self.skin.git_status_new, 'R'),
+                Some(LineGitStatus::Ignored) => (&self.skin.git_status_ignored, 'I'),
+                Some(LineGitStatus::Other) => (&self.skin.git_status_other, '?'),
                 None => (&self.skin.tree, ' '),
-                _ => (&self.skin.git_status_other, '?'),
             }
         } else {
             (&self.skin.tree, ' ')

--- a/src/display/displayable_tree.rs
+++ b/src/display/displayable_tree.rs
@@ -13,7 +13,6 @@ use {
         content_search::ContentMatch,
         errors::ProgramError,
         file_sum::FileSum,
-        git::LineGitStatus,
         pattern::PatternObject,
         skin::{
             ExtColorMap,
@@ -237,14 +236,7 @@ impl<'a, 's, 't> DisplayableTree<'a, 's, 't> {
     ) -> Result<usize, termimad::Error> {
         let (style, char) = if line.is_selectable() {
             match line.git_status {
-                Some(LineGitStatus::New) => (&self.skin.git_status_new, 'N'),
-                Some(LineGitStatus::Added) => (&self.skin.git_status_staged, 'A'),
-                Some(LineGitStatus::Staged) => (&self.skin.git_status_staged, 'S'),
-                Some(LineGitStatus::Conflicted) => (&self.skin.git_status_conflicted, 'C'),
-                Some(LineGitStatus::Modified) => (&self.skin.git_status_modified, 'M'),
-                Some(LineGitStatus::Renamed) => (&self.skin.git_status_new, 'R'),
-                Some(LineGitStatus::Ignored) => (&self.skin.git_status_ignored, 'I'),
-                Some(LineGitStatus::Other) => (&self.skin.git_status_other, '?'),
+                Some(status) => (self.skin.git_status_style(status), status.letter()),
                 None => (&self.skin.tree, ' '),
             }
         } else {

--- a/src/display/git_status_display.rs
+++ b/src/display/git_status_display.rs
@@ -12,8 +12,21 @@ pub struct GitStatusDisplay<'a, 's> {
     skin: &'s StyleMap,
     show_branch: bool,
     show_wide: bool,
+    show_ahead_behind: bool,
     show_stats: bool,
     pub width: usize,
+}
+
+/// Return the unstyled "↑3↓1" showing the divergence with the upstream branch
+fn ahead_behind_string(status: &TreeGitStatus) -> Option<String> {
+    let mut s = String::new();
+    if status.ahead > 0 {
+        s.push_str(&format!("↑{}", status.ahead));
+    }
+    if status.behind > 0 {
+        s.push_str(&format!("↓{}", status.behind));
+    }
+    (!s.is_empty()).then_some(s)
 }
 
 impl<'a, 's> GitStatusDisplay<'a, 's> {
@@ -29,6 +42,14 @@ impl<'a, 's> GitStatusDisplay<'a, 's> {
             if branch_width < available_width {
                 width += branch_width;
                 show_branch = true;
+            }
+        }
+        let mut show_ahead_behind = false;
+        if let Some(ab) = ahead_behind_string(status) {
+            let ab_width = ab.chars().count() + 1; // with the trailing space
+            if width + ab_width < available_width {
+                width += ab_width;
+                show_ahead_behind = true;
             }
         }
         let mut show_stats = false;
@@ -47,6 +68,7 @@ impl<'a, 's> GitStatusDisplay<'a, 's> {
             skin,
             show_branch,
             show_wide,
+            show_ahead_behind,
             show_stats,
             width,
         }
@@ -71,6 +93,17 @@ impl<'a, 's> GitStatusDisplay<'a, 's> {
                 cw.queue_str(branch_style, name)?;
                 cw.queue_char(branch_style, ' ')?;
             }
+        }
+        if self.show_ahead_behind {
+            if self.status.ahead > 0 {
+                cond_bg!(ahead_style, self, selected, self.skin.git_insertions);
+                cw.queue_g_string(ahead_style, format!("↑{}", self.status.ahead))?;
+            }
+            if self.status.behind > 0 {
+                cond_bg!(behind_style, self, selected, self.skin.git_deletions);
+                cw.queue_g_string(behind_style, format!("↓{}", self.status.behind))?;
+            }
+            cw.queue_char(&self.skin.default, ' ')?;
         }
         if self.show_stats {
             cond_bg!(insertions_style, self, selected, self.skin.git_insertions);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,7 @@ custom_error! {pub ProgramError
     ArgParse {bad: String, valid: String} = "{bad:?} can't be parsed (valid values: {valid:?})",
     ConfFile {path:String, details: ConfError} = "Bad configuration file {path:?} : {details}",
     Conf {source: ConfError} = "Bad configuration: {source}",
+    Git {details: String} = "Git error: {details}",
     ImageError {details: String} = "Image error: {details}",
     Internal {details: String} = "Internal error: {details}", // should not happen
     Io {source: io::Error} = "IO Error : {source}",

--- a/src/filesystems/filesystems_state.rs
+++ b/src/filesystems/filesystems_state.rs
@@ -144,12 +144,7 @@ impl FilesystemState {
     }
 
     fn no_opt_selection(&self) -> Selection<'_> {
-        Selection {
-            path: self.no_opt_selected_path(),
-            stype: SelectionType::Directory,
-            is_exe: false,
-            line: 0,
-        }
+        Selection::new(self.no_opt_selected_path(), SelectionType::Directory)
     }
 }
 

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -1,0 +1,287 @@
+use {
+    crate::{
+        errors::ProgramError,
+        syntactic::is_char_unprintable,
+    },
+    gix::{
+        diff::blob::{
+            Diff,
+            InternedInput,
+            ResourceKind,
+            pipeline::{
+                Mode,
+                WorktreeRoots,
+            },
+            platform::prepare_diff::Operation,
+        },
+        object::tree::EntryKind,
+    },
+    std::{
+        fmt::Display,
+        ops::Range,
+        path::{
+            Path,
+            PathBuf,
+        },
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Context,
+    Added,
+    Removed,
+}
+
+/// A line of a diff hunk
+#[derive(Debug, Clone)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    /// the number of the line in the old version (none for an added line)
+    pub old_number: Option<usize>,
+    /// the number of the line in the new version (none for a removed line)
+    pub new_number: Option<usize>,
+    pub content: String,
+}
+
+/// A group of changes, with the unchanged lines around them
+#[derive(Debug, Clone)]
+pub struct Hunk {
+    pub old_start: usize,
+    pub old_len: usize,
+    pub new_start: usize,
+    pub new_len: usize,
+    pub lines: Vec<DiffLine>,
+}
+
+#[derive(Debug, Clone)]
+pub enum FileDiffContent {
+    Text(Vec<Hunk>),
+    Binary,
+    Unchanged,
+}
+
+/// The changes of one file between two versions
+#[derive(Debug, Clone)]
+pub struct FileDiff {
+    pub path: PathBuf,
+    pub content: FileDiffContent,
+    pub insertions: usize,
+    pub deletions: usize,
+}
+
+fn git_error<E: Display>(e: E) -> ProgramError {
+    ProgramError::Git {
+        details: e.to_string(),
+    }
+}
+
+/// Compute the changes of the file in the worktree, compared to HEAD.
+/// `context` is the number of unchanged lines kept around the changes.
+pub fn diff_worktree_vs_head(
+    path: &Path,
+    context: usize,
+) -> Result<FileDiff, ProgramError> {
+    let repo = super::discover(path).ok_or_else(|| git_error("not in a git repository"))?;
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| git_error("bare repository"))?;
+    let rela_path = path.strip_prefix(workdir).map_err(git_error)?;
+    let rela_bstr = gix::path::to_unix_separators_on_windows(gix::path::into_bstr(rela_path));
+    let null = repo.object_hash().null();
+    let (old_id, old_kind) = match repo
+        .head_tree()
+        .map_err(git_error)?
+        .lookup_entry_by_path(rela_path)
+        .map_err(git_error)?
+    {
+        Some(entry) => (entry.object_id(), entry.mode().kind()),
+        None => (null, EntryKind::Blob), // not in HEAD: everything is added
+    };
+    let mut cache = repo
+        .diff_resource_cache(
+            Mode::ToWorktreeAndBinaryToText,
+            WorktreeRoots {
+                old_root: None,
+                new_root: Some(workdir.to_path_buf()),
+            },
+        )
+        .map_err(git_error)?;
+    cache
+        .set_resource(
+            old_id,
+            old_kind,
+            rela_bstr.as_ref(),
+            ResourceKind::OldOrSource,
+            &repo,
+        )
+        .map_err(git_error)?;
+    cache
+        .set_resource(
+            null,
+            EntryKind::Blob,
+            rela_bstr.as_ref(),
+            ResourceKind::NewOrDestination,
+            &repo,
+        )
+        .map_err(git_error)?;
+    cache.options.skip_internal_diff_if_external_is_configured = false;
+    let prep = cache.prepare_diff().map_err(git_error)?;
+    let content = match prep.operation {
+        Operation::InternalDiff { algorithm } => {
+            let input = prep.interned_input();
+            let diff = gix::diff::blob::diff_with_slider_heuristics(algorithm, &input);
+            let hunks = hunks(&diff, &input, context);
+            if hunks.is_empty() {
+                FileDiffContent::Unchanged
+            } else {
+                FileDiffContent::Text(hunks)
+            }
+        }
+        Operation::SourceOrDestinationIsBinary => FileDiffContent::Binary,
+        Operation::ExternalCommand { .. } => {
+            return Err(git_error("unexpected external diff"));
+        }
+    };
+    let (insertions, deletions) = match &content {
+        FileDiffContent::Text(hunks) => hunks
+            .iter()
+            .flat_map(|hunk| &hunk.lines)
+            .fold((0, 0), |(ins, del), line| match line.kind {
+                DiffLineKind::Added => (ins + 1, del),
+                DiffLineKind::Removed => (ins, del + 1),
+                DiffLineKind::Context => (ins, del),
+            }),
+        _ => (0, 0),
+    };
+    Ok(FileDiff {
+        path: path.to_path_buf(),
+        content,
+        insertions,
+        deletions,
+    })
+}
+
+/// Build the hunks of a diff, each change surrounded by `context` unchanged
+/// lines, changes closer than that being grouped in the same hunk
+fn hunks(
+    diff: &Diff,
+    input: &InternedInput<&[u8]>,
+    context: usize,
+) -> Vec<Hunk> {
+    let text = |line: &[u8]| -> String {
+        let s = String::from_utf8_lossy(line);
+        if s.contains(is_char_unprintable) {
+            s.replace(is_char_unprintable, "�")
+        } else {
+            s.into_owned()
+        }
+    };
+    let before_text = |idx: usize| text(input.interner[input.before[idx]]);
+    let after_text = |idx: usize| text(input.interner[input.after[idx]]);
+    let mut hunks = Vec::new();
+    let mut hunk = HunkBuilder::default();
+    // indexes of the first lines after the previous change
+    let mut done_before = 0;
+    let mut done_after = 0;
+    for change in diff.hunks() {
+        let b: Range<usize> = change.before.start as usize..change.before.end as usize;
+        let a: Range<usize> = change.after.start as usize..change.after.end as usize;
+        let gap = b.start - done_before; // unchanged lines since the previous change
+        if hunk.is_empty() || gap > 2 * context {
+            if !hunk.is_empty() {
+                for i in 0..context.min(gap) {
+                    hunk.push_context(done_before + i, done_after + i, before_text(done_before + i));
+                }
+                hunks.push(hunk.build());
+            }
+            let ctx = context.min(gap);
+            for i in (b.start - ctx)..b.start {
+                hunk.push_context(i, a.start - (b.start - i), before_text(i));
+            }
+        } else {
+            // the changes are close: all the lines between them are context
+            for i in 0..gap {
+                hunk.push_context(done_before + i, done_after + i, before_text(done_before + i));
+            }
+        }
+        for i in b.clone() {
+            hunk.push_removed(i, before_text(i));
+        }
+        for i in a.clone() {
+            hunk.push_added(i, after_text(i));
+        }
+        done_before = b.end;
+        done_after = a.end;
+    }
+    if !hunk.is_empty() {
+        let gap = input.before.len() - done_before;
+        for i in 0..context.min(gap) {
+            hunk.push_context(done_before + i, done_after + i, before_text(done_before + i));
+        }
+        hunks.push(hunk.build());
+    }
+    hunks
+}
+
+#[derive(Default)]
+struct HunkBuilder {
+    lines: Vec<DiffLine>,
+}
+
+impl HunkBuilder {
+    fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+    /// Push an unchanged line, given its 0-based indexes in both versions
+    fn push_context(
+        &mut self,
+        old_idx: usize,
+        new_idx: usize,
+        content: String,
+    ) {
+        self.lines.push(DiffLine {
+            kind: DiffLineKind::Context,
+            old_number: Some(old_idx + 1),
+            new_number: Some(new_idx + 1),
+            content,
+        });
+    }
+    fn push_removed(
+        &mut self,
+        old_idx: usize,
+        content: String,
+    ) {
+        self.lines.push(DiffLine {
+            kind: DiffLineKind::Removed,
+            old_number: Some(old_idx + 1),
+            new_number: None,
+            content,
+        });
+    }
+    fn push_added(
+        &mut self,
+        new_idx: usize,
+        content: String,
+    ) {
+        self.lines.push(DiffLine {
+            kind: DiffLineKind::Added,
+            old_number: None,
+            new_number: Some(new_idx + 1),
+            content,
+        });
+    }
+    /// Return the hunk made of the pushed lines, leaving the builder empty
+    fn build(&mut self) -> Hunk {
+        let lines = std::mem::take(&mut self.lines);
+        let old_numbers = lines.iter().filter_map(|l| l.old_number);
+        let new_numbers = lines.iter().filter_map(|l| l.new_number);
+        Hunk {
+            old_start: old_numbers.clone().next().unwrap_or(0),
+            old_len: old_numbers.count(),
+            new_start: new_numbers.clone().next().unwrap_or(0),
+            new_len: new_numbers.count(),
+            lines,
+        }
+    }
+}

--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -3,7 +3,6 @@
 // TODO rename without the "Git" prefix, as it's not only for gitignore
 
 use {
-    git2,
     glob,
     id_arena::{
         Arena,
@@ -164,10 +163,50 @@ impl IgnoreFile {
     }
 }
 
-pub fn find_global_ignore() -> Option<PathBuf> {
-    git2::Config::open_default()
-        .and_then(|global_config| global_config.get_path("core.excludesfile"))
+/// Read the git configuration files at the system level (`/etc/gitconfig`,
+/// or `$GIT_CONFIG_SYSTEM`) and user level (`~/.gitconfig`, `~/.config/git/config`).
+fn global_git_config() -> Option<gix::config::File> {
+    use gix::config::{
+        file::{
+            Metadata,
+            includes,
+            init,
+        },
+        source::Kind,
+    };
+    let metas = [Kind::System, Kind::Global]
+        .iter()
+        .flat_map(|kind| kind.sources())
+        .map(|source| Metadata {
+            path: source
+                .storage_location(&mut gix::path::env::var)
+                .filter(|p| p.is_file()),
+            source: *source,
+            level: 0,
+            trust: gix::sec::Trust::Full,
+        });
+    let home = gix::path::env::home_dir();
+    let options = init::Options {
+        includes: includes::Options::follow_without_conditional(home.as_deref()),
+        ..Default::default()
+    };
+    gix::config::File::from_paths_metadata(metas, options)
         .ok()
+        .flatten()
+}
+
+pub fn find_global_ignore() -> Option<PathBuf> {
+    global_git_config()
+        .and_then(|config| {
+            let path = config.path("core.excludesfile")?;
+            let home = directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf());
+            let context = gix::config::path::interpolate::Context {
+                home_dir: home.as_deref(),
+                home_for_user: Some(gix::config::path::interpolate::home_for_user),
+                git_install_dir: None,
+            };
+            path.interpolate(context).ok()
+        })
         .or_else(|| {
             directories::BaseDirs::new()
                 .map(|base_dirs| base_dirs.config_dir().join("git/ignore"))

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,6 +23,18 @@ use std::path::{
     PathBuf,
 };
 
+/// Find the git repository containing the given path (a file or a directory)
+pub fn discover(path: &Path) -> Option<gix::Repository> {
+    let dir = if path.is_dir() { path } else { path.parent()? };
+    gix::discover(dir).ok()
+}
+
+/// Return the root of the working directory of the git repository
+/// containing the given path, if any
+pub fn workdir(path: &Path) -> Option<PathBuf> {
+    discover(path)?.workdir().map(Path::to_path_buf)
+}
+
 /// return the closest parent (or self) containing a .git file
 pub fn closest_repo_dir(mut path: &Path) -> Option<PathBuf> {
     loop {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,8 +1,17 @@
+mod diff;
 mod ignore;
 mod status;
 mod status_computer;
 
 pub use {
+    diff::{
+        DiffLine,
+        DiffLineKind,
+        FileDiff,
+        FileDiffContent,
+        Hunk,
+        diff_worktree_vs_head,
+    },
     ignore::{
         IgnoreChain,
         Ignorer,

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -85,6 +85,26 @@ impl LineGitStatus {
             _ => Self::Other,
         })
     }
+    /// Return the letter showing the status in the git column
+    pub fn letter(self) -> char {
+        match self {
+            Self::New => 'N',
+            Self::Added => 'A',
+            Self::Staged => 'S',
+            Self::Modified => 'M',
+            Self::Renamed => 'R',
+            Self::Conflicted => 'C',
+            Self::Ignored => 'I',
+            Self::Other => '?',
+        }
+    }
+    /// Return whether the file has changes since the last commit
+    pub fn has_diff(self) -> bool {
+        matches!(
+            self,
+            Self::Modified | Self::Staged | Self::Conflicted | Self::Added | Self::Renamed
+        )
+    }
     /// Return the precedence of the status, used when a path has both a
     /// HEAD->index and an index->worktree change
     fn rank(self) -> u8 {

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -1,40 +1,102 @@
 use {
-    git2::{
-        self,
+    gix::{
         Repository,
-        Status,
+        bstr::{
+            BStr,
+            BString,
+        },
+        diff::{
+            blob::{
+                DiffLineStats,
+                pipeline::{
+                    Mode,
+                    WorktreeRoots,
+                },
+            },
+            index::Change,
+        },
+        dir::{
+            entry::Status as DirEntryStatus,
+            walk::{
+                CollapsedEntriesEmissionMode,
+                EmissionMode,
+            },
+        },
+        object::tree::EntryKind,
+        status::{
+            Item,
+            Submodule,
+            UntrackedFiles,
+            index_worktree,
+            index_worktree::iter::Summary,
+        },
     },
     rustc_hash::FxHashMap,
-    std::path::{
-        Path,
-        PathBuf,
+    std::{
+        collections::hash_map::Entry,
+        path::{
+            Path,
+            PathBuf,
+        },
     },
 };
 
-const INTERESTING: Status = Status::from_bits_truncate(
-    Status::WT_NEW.bits()
-        | Status::CONFLICTED.bits()
-        | Status::WT_MODIFIED.bits()
-        | Status::IGNORED.bits(),
-);
-
-/// A git status
-#[derive(Debug, Clone, Copy)]
-pub struct LineGitStatus {
-    pub status: Status,
+/// The git status of a file
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineGitStatus {
+    /// untracked
+    New,
+    /// staged, absent from HEAD
+    Added,
+    /// staged modification, worktree identical to the index
+    Staged,
+    /// modified in the worktree (staged or not)
+    Modified,
+    /// staged rename
+    Renamed,
+    Conflicted,
+    Ignored,
+    Other,
 }
 
 impl LineGitStatus {
-    pub fn from(
-        repo: &Repository,
-        relative_path: &Path,
-    ) -> Option<LineGitStatus> {
-        repo.status_file(relative_path)
-            .ok()
-            .map(|status| LineGitStatus { status })
+    fn from_item(item: &Item) -> Option<Self> {
+        match item {
+            Item::IndexWorktree(item) => Self::from_index_worktree_item(item),
+            Item::TreeIndex(change) => Some(match change {
+                Change::Addition { .. } => Self::Added,
+                Change::Modification { .. } => Self::Staged,
+                Change::Rewrite { .. } => Self::Renamed,
+                Change::Deletion { .. } => return None,
+            }),
+        }
     }
-    pub fn is_interesting(self) -> bool {
-        self.status.intersects(INTERESTING)
+    fn from_index_worktree_item(item: &index_worktree::Item) -> Option<Self> {
+        if let index_worktree::Item::DirectoryContents { entry, .. } = item {
+            if let DirEntryStatus::Ignored(_) = entry.status {
+                return Some(Self::Ignored);
+            }
+        }
+        Some(match item.summary()? {
+            Summary::Added | Summary::IntentToAdd => Self::New,
+            Summary::Modified => Self::Modified,
+            Summary::Conflict => Self::Conflicted,
+            Summary::Removed => return None,
+            _ => Self::Other,
+        })
+    }
+    /// Return the precedence of the status, used when a path has both a
+    /// HEAD->index and an index->worktree change
+    fn rank(self) -> u8 {
+        match self {
+            Self::Conflicted => 7,
+            Self::Modified => 6,
+            Self::Renamed => 5,
+            Self::New => 4,
+            Self::Staged | Self::Added => 3,
+            Self::Ignored => 2,
+            Self::Other => 1,
+        }
     }
 }
 
@@ -42,19 +104,53 @@ impl LineGitStatus {
 /// looks at all the statuses of the repo and build a map path->status
 /// which can then be efficiently queried
 pub struct LineStatusComputer {
-    interesting_statuses: FxHashMap<PathBuf, Status>,
+    interesting_statuses: FxHashMap<PathBuf, LineGitStatus>,
 }
 impl LineStatusComputer {
-    pub fn from(repo: &Repository) -> Option<Self> {
+    /// Build the map of the statuses of the files of the tree rooted at `root`
+    pub fn from_root(root: &Path) -> Option<Self> {
+        let repo = super::discover(root)?;
+        Self::from(&repo, root)
+    }
+    fn from(
+        repo: &Repository,
+        root: &Path,
+    ) -> Option<Self> {
         let workdir = repo.workdir()?;
-        let mut interesting_statuses = FxHashMap::default();
-        let statuses = repo.statuses(None).ok()?;
-        for entry in statuses.iter() {
-            let status = entry.status();
-            if status.intersects(INTERESTING) {
-                if let Some(path) = entry.path() {
-                    let path = workdir.join(path);
-                    interesting_statuses.insert(path, status);
+        let items = repo
+            .status(gix::progress::Discard)
+            .ok()?
+            // untracked directories are reported as a whole, and their content too
+            .untracked_files(UntrackedFiles::Collapsed)
+            // we only need to know whether a submodule is dirty
+            .index_worktree_submodules(Submodule::AsConfigured { check_dirty: true })
+            .dirwalk_options(|o| {
+                o.emit_ignored(Some(EmissionMode::Matching))
+                    .emit_collapsed(Some(CollapsedEntriesEmissionMode::All))
+            })
+            .into_iter(pathspecs(workdir, root))
+            .ok()?;
+        let mut interesting_statuses: FxHashMap<PathBuf, LineGitStatus> = FxHashMap::default();
+        for item in items {
+            let item = match item {
+                Ok(item) => item,
+                Err(e) => {
+                    debug!("git status item error: {e:?}");
+                    continue;
+                }
+            };
+            let Some(status) = LineGitStatus::from_item(&item) else {
+                continue;
+            };
+            let path = workdir.join(gix::path::from_bstr(item.location()));
+            match interesting_statuses.entry(path) {
+                Entry::Vacant(e) => {
+                    e.insert(status);
+                }
+                Entry::Occupied(mut e) => {
+                    if status.rank() > e.get().rank() {
+                        e.insert(status);
+                    }
                 }
             }
         }
@@ -66,9 +162,7 @@ impl LineStatusComputer {
         &self,
         path: &Path,
     ) -> Option<LineGitStatus> {
-        self.interesting_statuses
-            .get(path)
-            .map(|&status| LineGitStatus { status })
+        self.interesting_statuses.get(path).copied()
     }
     pub fn is_interesting(
         &self,
@@ -78,36 +172,176 @@ impl LineStatusComputer {
     }
 }
 
+/// Return the pathspec limiting the status to the tree root, when
+/// it's not the repository root
+fn pathspecs(
+    workdir: &Path,
+    root: &Path,
+) -> Vec<BString> {
+    root.strip_prefix(workdir)
+        .ok()
+        .filter(|rel| !rel.as_os_str().is_empty())
+        .map(|rel| gix::path::to_unix_separators_on_windows(gix::path::into_bstr(rel)).into_owned())
+        .into_iter()
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 pub struct TreeGitStatus {
     pub current_branch_name: Option<String>,
     pub insertions: usize,
     pub deletions: usize,
+    /// commits of HEAD not in the upstream branch (0 when there's no upstream)
+    pub ahead: usize,
+    /// commits of the upstream branch not in HEAD (0 when there's no upstream)
+    pub behind: usize,
 }
 
 impl TreeGitStatus {
     pub fn from(repo: &Repository) -> Option<Self> {
-        let current_branch_name = repo
-            .head()
-            .ok()
-            .and_then(|head| head.shorthand().map(String::from));
-        let stats = match repo.diff_index_to_workdir(None, None) {
-            Ok(diff) => match diff.stats() {
-                Ok(stats) => stats,
-                Err(e) => {
-                    debug!("get stats failed : {e:?}");
-                    return None;
-                }
-            },
+        let current_branch_name = match repo.head_name() {
+            Ok(Some(name)) => Some(name.shorten().to_string()),
+            Ok(None) => repo.head_id().ok().map(|id| id.shorten_or_id().to_string()),
             Err(e) => {
-                debug!("get diff failed : {e:?}");
+                debug!("get head failed : {e:?}");
+                None
+            }
+        };
+        let (insertions, deletions) = match index_to_workdir_stats(repo) {
+            Ok(stats) => stats,
+            Err(e) => {
+                debug!("get diff stats failed : {e:?}");
                 return None;
             }
         };
+        let (ahead, behind) = ahead_behind(repo).unwrap_or((0, 0));
         Some(Self {
             current_branch_name,
-            insertions: stats.insertions(),
-            deletions: stats.deletions(),
+            insertions,
+            deletions,
+            ahead,
+            behind,
         })
     }
+}
+
+/// Count the commits of HEAD which aren't in the upstream branch, and
+/// the commits of the upstream branch which aren't in HEAD.
+/// None when there's no upstream branch.
+fn ahead_behind(repo: &Repository) -> Option<(usize, usize)> {
+    let head_ref = repo.head_ref().ok()??;
+    let upstream_name = head_ref
+        .remote_tracking_ref_name(gix::remote::Direction::Fetch)?
+        .ok()?;
+    let upstream_id = repo
+        .find_reference(upstream_name.as_ref())
+        .ok()?
+        .into_fully_peeled_id()
+        .ok()?
+        .detach();
+    let head_id = repo.head_id().ok()?.detach();
+    if head_id == upstream_id {
+        return Some((0, 0));
+    }
+    let count = |from, hidden| -> Option<usize> {
+        let walk = repo.rev_walk([from]).with_hidden([hidden]).all().ok()?;
+        Some(walk.filter(Result::is_ok).count())
+    };
+    Some((count(head_id, upstream_id)?, count(upstream_id, head_id)?))
+}
+
+/// Count the lines inserted and deleted in the worktree compared to the index
+fn index_to_workdir_stats(repo: &Repository) -> Result<(usize, usize), Box<dyn std::error::Error>> {
+    use gix::status::index_worktree::iter::Summary::*;
+    let Some(workdir) = repo.workdir() else {
+        return Ok((0, 0));
+    };
+    let null = repo.object_hash().null();
+    // the resources of this cache are read from the worktree
+    let mut wt_cache = repo.diff_resource_cache(
+        Mode::ToGit,
+        WorktreeRoots {
+            old_root: None,
+            new_root: Some(workdir.to_path_buf()),
+        },
+    )?;
+    // the resources of this cache are read from the object database
+    let mut odb_cache = repo.diff_resource_cache(Mode::ToGit, WorktreeRoots::default())?;
+    let items = repo
+        .status(gix::progress::Discard)?
+        .untracked_files(UntrackedFiles::None)
+        .into_index_worktree_iter(Vec::<BString>::new())?;
+    let mut insertions = 0;
+    let mut deletions = 0;
+    for item in items {
+        let item = item?;
+        let index_worktree::Item::Modification {
+            entry, rela_path, ..
+        } = &item
+        else {
+            continue;
+        };
+        let Some(kind) = entry.mode.to_tree_entry_mode().map(|m| m.kind()) else {
+            continue;
+        };
+        if !matches!(
+            kind,
+            EntryKind::Blob | EntryKind::BlobExecutable | EntryKind::Link
+        ) {
+            continue; // submodules
+        }
+        let stats = match item.summary() {
+            Some(Modified) => line_counts(
+                &mut wt_cache,
+                entry.id,
+                null,
+                kind,
+                rela_path.as_ref(),
+                repo,
+            ),
+            Some(Removed) => line_counts(
+                &mut odb_cache,
+                entry.id,
+                null,
+                kind,
+                rela_path.as_ref(),
+                repo,
+            ),
+            Some(IntentToAdd) => {
+                line_counts(&mut wt_cache, null, null, kind, rela_path.as_ref(), repo)
+            }
+            _ => continue,
+        };
+        match stats {
+            Ok(Some(stats)) => {
+                insertions += stats.insertions as usize;
+                deletions += stats.removals as usize;
+            }
+            Ok(None) => {} // binary
+            Err(e) => {
+                debug!("diff failed for {rela_path}: {e:?}");
+            }
+        }
+    }
+    Ok((insertions, deletions))
+}
+
+/// Diff the two versions of a file, identified by their object id, a null id
+/// meaning either the worktree file if the cache has a worktree root for
+/// this side, or a missing file otherwise.
+fn line_counts(
+    cache: &mut gix::diff::blob::Platform,
+    old_id: gix::ObjectId,
+    new_id: gix::ObjectId,
+    kind: EntryKind,
+    rela_path: &BStr,
+    repo: &Repository,
+) -> Result<Option<DiffLineStats>, Box<dyn std::error::Error>> {
+    use gix::diff::blob::ResourceKind::*;
+    cache.set_resource(old_id, kind, rela_path, OldOrSource, repo)?;
+    cache.set_resource(new_id, kind, rela_path, NewOrDestination, repo)?;
+    let mut platform = gix::object::blob::diff::Platform {
+        resource_cache: cache,
+    };
+    Ok(platform.line_counts()?)
 }

--- a/src/git/status_computer.rs
+++ b/src/git/status_computer.rs
@@ -8,7 +8,6 @@ use {
             Dam,
         },
     },
-    git2::Repository,
     once_cell::sync::Lazy,
     rustc_hash::FxHashMap,
     std::{
@@ -22,7 +21,7 @@ use {
 };
 
 fn compute_tree_status(root_path: &Path) -> ComputationResult<TreeGitStatus> {
-    match Repository::open(root_path) {
+    match gix::open(root_path) {
         Ok(git_repo) => {
             let tree_git_status = time!(TreeGitStatus::from(&git_repo),);
             match tree_git_status {
@@ -31,7 +30,7 @@ fn compute_tree_status(root_path: &Path) -> ComputationResult<TreeGitStatus> {
             }
         }
         Err(e) => {
-            debug!("failed to discover repo: {e:?}");
+            debug!("failed to open repo: {e:?}");
             ComputationResult::None
         }
     }

--- a/src/help/help_state.rs
+++ b/src/help/help_state.rs
@@ -102,12 +102,7 @@ impl PanelState for HelpState {
     }
 
     fn selection(&self) -> Option<Selection<'_>> {
-        Some(Selection {
-            path: &self.config_path,
-            stype: SelectionType::File,
-            is_exe: false,
-            line: 0,
-        })
+        Some(Selection::new(&self.config_path, SelectionType::File))
     }
 
     fn refresh(

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -2,6 +2,7 @@ mod dir_view;
 mod preview;
 mod preview_state;
 mod preview_transformer;
+mod unified_diff_view;
 mod zero_len_file_view;
 
 pub use {
@@ -9,6 +10,7 @@ pub use {
     preview::Preview,
     preview_state::PreviewState,
     preview_transformer::*,
+    unified_diff_view::UnifiedDiffView,
     zero_len_file_view::ZeroLenFileView,
 };
 
@@ -27,4 +29,7 @@ pub enum PreviewMode {
 
     /// Show the content with ANSI escape codes
     Tty,
+
+    /// show the changes of the file since the last commit
+    Diff,
 }

--- a/src/preview/preview.rs
+++ b/src/preview/preview.rs
@@ -5,6 +5,7 @@ use {
         command::ScrollCommand,
         display::*,
         errors::ProgramError,
+        git::LineGitStatus,
         hex::HexView,
         image::ImageView,
         pattern::InputPattern,
@@ -35,6 +36,7 @@ pub enum Preview {
     Text(TextView),
     Hex(HexView),
     Tty(TtyView),
+    Diff(UnifiedDiffView),
     ZeroLen(ZeroLenFileView),
     IoError(io::Error),
 }
@@ -44,6 +46,7 @@ impl Preview {
     /// If the preferred mode can't be applied, an other mode is chosen.
     pub fn new(
         path: &Path,
+        git_status: Option<LineGitStatus>,
         preferred_mode: Option<PreviewMode>,
         con: &AppContext,
     ) -> Self {
@@ -53,11 +56,17 @@ impl Preview {
                 Some(PreviewMode::Image) => Self::image(path),
                 Some(PreviewMode::Text) => Self::unfiltered_text(path, con),
                 Some(PreviewMode::Tty) => Self::tty(path),
+                Some(PreviewMode::Diff) => Self::diff(path, con),
                 None => {
-                    // automatic behavior: image, text, hex
-                    ImageView::new(path)
-                        .map(Self::Image)
-                        .unwrap_or_else(|_| Self::unfiltered_text(path, con))
+                    // automatic behavior: diff when the file has git changes,
+                    // then image, text, hex
+                    if git_status.is_some_and(LineGitStatus::has_diff) {
+                        Self::diff(path, con)
+                    } else {
+                        ImageView::new(path)
+                            .map(Self::Image)
+                            .unwrap_or_else(|_| Self::unfiltered_text(path, con))
+                    }
                 }
             }
         } else {
@@ -73,6 +82,7 @@ impl Preview {
     ) -> Result<Self, ProgramError> {
         if path.is_file() {
             match mode {
+                PreviewMode::Diff => UnifiedDiffView::new(path, con).map(Self::Diff),
                 PreviewMode::Hex => Ok(HexView::new(path.to_path_buf()).map(Self::Hex)?),
                 PreviewMode::Image => ImageView::new(path).map(Self::Image),
                 PreviewMode::Tty => TtyView::new(path)
@@ -119,6 +129,21 @@ impl Preview {
             .ok()
             .map(Self::Image)
             .unwrap_or_else(|| Self::hex(path))
+    }
+
+    /// build a view of the changes of the file since the last commit,
+    /// or a text preview when the diff can't be computed
+    pub fn diff(
+        path: &Path,
+        con: &AppContext,
+    ) -> Self {
+        match UnifiedDiffView::new(path, con) {
+            Ok(view) => Self::Diff(view),
+            Err(e) => {
+                warn!("can't diff {path:?}: {e}");
+                Self::unfiltered_text(path, con)
+            }
+        }
     }
 
     /// build an tty view, unless there's an IO error
@@ -243,6 +268,7 @@ impl Preview {
             Self::ZeroLen(_) => Some(PreviewMode::Text),
             Self::Hex(_) => Some(PreviewMode::Hex),
             Self::Tty(_) => Some(PreviewMode::Tty),
+            Self::Diff(_) => Some(PreviewMode::Diff),
             Self::IoError(_) => None,
             Self::Dir(_) => None,
         }
@@ -263,6 +289,7 @@ impl Preview {
             Self::Text(sv) => sv.try_scroll(cmd),
             Self::Hex(hv) => hv.try_scroll(cmd),
             Self::Tty(v) => v.try_scroll(cmd),
+            Self::Diff(v) => v.try_scroll(cmd),
             _ => false,
         }
     }
@@ -273,12 +300,14 @@ impl Preview {
     pub fn get_selected_line(&self) -> Option<String> {
         match self {
             Self::Text(sv) => sv.get_selected_line(),
+            Self::Diff(v) => v.get_selected_line(),
             _ => None,
         }
     }
     pub fn get_selected_line_number(&self) -> Option<LineNumber> {
         match self {
             Self::Text(sv) => sv.get_selected_line_number(),
+            Self::Diff(v) => v.get_selected_line_number(),
             _ => None,
         }
     }
@@ -306,6 +335,7 @@ impl Preview {
             Self::Dir(dv) => dv.try_select_y(y),
             Self::Text(sv) => sv.try_select_y(y),
             Self::Tty(v) => v.try_select_y(y),
+            Self::Diff(v) => v.try_select_y(y),
             _ => false,
         }
     }
@@ -318,6 +348,7 @@ impl Preview {
             Self::Dir(dv) => dv.move_selection(dy, cycle),
             Self::Text(sv) => sv.move_selection(dy, cycle),
             Self::Tty(v) => v.move_selection(dy, cycle),
+            Self::Diff(v) => v.move_selection(dy, cycle),
             Self::Hex(hv) => {
                 hv.try_scroll(ScrollCommand::Lines(dy));
             }
@@ -346,6 +377,7 @@ impl Preview {
             Self::Text(sv) => sv.select_first(),
             Self::Hex(hv) => hv.select_first(),
             Self::Tty(v) => v.select_first(),
+            Self::Diff(v) => v.select_first(),
             _ => {}
         }
     }
@@ -354,6 +386,7 @@ impl Preview {
             Self::Text(sv) => sv.select_last(),
             Self::Hex(hv) => hv.select_last(),
             Self::Tty(v) => v.select_last(),
+            Self::Diff(v) => v.select_last(),
             _ => {}
         }
     }
@@ -373,6 +406,7 @@ impl Preview {
             Self::ZeroLen(zlv) => zlv.display(w, screen, panel_skin, area),
             Self::Hex(hv) => hv.display(w, screen, panel_skin, area),
             Self::Tty(v) => v.display(w, screen, panel_skin, area),
+            Self::Diff(v) => v.display(w, screen, panel_skin, area, con),
             Self::IoError(err) => {
                 let mut y = area.top;
                 w.queue(cursor::MoveTo(area.left, y))?;
@@ -407,6 +441,7 @@ impl Preview {
             Self::Image(iv) => iv.display_info(w, screen, panel_skin, area),
             Self::Text(sv) => sv.display_info(w, screen, panel_skin, area),
             Self::Hex(hv) => hv.display_info(w, screen, panel_skin, area),
+            Self::Diff(v) => v.display_info(w, screen, panel_skin, area),
             _ => Ok(()),
         }
     }

--- a/src/preview/preview.rs
+++ b/src/preview/preview.rs
@@ -317,6 +317,7 @@ impl Preview {
     ) -> bool {
         match self {
             Self::Text(sv) => sv.try_select_line_number(number),
+            Self::Diff(v) => v.try_select_line_number(number),
             _ => false,
         }
     }
@@ -357,17 +358,17 @@ impl Preview {
     }
 
     pub fn previous_match(&mut self) {
-        if let Self::Text(sv) = self {
-            sv.previous_match();
-        } else {
-            self.move_selection(-1, true);
+        match self {
+            Self::Text(sv) => sv.previous_match(),
+            Self::Diff(v) => v.previous_change(),
+            _ => self.move_selection(-1, true),
         }
     }
     pub fn next_match(&mut self) {
-        if let Self::Text(sv) = self {
-            sv.next_match();
-        } else {
-            self.move_selection(1, true);
+        match self {
+            Self::Text(sv) => sv.next_match(),
+            Self::Diff(v) => v.next_change(),
+            _ => self.move_selection(1, true),
         }
     }
 

--- a/src/preview/preview_state.rs
+++ b/src/preview/preview_state.rs
@@ -48,6 +48,8 @@ pub struct PreviewState {
     pending_pattern: InputPattern, // a pattern (or not) which has not yet be applied
     filtered_preview: Option<Preview>,
     removed_pattern: InputPattern,
+    /// whether the diff preview was left to look at the file
+    left_diff: bool,
     preferred_mode: Option<PreviewMode>,
     tree_options: TreeOptions,
     mode: Mode,
@@ -81,6 +83,7 @@ impl PreviewState {
             pending_pattern,
             filtered_preview: None,
             removed_pattern: InputPattern::none(),
+            left_diff: false,
             preferred_mode,
             tree_options,
             mode: con.initial_mode(),
@@ -228,6 +231,7 @@ impl PanelState for PreviewState {
         let selected_line_number = if self.preview_path() == path {
             self.preview.get_selected_line_number()
         } else {
+            self.left_diff = false;
             None
         };
         if let Some(fp) = &self.filtered_preview {
@@ -447,11 +451,33 @@ impl PanelState for PreviewState {
                 self.pending_pattern = self.removed_pattern.take();
                 Ok(CmdResult::Keep)
             }
+            Internal::panel_left | Internal::panel_left_no_open if self.left_diff => {
+                // back to the diff, on the hunk of the selected line
+                let line_number = self.preview.get_selected_line_number();
+                self.preview = Preview::diff(self.preview_path(), con);
+                if let Some(number) = line_number {
+                    self.preview.try_select_line_number(number);
+                }
+                self.left_diff = false;
+                Ok(CmdResult::Keep)
+            }
             Internal::panel_right if self.filtered_preview.is_some() => {
                 self.on_pattern(InputPattern::none(), app_state, con)
             }
             Internal::panel_right_no_open if self.filtered_preview.is_some() => {
                 self.on_pattern(InputPattern::none(), app_state, con)
+            }
+            Internal::panel_right | Internal::panel_right_no_open
+                if self.preview.get_mode() == Some(PreviewMode::Diff) =>
+            {
+                // dive into the file, at the selected line
+                let line_number = self.preview.get_selected_line_number();
+                self.preview = Preview::unfiltered_text(self.preview_path(), con);
+                if let Some(number) = line_number {
+                    self.preview.try_select_line_number(number);
+                }
+                self.left_diff = true;
+                Ok(CmdResult::Keep)
             }
             Internal::select_first => {
                 self.mut_preview().select_first();

--- a/src/preview/preview_state.rs
+++ b/src/preview/preview_state.rs
@@ -13,6 +13,7 @@ use {
         },
         errors::ProgramError,
         flag::Flag,
+        git::LineGitStatus,
         pattern::InputPattern,
         task_sync::Dam,
         tree::TreeOptions,
@@ -36,11 +37,12 @@ use {
 /// an application state dedicated to previewing files.
 ///
 /// It's usually the only state in its panel and is kept when the
-/// selection changes (other panels indirectly call `set_selected_path`).
+/// selection changes (other panels indirectly call `set_selected`).
 pub struct PreviewState {
     pub preview_area: Area,
     dirty: bool,          // true when background must be cleared
     source_path: PathBuf, // path to the file whose preview is requested
+    source_git_status: Option<LineGitStatus>,
     transform: Option<PreviewTransform>,
     preview: Preview,
     pending_pattern: InputPattern, // a pattern (or not) which has not yet be applied
@@ -54,6 +56,7 @@ pub struct PreviewState {
 impl PreviewState {
     pub fn new(
         source_path: PathBuf,
+        source_git_status: Option<LineGitStatus>,
         pending_pattern: InputPattern,
         preferred_mode: Option<PreviewMode>,
         tree_options: TreeOptions,
@@ -63,15 +66,16 @@ impl PreviewState {
         let transform = con
             .preview_transformers
             .transform(&source_path, preferred_mode);
-        let preview_path = transform
-            .as_ref()
-            .map(|c| &c.output_path)
-            .unwrap_or(&source_path);
-        let preview = Preview::new(preview_path, preferred_mode, con);
+        let preview = match &transform {
+            // the git status doesn't apply to the transformed file
+            Some(transform) => Preview::new(&transform.output_path, None, preferred_mode, con),
+            None => Preview::new(&source_path, source_git_status, preferred_mode, con),
+        };
         PreviewState {
             preview_area,
             dirty: true,
             source_path,
+            source_git_status,
             transform,
             preview,
             pending_pattern,
@@ -115,18 +119,10 @@ impl PreviewState {
     fn no_opt_selection(&self) -> Selection<'_> {
         match self.transform.as_ref() {
             // When there's a transform, we can't assume the line number makes sense
-            Some(transform) => Selection {
-                path: &transform.output_path,
-                stype: SelectionType::File,
-                is_exe: false,
-                line: 0,
-            },
-            None => Selection {
-                path: &self.source_path,
-                stype: SelectionType::File,
-                is_exe: false,
-                line: self.vis_preview().get_selected_line_number().unwrap_or(0),
-            },
+            Some(transform) => Selection::new(&transform.output_path, SelectionType::File),
+            None => Selection::new(&self.source_path, SelectionType::File)
+                .with_line(self.vis_preview().get_selected_line_number().unwrap_or(0))
+                .with_git_status(self.source_git_status),
         }
     }
 
@@ -223,9 +219,10 @@ impl PanelState for PreviewState {
         Some(&self.source_path)
     }
 
-    fn set_selected_path(
+    fn set_selected(
         &mut self,
         path: PathBuf,
+        git_status: Option<LineGitStatus>,
         con: &AppContext,
     ) {
         let selected_line_number = if self.preview_path() == path {
@@ -239,12 +236,16 @@ impl PanelState for PreviewState {
         self.transform = con
             .preview_transformers
             .transform(&path, self.preferred_mode);
-        let preview_path = self.transform.as_ref().map_or(&path, |c| &c.output_path);
-        self.preview = Preview::new(preview_path, self.preferred_mode, con);
+        self.preview = match &self.transform {
+            // the git status doesn't apply to the transformed file
+            Some(transform) => Preview::new(&transform.output_path, None, self.preferred_mode, con),
+            None => Preview::new(&path, git_status, self.preferred_mode, con),
+        };
         if let Some(number) = selected_line_number {
             self.preview.try_select_line_number(number);
         }
         self.source_path = path;
+        self.source_git_status = git_status;
     }
 
     fn selection(&self) -> Option<Selection<'_>> {
@@ -276,7 +277,7 @@ impl PanelState for PreviewState {
         con: &AppContext,
     ) -> Command {
         self.dirty = true;
-        self.set_selected_path(self.source_path.clone(), con);
+        self.set_selected(self.source_path.clone(), self.source_git_status, con);
         Command::empty()
     }
 
@@ -319,6 +320,10 @@ impl PanelState for PreviewState {
         let styles = &disc.panel_skin.styles;
         w.queue(cursor::MoveTo(state_area.left, 0))?;
         let mut cw = CropWriter::new(w, state_area.width as usize);
+        if let Some(git_status) = self.source_git_status {
+            cw.queue_char(styles.git_status_style(git_status), git_status.letter())?;
+            cw.queue_char(&styles.preview_title, ' ')?;
+        }
         let file_name = self
             .source_path
             .file_name()
@@ -468,6 +473,7 @@ impl PanelState for PreviewState {
             Internal::preview_text => self.set_mode(PreviewMode::Text, con),
             Internal::preview_tty => self.set_mode(PreviewMode::Tty, con),
             Internal::preview_binary => self.set_mode(PreviewMode::Hex, con),
+            Internal::preview_diff => self.set_mode(PreviewMode::Diff, con),
             _ => self.on_internal_generic(
                 w,
                 invocation_parser,

--- a/src/preview/unified_diff_view.rs
+++ b/src/preview/unified_diff_view.rs
@@ -1,0 +1,339 @@
+use {
+    crate::{
+        app::{
+            AppContext,
+            LineNumber,
+        },
+        command::{
+            ScrollCommand,
+            move_sel,
+        },
+        display::{
+            Screen,
+            W,
+        },
+        errors::ProgramError,
+        git::{
+            DiffLineKind,
+            FileDiff,
+            FileDiffContent,
+            diff_worktree_vs_head,
+        },
+        skin::PanelSkin,
+        syntactic::SEPARATOR_FILLING,
+    },
+    crokey::crossterm::{
+        QueueableCommand,
+        cursor,
+        style::{
+            Color,
+            Print,
+            SetBackgroundColor,
+            SetForegroundColor,
+        },
+    },
+    std::path::Path,
+    termimad::{
+        Area,
+        CropWriter,
+        SPACE_FILLING,
+    },
+};
+
+/// A displayed row of the diff
+#[derive(Debug, Clone, Copy)]
+enum Row {
+    /// indexes of the hunk and of the line in the hunk
+    Line(usize, usize),
+    /// a separator between two hunks
+    Separator,
+}
+
+/// A preview showing the changes of a file since the last commit,
+/// as a unified diff
+pub struct UnifiedDiffView {
+    diff: FileDiff,
+    rows: Vec<Row>,
+    scroll: usize,
+    page_height: usize,
+    selection_idx: Option<usize>,
+}
+
+impl UnifiedDiffView {
+    pub fn new(
+        path: &Path,
+        con: &AppContext,
+    ) -> Result<Self, ProgramError> {
+        let diff = diff_worktree_vs_head(path, con.lines_around_diff_hunks)?;
+        let mut rows = Vec::new();
+        if let FileDiffContent::Text(hunks) = &diff.content {
+            for (hunk_idx, hunk) in hunks.iter().enumerate() {
+                if hunk_idx > 0 {
+                    rows.push(Row::Separator);
+                }
+                for line_idx in 0..hunk.lines.len() {
+                    rows.push(Row::Line(hunk_idx, line_idx));
+                }
+            }
+        }
+        Ok(Self {
+            diff,
+            rows,
+            scroll: 0,
+            page_height: 0,
+            selection_idx: None,
+        })
+    }
+    fn line(
+        &self,
+        row: Row,
+    ) -> Option<&crate::git::DiffLine> {
+        match (row, &self.diff.content) {
+            (Row::Line(hunk_idx, line_idx), FileDiffContent::Text(hunks)) => {
+                hunks.get(hunk_idx).and_then(|hunk| hunk.lines.get(line_idx))
+            }
+            _ => None,
+        }
+    }
+    fn max_line_number(&self) -> usize {
+        match &self.diff.content {
+            FileDiffContent::Text(hunks) => hunks
+                .last()
+                .map(|hunk| {
+                    (hunk.old_start + hunk.old_len).max(hunk.new_start + hunk.new_len)
+                })
+                .unwrap_or(0),
+            _ => 0,
+        }
+    }
+    fn ensure_selection_is_visible(&mut self) {
+        if self.page_height >= self.rows.len() {
+            self.scroll = 0;
+        } else if let Some(idx) = self.selection_idx {
+            let padding = self.padding();
+            if idx < self.scroll + padding || idx + padding > self.scroll + self.page_height {
+                if idx <= padding {
+                    self.scroll = 0;
+                } else if idx + padding > self.rows.len() {
+                    self.scroll = self.rows.len() - self.page_height;
+                } else if idx < self.scroll + self.page_height / 2 {
+                    self.scroll = idx - padding;
+                } else {
+                    self.scroll = idx + padding - self.page_height;
+                }
+            }
+        }
+    }
+    fn padding(&self) -> usize {
+        (self.page_height / 4).min(4)
+    }
+    /// Return the number, in the current version of the file, of the
+    /// selected line or of the closest following one
+    pub fn get_selected_line_number(&self) -> Option<LineNumber> {
+        let idx = self.selection_idx?;
+        self.rows[idx..]
+            .iter()
+            .find_map(|&row| self.line(row).and_then(|line| line.new_number))
+    }
+    pub fn get_selected_line(&self) -> Option<String> {
+        self.selection_idx
+            .and_then(|idx| self.line(self.rows[idx]))
+            .map(|line| line.content.clone())
+    }
+    pub fn try_select_y(
+        &mut self,
+        y: u16,
+    ) -> bool {
+        let idx = y as usize + self.scroll;
+        if idx < self.rows.len() {
+            self.selection_idx = Some(idx);
+            true
+        } else {
+            false
+        }
+    }
+    pub fn select_first(&mut self) {
+        if !self.rows.is_empty() {
+            self.selection_idx = Some(0);
+            self.scroll = 0;
+        }
+    }
+    pub fn select_last(&mut self) {
+        if !self.rows.is_empty() {
+            self.selection_idx = Some(self.rows.len() - 1);
+            self.ensure_selection_is_visible();
+        }
+    }
+    pub fn move_selection(
+        &mut self,
+        dy: i32,
+        cycle: bool,
+    ) {
+        if let Some(idx) = self.selection_idx {
+            self.selection_idx = Some(move_sel(idx, self.rows.len(), dy, cycle));
+        } else if !self.rows.is_empty() {
+            self.selection_idx = Some(0);
+        }
+        self.ensure_selection_is_visible();
+    }
+    pub fn try_scroll(
+        &mut self,
+        cmd: ScrollCommand,
+    ) -> bool {
+        let old_scroll = self.scroll;
+        self.scroll = cmd.apply(self.scroll, self.rows.len(), self.page_height);
+        if let Some(idx) = self.selection_idx {
+            if self.scroll == old_scroll {
+                let old_selection = self.selection_idx;
+                if cmd.is_up() {
+                    self.selection_idx = Some(0);
+                } else {
+                    self.selection_idx = Some(self.rows.len() - 1);
+                }
+                return self.selection_idx == old_selection;
+            } else if idx >= old_scroll && idx < old_scroll + self.page_height {
+                if idx + self.scroll < old_scroll {
+                    self.selection_idx = Some(0);
+                } else if idx + self.scroll - old_scroll >= self.rows.len() {
+                    self.selection_idx = Some(self.rows.len() - 1);
+                } else {
+                    self.selection_idx = Some(idx + self.scroll - old_scroll);
+                }
+            }
+        }
+        self.scroll != old_scroll
+    }
+    pub fn display(
+        &mut self,
+        w: &mut W,
+        _screen: Screen,
+        panel_skin: &PanelSkin,
+        area: &Area,
+        con: &AppContext,
+    ) -> Result<(), ProgramError> {
+        if area.height as usize != self.page_height {
+            self.page_height = area.height as usize;
+            self.ensure_selection_is_visible();
+        }
+        let styles = &panel_skin.styles;
+        let number_len = self.max_line_number().to_string().len();
+        let show_line_numbers = area.width as usize > 2 * number_len + 30;
+        let code_width = area.width as usize - 1; // 1 char left for scrollbar
+        let scrollbar = area.scrollbar(self.scroll, self.rows.len());
+        let scrollbar_fg = styles
+            .scrollbar_thumb
+            .get_fg()
+            .or_else(|| styles.preview.get_fg())
+            .unwrap_or(Color::White);
+        for y in 0..area.height as usize {
+            w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
+            let mut cw = CropWriter::new(w, code_width);
+            let row_idx = self.scroll + y;
+            let selected = self.selection_idx == Some(row_idx);
+            match self.rows.get(row_idx) {
+                Some(Row::Separator) => {
+                    cw.queue_unstyled_str(" ")?;
+                    cw.fill(&styles.preview_separator, &SEPARATOR_FILLING)?;
+                }
+                Some(&row @ Row::Line(..)) => {
+                    let Some(line) = self.line(row) else {
+                        continue;
+                    };
+                    let (line_style, sign) = match line.kind {
+                        DiffLineKind::Context => (&styles.preview, ' '),
+                        DiffLineKind::Added => (&styles.diff_added, '+'),
+                        DiffLineKind::Removed => (&styles.diff_removed, '-'),
+                    };
+                    let style = if selected {
+                        &styles.selected_line
+                    } else {
+                        line_style
+                    };
+                    if show_line_numbers {
+                        let number = |n: Option<usize>| match n {
+                            Some(n) => format!("{n:>number_len$}"),
+                            None => " ".repeat(number_len),
+                        };
+                        cw.queue_g_string(
+                            &styles.diff_line_number,
+                            format!(
+                                " {} {} ",
+                                number(line.old_number),
+                                number(line.new_number),
+                            ),
+                        )?;
+                    }
+                    if con.show_selection_mark {
+                        cw.queue_char(style, if selected { '▶' } else { ' ' })?;
+                    }
+                    cw.queue_char(style, sign)?;
+                    cw.queue_char(style, ' ')?;
+                    cw.queue_str(style, &line.content)?;
+                    cw.fill(style, &SPACE_FILLING)?;
+                }
+                None => {
+                    cw.fill(&styles.preview, &SPACE_FILLING)?;
+                }
+            }
+            if is_thumb(y + area.top as usize, scrollbar) {
+                w.queue(SetForegroundColor(scrollbar_fg))?;
+                w.queue(Print('▐'))?;
+            } else {
+                let bg = styles
+                    .preview
+                    .get_bg()
+                    .or_else(|| styles.default.get_bg())
+                    .unwrap_or(Color::Reset);
+                w.queue(SetBackgroundColor(bg))?;
+                w.queue(Print(' '))?;
+            }
+        }
+        Ok(())
+    }
+    pub fn display_info(
+        &mut self,
+        w: &mut W,
+        _screen: Screen,
+        panel_skin: &PanelSkin,
+        area: &Area,
+    ) -> Result<(), ProgramError> {
+        let styles = &panel_skin.styles;
+        let width = area.width as usize;
+        match &self.diff.content {
+            FileDiffContent::Text(_) => {
+                let insertions = format!("+{}", self.diff.insertions);
+                let deletions = format!("-{}", self.diff.deletions);
+                let len = insertions.len() + deletions.len();
+                if len > width {
+                    return Ok(());
+                }
+                w.queue(cursor::MoveTo(area.left + (width - len) as u16, area.top))?;
+                styles.git_insertions.queue(w, insertions)?;
+                styles.git_deletions.queue(w, deletions)?;
+            }
+            FileDiffContent::Binary | FileDiffContent::Unchanged => {
+                let s = if matches!(self.diff.content, FileDiffContent::Binary) {
+                    "binary"
+                } else {
+                    "no change"
+                };
+                if s.len() > width {
+                    return Ok(());
+                }
+                w.queue(cursor::MoveTo(area.left + (width - s.len()) as u16, area.top))?;
+                styles.default.queue(w, s)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_thumb(
+    y: usize,
+    scrollbar: Option<(u16, u16)>,
+) -> bool {
+    scrollbar.is_some_and(|(top, bottom)| {
+        let y = y as u16;
+        top <= y && y <= bottom
+    })
+}

--- a/src/preview/unified_diff_view.rs
+++ b/src/preview/unified_diff_view.rs
@@ -65,6 +65,9 @@ impl UnifiedDiffView {
         con: &AppContext,
     ) -> Result<Self, ProgramError> {
         let diff = diff_worktree_vs_head(path, con.lines_around_diff_hunks)?;
+        Ok(Self::from_diff(diff))
+    }
+    pub fn from_diff(diff: FileDiff) -> Self {
         let mut rows = Vec::new();
         if let FileDiffContent::Text(hunks) = &diff.content {
             for (hunk_idx, hunk) in hunks.iter().enumerate() {
@@ -76,13 +79,13 @@ impl UnifiedDiffView {
                 }
             }
         }
-        Ok(Self {
+        Self {
             diff,
             rows,
             scroll: 0,
             page_height: 0,
             selection_idx: None,
-        })
+        }
     }
     fn line(
         &self,
@@ -139,6 +142,64 @@ impl UnifiedDiffView {
         self.selection_idx
             .and_then(|idx| self.line(self.rows[idx]))
             .map(|line| line.content.clone())
+    }
+    /// Select the row of the line having this number in the current version
+    /// of the file, or the closest following one
+    pub fn try_select_line_number(
+        &mut self,
+        number: LineNumber,
+    ) -> bool {
+        let idx = self.rows.iter().position(|&row| {
+            self.line(row)
+                .and_then(|line| line.new_number)
+                .is_some_and(|n| n >= number)
+        });
+        if let Some(idx) = idx {
+            self.selection_idx = Some(idx);
+            self.ensure_selection_is_visible();
+        }
+        idx.is_some()
+    }
+    fn is_changed(
+        &self,
+        idx: usize,
+    ) -> bool {
+        self.rows
+            .get(idx)
+            .and_then(|&row| self.line(row))
+            .is_some_and(|line| line.kind != DiffLineKind::Context)
+    }
+    /// Return whether the row is the first line of a block of
+    /// consecutive changed lines
+    fn is_change_start(
+        &self,
+        idx: usize,
+    ) -> bool {
+        self.is_changed(idx) && (idx == 0 || !self.is_changed(idx - 1))
+    }
+    /// Select the first line of the next block of changes
+    pub fn next_change(&mut self) {
+        let s = self.selection_idx.unwrap_or(self.rows.len().saturating_sub(1));
+        for d in 1..=self.rows.len() {
+            let idx = (s + d) % self.rows.len();
+            if self.is_change_start(idx) {
+                self.selection_idx = Some(idx);
+                self.ensure_selection_is_visible();
+                return;
+            }
+        }
+    }
+    /// Select the first line of the previous block of changes
+    pub fn previous_change(&mut self) {
+        let s = self.selection_idx.unwrap_or(0);
+        for d in 1..=self.rows.len() {
+            let idx = (self.rows.len() + s - d) % self.rows.len();
+            if self.is_change_start(idx) {
+                self.selection_idx = Some(idx);
+                self.ensure_selection_is_visible();
+                return;
+            }
+        }
     }
     pub fn try_select_y(
         &mut self,
@@ -336,4 +397,66 @@ fn is_thumb(
         let y = y as u16;
         top <= y && y <= bottom
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::git::{
+            DiffLine,
+            Hunk,
+        },
+    };
+
+    fn line(kind: DiffLineKind, n: usize) -> DiffLine {
+        DiffLine {
+            kind,
+            old_number: Some(n),
+            new_number: Some(n),
+            content: String::new(),
+        }
+    }
+    /// a hunk made of the given pattern of context (' ') and changed ('+') lines
+    fn hunk(start: usize, pattern: &str) -> Hunk {
+        let lines: Vec<DiffLine> = pattern
+            .chars()
+            .enumerate()
+            .map(|(i, c)| {
+                let kind = if c == ' ' { DiffLineKind::Context } else { DiffLineKind::Added };
+                line(kind, start + i)
+            })
+            .collect();
+        Hunk { old_start: start, old_len: lines.len(), new_start: start, new_len: lines.len(), lines }
+    }
+
+    #[test]
+    fn change_cycling() {
+        let diff = FileDiff {
+            path: std::path::PathBuf::from("f"),
+            // the last hunk has two blocks of changes
+            content: FileDiffContent::Text(vec![hunk(1, " ++ "), hunk(20, " + "), hunk(40, " +++  + ")]),
+            insertions: 7,
+            deletions: 0,
+        };
+        let mut view = UnifiedDiffView::from_diff(diff);
+        view.page_height = 10;
+        // rows: h0 = 0..4, sep 4, h1 = 5..8, sep 8, h2 = 9..17
+        let starts: Vec<usize> = (0..view.rows.len()).filter(|&i| view.is_change_start(i)).collect();
+        assert_eq!(starts, vec![1, 6, 10, 15]);
+        view.next_change();
+        assert_eq!(view.selection_idx, Some(1));
+        view.next_change();
+        assert_eq!(view.selection_idx, Some(6));
+        view.next_change();
+        assert_eq!(view.selection_idx, Some(10));
+        view.next_change();
+        assert_eq!(view.selection_idx, Some(15));
+        view.next_change();
+        assert_eq!(view.selection_idx, Some(1));
+        view.previous_change();
+        assert_eq!(view.selection_idx, Some(15));
+        view.previous_change();
+        assert_eq!(view.selection_idx, Some(10));
+    }
 }

--- a/src/skin/style_map.rs
+++ b/src/skin/style_map.rs
@@ -186,6 +186,7 @@ StyleMap! {
     git_deletions: ansi(160), None, []
     git_status_current: gray(5), None, []
     git_status_modified: ansi(28), None, []
+    git_status_staged: ansi(34), None, []
     git_status_new: ansi(94), None, [Bold]
     git_status_ignored: gray(17), None, []
     git_status_conflicted: ansi(88), None, []

--- a/src/skin/style_map.rs
+++ b/src/skin/style_map.rs
@@ -5,7 +5,10 @@
 /// one (there are thus two instances in the application)
 use {
     super::*,
-    crate::errors::ProgramError,
+    crate::{
+        errors::ProgramError,
+        git::LineGitStatus,
+    },
     crokey::crossterm::{
         QueueableCommand,
         style::{
@@ -131,6 +134,20 @@ impl StyleMap {
         }
         Ok(())
     }
+    /// Return the style of the letter showing a git status
+    pub fn git_status_style(
+        &self,
+        status: LineGitStatus,
+    ) -> &CompoundStyle {
+        match status {
+            LineGitStatus::New | LineGitStatus::Renamed => &self.git_status_new,
+            LineGitStatus::Added | LineGitStatus::Staged => &self.git_status_staged,
+            LineGitStatus::Modified => &self.git_status_modified,
+            LineGitStatus::Conflicted => &self.git_status_conflicted,
+            LineGitStatus::Ignored => &self.git_status_ignored,
+            LineGitStatus::Other => &self.git_status_other,
+        }
+    }
     pub fn good_to_bad_color(
         &self,
         value: f64,
@@ -221,6 +238,9 @@ StyleMap! {
     preview_line_number: gray(12), gray(3), []
     preview_separator: gray(7), None, []
     preview_match: None, ansi(29), []
+    diff_line_number: gray(12), gray(3), []
+    diff_added: gray(22), rgb(28, 68, 40), []
+    diff_removed: gray(22), rgb(88, 34, 34), []
     hex_null: gray(8), None, []
     hex_ascii_graphic: gray(18), None, []
     hex_ascii_whitespace: ansi(143), None, []

--- a/src/stage/stage.rs
+++ b/src/stage/stage.rs
@@ -108,12 +108,7 @@ impl Stage {
     pub fn to_selections(&self) -> Vec<Selection<'_>> {
         self.paths
             .iter()
-            .map(|path| Selection {
-                path,
-                line: 0,
-                stype: SelectionType::from(path),
-                is_exe: false,
-            })
+            .map(|path| Selection::from_path(path))
             .collect()
     }
 }

--- a/src/stage/stage_state.rs
+++ b/src/stage/stage_state.rs
@@ -187,12 +187,10 @@ impl PanelState for StageState {
     ) -> SelInfo<'c> {
         match app_state.stage.len() {
             0 => SelInfo::None,
-            1 => SelInfo::One(Selection {
-                path: &app_state.stage.paths()[0],
-                stype: SelectionType::File,
-                is_exe: false,
-                line: 0,
-            }),
+            1 => SelInfo::One(Selection::new(
+                &app_state.stage.paths()[0],
+                SelectionType::File,
+            )),
             _ => SelInfo::More(&app_state.stage),
         }
     }

--- a/src/syntactic/mod.rs
+++ b/src/syntactic/mod.rs
@@ -3,7 +3,11 @@ mod syntax_theme;
 mod syntaxer;
 
 pub use {
-    text_view::TextView,
+    text_view::{
+        SEPARATOR_FILLING,
+        TextView,
+        is_char_unprintable,
+    },
     syntax_theme::*,
     syntaxer::{
         SYNTAXER,

--- a/src/syntactic/text_view.rs
+++ b/src/syntactic/text_view.rs
@@ -674,7 +674,7 @@ fn is_thumb(
 }
 
 /// Tell whether the character must be replaced to prevent rendering from being broken
-fn is_char_unprintable(c: char) -> bool {
+pub fn is_char_unprintable(c: char) -> bool {
     match c {
         '\u{8}' => true, // backspace
         '\u{b}'..='\u{e}' => true,

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -442,13 +442,7 @@ impl Tree {
         for di in (0..self.lines.len()).rev() {
             let idx = (self.selection + di) % self.lines.len();
             let line = &self.lines[idx];
-            if !line.is_selectable() {
-                continue;
-            }
-            if !filter(line) {
-                continue;
-            }
-            if line.score > 0 {
+            if line.is_selectable() && filter(line) {
                 self.selection = idx;
                 self.make_selection_visible(page_height);
                 return true;
@@ -467,13 +461,7 @@ impl Tree {
         for di in 0..self.lines.len() {
             let idx = (self.selection + di + 1) % self.lines.len();
             let line = &self.lines[idx];
-            if !line.is_selectable() {
-                continue;
-            }
-            if !filter(line) {
-                continue;
-            }
-            if line.score > 0 {
+            if line.is_selectable() && filter(line) {
                 self.selection = idx;
                 self.make_selection_visible(page_height);
                 return true;

--- a/src/tree/tree_line.rs
+++ b/src/tree/tree_line.rs
@@ -195,12 +195,9 @@ impl TreeLine {
         }
     }
     pub fn as_selection(&self) -> Selection<'_> {
-        Selection {
-            path: &self.path,
-            stype: self.selection_type(),
-            is_exe: self.is_exe(),
-            line: 0,
-        }
+        Selection::new(&self.path, self.selection_type())
+            .with_exe(self.is_exe())
+            .with_git_status(self.git_status)
     }
     #[cfg(unix)]
     pub fn mode(&self) -> Mode {

--- a/src/tree/tree_options.rs
+++ b/src/tree/tree_options.rs
@@ -163,8 +163,20 @@ impl TreeOptions {
         if let Some(max_depth) = cli_args.max_depth {
             self.max_depth = Some(max_depth);
         }
+        // git information level: 0 nothing, 1 statuses of files, 2 only files with a status
+        let mut level: u8 = match (self.filter_by_git_status, self.show_git_file_info) {
+            (true, _) => 2,
+            (false, true) => 1,
+            (false, false) => 0,
+        };
+        level = level.saturating_add(cli_args.show_git_info).min(2);
         if cli_args.git_status {
-            self.filter_by_git_status = true;
+            level = 2;
+        }
+        level = level.saturating_sub(cli_args.no_show_git_info);
+        self.show_git_file_info = level >= 1;
+        self.filter_by_git_status = level == 2;
+        if level == 2 && (cli_args.show_git_info > 0 || cli_args.git_status) {
             self.show_hidden = true;
         }
         if cli_args.hidden {
@@ -189,11 +201,6 @@ impl TreeOptions {
             self.respect_git_ignore = false;
         } else if cli_args.no_git_ignored {
             self.respect_git_ignore = true;
-        }
-        if cli_args.show_git_info {
-            self.show_git_file_info = true;
-        } else if cli_args.no_show_git_info {
-            self.show_git_file_info = false;
         }
         if cli_args.sort_by_count {
             self.sort = Sort::Count;

--- a/src/tree_build/builder.rs
+++ b/src/tree_build/builder.rs
@@ -23,7 +23,6 @@ use {
         },
         tree::*,
     },
-    git2::Repository,
     id_arena::Arena,
     std::{
         collections::{
@@ -97,10 +96,7 @@ impl<'c> TreeBuilder<'c> {
         let line_status_computer = if options.filter_by_git_status || options.show_git_file_info {
             time!(
                 "init line_status_computer",
-                Repository::discover(&path)
-                    .ok()
-                    .as_ref()
-                    .and_then(LineStatusComputer::from),
+                LineStatusComputer::from_root(&path),
             )
         } else {
             None

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -3,6 +3,7 @@ use {
     crate::{
         app::*,
         command::*,
+        git,
         path::{
             self,
             PathAnchor,
@@ -183,26 +184,21 @@ impl<'b> ExecutionBuilder<'b> {
             "git-root" => {
                 // path to git repo workdir
                 debug!("finding git root");
-                sel.and_then(|s| git2::Repository::discover(s.path).ok())
-                    .and_then(|repo| repo.workdir().map(|p| self.path_to_string(p)))
+                sel.and_then(|s| git::workdir(s.path))
+                    .map(|p| self.path_to_string(&p))
             }
             "git-name" => {
                 // name of the git repo workdir
-                sel.and_then(|s| git2::Repository::discover(s.path).ok())
-                    .and_then(|repo| {
-                        repo.workdir().and_then(|path| {
-                            path.file_name()
-                                .and_then(|oss| oss.to_str())
-                                .map(|s| s.to_string())
-                        })
-                    })
+                sel.and_then(|s| git::workdir(s.path)).and_then(|path| {
+                    path.file_name()
+                        .and_then(|oss| oss.to_str())
+                        .map(|s| s.to_string())
+                })
             }
             "file-git-relative" => {
                 // file path relative to git repo workdir
                 let sel = sel?;
-                let path = git2::Repository::discover(self.root)
-                    .ok()
-                    .and_then(|repo| repo.workdir().map(|p| self.path_to_string(p)))
+                let path = git::workdir(self.root)
                     .and_then(|gitroot| sel.path.strip_prefix(gitroot).ok())
                     .filter(|p| {
                         // it's empty when the file is both the tree root and the git root

--- a/src/verb/execution_builder.rs
+++ b/src/verb/execution_builder.rs
@@ -539,12 +539,7 @@ mod execution_builder_test {
         chk_exec_token: Vec<&str>,
     ) {
         let path = PathBuf::from(path);
-        let sel = Selection {
-            path: &path,
-            line: 0,
-            stype: SelectionType::File,
-            is_exe: false,
-        };
+        let sel = Selection::new(&path, SelectionType::File);
         let app_state = AppState::new(PathBuf::from("/".to_owned()));
         let mut builder = ExecutionBuilder::without_invocation(SelInfo::One(sel), &app_state);
         let mut map = FxHashMap::default();

--- a/src/verb/external_execution.rs
+++ b/src/verb/external_execution.rs
@@ -240,12 +240,7 @@ impl ExternalExecution {
                 match coarity {
                     CommandCoarity::PerSelection => {
                         // we execute once per selection
-                        let sels = stage.paths().iter().map(|path| Selection {
-                            path,
-                            line: 0,
-                            stype: SelectionType::from(path),
-                            is_exe: false,
-                        });
+                        let sels = stage.paths().iter().map(|path| Selection::from_path(path));
                         let n = sels.len();
                         for (i, sel) in sels.enumerate() {
                             let launchable = self.sel_launchable(

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -108,6 +108,7 @@ Internals! {
     panel_right_no_open: "either focus panel on right or close left one" false,
     parent: "move to the parent directory" false,
     preview_binary: "preview the selection as binary" true,
+    preview_diff: "preview the changes of the selection since the last commit" true,
     preview_image: "preview the selection as image" true,
     preview_text: "preview the selection as text" true,
     preview_tty: "preview the selection as tty" true,

--- a/src/verb/internal_focus.rs
+++ b/src/verb/internal_focus.rs
@@ -76,7 +76,7 @@ pub fn new_panel_on_path(
     if purpose.is_preview() {
         let pattern = tree_options.pattern.tree_to_preview();
         CmdResult::NewPanel {
-            state: Box::new(PreviewState::new(path, pattern, None, tree_options, con)),
+            state: Box::new(PreviewState::new(path, None, pattern, None, tree_options, con)),
             purpose,
             direction,
         }

--- a/src/verb/verb.rs
+++ b/src/verb/verb.rs
@@ -214,12 +214,7 @@ impl Verb {
                 .paths()
                 .iter()
                 .filter_map(|path| {
-                    let sel = Selection {
-                        path,
-                        line: 0,
-                        stype: SelectionType::from(path),
-                        is_exe: false,
-                    };
+                    let sel = Selection::from_path(path);
                     self.check_sel_args(Some(sel), invocation, other_path)
                 })
                 .next(),

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -331,7 +331,9 @@ impl VerbStore {
             .with_key(key!(alt - i))
             .with_shortcut("gi");
         self.add_internal(toggle_git_file_info).with_shortcut("gf");
-        self.add_internal(toggle_git_status).with_shortcut("gs");
+        self.add_internal(toggle_git_status)
+            .with_key(key!(alt - g))
+            .with_shortcut("gs");
         self.add_internal(toggle_root_fs).with_shortcut("rfs");
         self.add_internal(set_max_depth);
         self.add_internal(unset_max_depth);

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -134,6 +134,7 @@ impl VerbStore {
         self.add_internal(preview_text).with_shortcut("txt");
         self.add_internal(preview_binary).with_shortcut("hex");
         self.add_internal(preview_tty).with_shortcut("tty");
+        self.add_internal(preview_diff);
         self.add_internal(close_panel_ok);
         self.add_internal(close_panel_cancel)
             .with_key(key!(ctrl - w));

--- a/website/src/common-problems.md
+++ b/website/src/common-problems.md
@@ -67,6 +67,8 @@ Note that this will change the behavior of `alt+enter` for all terminal windows,
 
 * [relevant issue](https://github.com/Canop/broot/issues/682)
 
+Other `alt` combinations, like <kbd>alt</kbd><kbd>g</kbd>, reach broot through the [Kitty keyboard protocol](../conf_file/#keyboard-enhancements), which broot enables by default in iTerm2. If you disabled it, either enable it again or set *Preferences->Profiles->Default->Keys->Left Option key* to `Esc+` (this prevents typing the characters composed with the option key, a problem on international layouts).
+
 **Ghostty**
 
 On macOS, [Ghostty](https://ghostty.org/) binds `alt+left` and `alt+right` by default to send the word-movement sequences `ESC b` and `ESC f`, so broot never receives those key combinations. To reclaim them, add this to your Ghostty configuration (`~/.config/ghostty/config`):

--- a/website/src/conf_file.md
+++ b/website/src/conf_file.md
@@ -430,16 +430,12 @@ And you'll get
 
 ## Keyboard enhancements
 
-By default, ANSI terminals make a lot of keyboard combinations impossible, for example <kbd>space</kbd><kbd>n</kbd>, or <kbd>alt</kbd><kbd>a</kbd><kbd>b</kbd>, or <kbd>shift</kbd><kbd>space</kbd>, etc.
-Some terminals implement [Kitty's keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) and basically make it possible to bind verbs to such combinations.
+Standard ANSI terminals make a lot of keyboard combinations impossible, for example <kbd>shift</kbd><kbd>space</kbd>, <kbd>alt</kbd><kbd>a</kbd><kbd>b</kbd>, or <kbd>space</kbd><kbd>n</kbd>.
+Many terminals implement [Kitty's keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) (Kitty, Wezterm, Ghostty, iTerm2, foot, etc.), which makes it possible to bind verbs to such combinations.
 
-Broot tests whether the terminal supports those enhancements, and if it's the case, tries to enable them.
+Broot tests whether the terminal supports this protocol, and if it's the case, enables it. It also makes <kbd>alt</kbd> combinations work on macOS terminals which otherwise let the option key compose characters.
 
-A small downside is that broot will react on key release instead of key press (so that you may press other keys before you release the first one), which may feel less instant. If the Kitty protocol isn't supported by your terminal, broot will react on key press.
-Another problem is that it may push you towards key combinations that you wouldn't be able to reuse when switching terminal.
-And finally, some terminals have buggy implementations (at time of writing).
-
-To enable those keyboard enhancements change this setting to true
+Multi-key combinations without modifier, like <kbd>space</kbd><kbd>n</kbd> or <kbd>a</kbd><kbd>b</kbd>, aren't enabled by default because they need broot to react on key release instead of key press (so that you may press other keys before you release the first one), which feels less instant. To enable them, set this to true:
 
 ```Hjson
 enable_kitty_keyboard: true
@@ -447,6 +443,10 @@ enable_kitty_keyboard: true
 ```TOML
 enable_kitty_keyboard = true
 ```
+
+Set it to false to not use the protocol at all (for example if your terminal has a buggy implementation).
+
+Keep in mind that combinations which are only possible with this protocol won't be available when switching to a terminal without it.
 
 ## Staging area
 

--- a/website/src/conf_file.md
+++ b/website/src/conf_file.md
@@ -98,6 +98,8 @@ Those flags can still be overridden at launch with the negating ones. For exampl
 
     br -H
 
+Some flags can be repeated: `-gg` shows only the files with a git status, and `-G` removes one level of git information (so with `default_flags: -gg`, `br -G` shows all files, with their git status).
+
 # Special Paths
 
 You may map special paths to specific behaviors. You may for example

--- a/website/src/conf_verbs.md
+++ b/website/src/conf_verbs.md
@@ -496,6 +496,7 @@ invocation | default key | default shortcut | behavior / details
 :panel_right_no_open | -  | - | move to panel to the right
 :parent | - | - | focus the parent directory
 :preview_binary | - | - | preview the selection as binary
+:preview_diff | - | - | preview the changes of the selection since the last commit
 :preview_image | - | - | preview the selection as image
 :preview_text | - | - | preview the selection as text
 :preview_tty | - | - | preview the selection as tty (with ANSI escape codes)

--- a/website/src/conf_verbs.md
+++ b/website/src/conf_verbs.md
@@ -532,7 +532,7 @@ invocation | default key | default shortcut | behavior / details
 :toggle_device_id | - | - | toggle display of device id (unix only)
 :toggle_files | - | - | toggle showing files (or just folders)
 :toggle_git_file_info | - | - | toggle display of git file information
-:toggle_git_status | - | - | toggle showing only the file which would show up on `git status`
+:toggle_git_status | <kbd>alt</kbd><kbd>g</kbd> | gs | toggle showing only the file which would show up on `git status`
 :toggle_hidden | - | - | toggle display of hidden files (the ones whose name starts with a dot on linux)
 :toggle_ignore | - | - | toggle display of files in .gitignore and .ignore
 :toggle_perm | - | - | toggle display of permissions (not available on Windows)

--- a/website/src/index.md
+++ b/website/src/index.md
@@ -164,7 +164,9 @@ If you hit `:fs`, you can check the usage of all filesystems, so that you focus 
 
 # Check git statuses:
 
-Use `:gf` to display the statuses of files (what are the new ones, the modified ones, etc.), the current branch name and the change statistics.
+Use `:gf` to display the statuses of files (what are the new ones, the modified ones, etc.), the current branch name, how many commits it is ahead (`↑`) or behind (`↓`) its upstream branch, and the change statistics.
+
+The letter tells the state of the file: `N` untracked, `A` staged (new), `S` staged modification, `M` modified in the working tree, `R` renamed, `C` conflict, `I` ignored.
 
 ![size](img/20230930-git.png)
 

--- a/website/src/launch.md
+++ b/website/src/launch.md
@@ -37,7 +37,7 @@ Here are the most frequently used:
 
 * `-d` and `-D`: showing (or hiding) dates
 * `-f` and `-F`: showing only folders
-* `-g` and `-G`: git info
+* `-g` and `-G`: git info (`-gg` to only show the files with a git status, as `--git-status` does)
 * `-h` and `-H`: whether to show "hidden" files (whose name starts with a dot on unix)
 * `-i` and `-I`: whether to show git-ignored files
 * `-p` and `-P`: permissions, user, group

--- a/website/src/skins.md
+++ b/website/src/skins.md
@@ -81,6 +81,9 @@ skin: {
 	preview_separator: ansi(94) None / gray(3) None
 	preview_line_number: gray(12) gray(3)
 	preview_match: None ansi(29)
+	diff_line_number: gray(12) gray(3)
+	diff_added: gray(22) rgb(28, 68, 40)
+	diff_removed: gray(22) rgb(88, 34, 34)
 	hex_null: gray(11) None
 	hex_ascii_graphic: gray(18) None
 	hex_ascii_whitespace: ansi(143) None
@@ -164,6 +167,9 @@ preview = "gray(20) gray(1) / gray(18) gray(2)"
 preview_line_number = "gray(12) gray(3)"
 preview_separator: "ansi(94) None / gray(3) None"
 preview_match = "None ansi(29)"
+diff_line_number = "gray(12) gray(3)"
+diff_added = "gray(22) rgb(28, 68, 40)"
+diff_removed = "gray(22) rgb(88, 34, 34)"
 hex_null = "gray(11) None"
 hex_ascii_graphic = "gray(18) None"
 hex_ascii_whitespace = "ansi(143) None"

--- a/website/src/skins.md
+++ b/website/src/skins.md
@@ -46,6 +46,7 @@ skin: {
 	git_deletions: ansi(160) None
 	git_status_current: gray(5) None
 	git_status_modified: ansi(28) None
+	git_status_staged: ansi(34) None
 	git_status_new: ansi(94) None Bold
 	git_status_ignored: gray(17) None
 	git_status_conflicted: ansi(88) None
@@ -128,6 +129,7 @@ git_insertions = "ansi(28) None"
 git_deletions = "ansi(160) None"
 git_status_current = "gray(5) None"
 git_status_modified = "ansi(28) None"
+git_status_staged = "ansi(34) None"
 git_status_new = "ansi(94) None Bold"
 git_status_ignored = "gray(17) None"
 git_status_conflicted = "ansi(88) None"

--- a/website/src/tricks.md
+++ b/website/src/tricks.md
@@ -147,7 +147,7 @@ If you want to start navigating with a view of the files which changed, you may 
 
 Then just hitting the `esc` key will show you the normal unfiltered broot view.
 
-(note: this isn't equivalent to `git status`. Most notably, removed files aren't displayed)
+(note: this isn't equivalent to `git status`. Most notably, removed files aren't displayed. Staged files are shown, with an `A`, `S`, or `R` mark)
 
 From there you may use the `:gd` verb (`:git_diff`) to open the selection into your favourite diff viewer.
 


### PR DESCRIPTION
For a very long time, I've waited for gix to be ready to replace ligbgit2.
It was now possible, so now, **broot is pure rust!**

- git status now computed with gix (pure Rust) instead of libgit2: no more C dependency, faster on big repositories
- in detached HEAD state, the status line shows the short commit id instead of `HEAD`
- git status: staged files are shown (`A` added, `S` staged modification, `R` renamed); new `git_status_staged` skin entry
- git status of a subdirectory of a big repository is computed on that subdirectory only, which is much faster
- git status: an untracked directory gets the `N` mark too
- the status line shows how many commits the branch is ahead (`↑`) or behind (`↓`) its upstream
- `{git-root}` and `{git-name}` now work when the selection is a file

Note: tests on Windows would be welcome, I'm unsure regarding handling of crlf.