### PR TITLE
Wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ A unified diff preview is now the default preview of a file with a git change (m
 - alt-g toggles the git status filter (`:toggle_git_status`). Status line suggests using it in git repo.
 - `-gg` shows only the files with a git status (same as `--git-status`), `-G` removes one level of git information
 - the Kitty keyboard protocol is now used by default when the terminal supports it, which notably makes `alt` combinations work on macOS terminals; multi-key combinations without modifier still need `enable_kitty_keyboard: true` - I'll watch this as this may have unwanted effects, like time related difficulty for some combinations - feedback welcome
-### Other Changes
+#### Other Changes
 - fix panic when previewing an image with 16 bits per channel, or HDR - Fix #1209
 - alt-arrows are bound like ctrl-arrows (panels, root up/down), as macOS captures ctrl-arrows; hints and help show the alt ones on macOS
 - arrow keys scroll the tty preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### next
-- fix panic when previewing an image with 16 bits per channel, or HDR - Fix #1209
-- alt-arrows are bound like ctrl-arrows (panels, root up/down), as macOS captures ctrl-arrows; hints and help show the alt ones on macOS
-
+#### Major Feature: preview wrapping
+By default, long lines in preview are now wrapped.
+This impacts text previews, with or without syntactic coloring, unified diffs, and TTY previews
+This can be toogled with `:toggle_preview_wrap` (shortcut `:wrap`), and `wrap_previews: false` in the conf disables it on start
 #### Major Feature: git diff preview, and many git related enhancements
 The `libgit2` library has been replaced by `gix`. With this change, broot becomes pure Rust, which simplifies compilation (no C compiler needed anymore).
 A unified diff preview is now the default preview of a file with a git change (modified, staged, added, renamed or in conflict) when git statuses are displayed. `:preview_diff` shows it for any file.
@@ -16,7 +17,14 @@ A unified diff preview is now the default preview of a file with a git change (m
 - `{git-root}` and `{git-name}` now work when the selection is a file
 - alt-g toggles the git status filter (`:toggle_git_status`). Status line suggests using it in git repo.
 - `-gg` shows only the files with a git status (same as `--git-status`), `-G` removes one level of git information
-- the Kitty keyboard protocol is now used by default when the terminal supports it, which notably makes `alt` combinations work on macOS terminals; multi-key combinations without modifier still need `enable_kitty_keyboard: true`
+- the Kitty keyboard protocol is now used by default when the terminal supports it, which notably makes `alt` combinations work on macOS terminals; multi-key combinations without modifier still need `enable_kitty_keyboard: true` - I'll watch this as this may have unwanted effects, like time related difficulty for some combinations - feedback welcome
+### Other Changes
+- fix panic when previewing an image with 16 bits per channel, or HDR - Fix #1209
+- alt-arrows are bound like ctrl-arrows (panels, root up/down), as macOS captures ctrl-arrows; hints and help show the alt ones on macOS
+- arrow keys scroll the tty preview
+- `:select_last` goes to the end of a directory preview
+- the tty preview shows its line count
+- `:preview_auto` cancels the effect of eg `:preview_text`, going back to automatically choosing the preview mode
 
 <a name="v1.59.0"></a>
 ### v1.59.0 - 2026-08-22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1127,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2629,7 +2629,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4051,7 +4051,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4426,17 +4426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "termimad"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc986efe2e680fbd1051790103f01b176eb6b1bbc926e41d46adfe44ea43614c"
+checksum = "bf1bd258b1ebd88fa518ee95f0307b206ee2fefd4e7342fd3a70ad73f91fbdfe"
 dependencies = [
  "coolor",
  "crokey",
@@ -4974,7 +4974,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ splitty = "1.0.2"
 strict = "0.2"
 syntect = { package = "syntect-no-panic", version = "6.0", default-features = false, features = ["default-fancy"] } # see https://github.com/Canop/broot/pull/968
 tempfile = "3.2"
-termimad = "0.35.2"
+termimad = "0.35.3"
 terminal-clipboard = { version = "0.4.1", optional = true }
 terminal-light = "1.8"
 toml = "1.1"

--- a/resources/default-conf/conf.hjson
+++ b/resources/default-conf/conf.hjson
@@ -62,6 +62,12 @@
 show_selection_mark: true
 
 ###############################################################
+# Whether to wrap long lines in previews. Default is true;
+# you can toggle wrapping at runtime with the :wrap verb.
+#
+# wrap_previews: false
+
+###############################################################
 # Column order
 # cols_order, if specified, must be a permutation of the following
 # array. You should keep the name column at the end as it has a

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -317,7 +317,7 @@ impl App {
                         }
                     }
                     Internal::toggle_preview_wrap => {
-                        app_state.wrap_previews ^= true;
+                        app_state.preview_overflow.toggle();
                         if is_input_invocation {
                             self.panels.clear_input_invocation(con);
                         }
@@ -490,6 +490,7 @@ impl App {
         let mut dam = Dam::from(rx_events);
         let skin = AppSkin::new(conf, con.launch_args.color == TriBool::No);
         let mut app_state = AppState::new(&con.initial_root);
+        app_state.preview_overflow = con.preview_overflow;
         terminal::update_title(w, &app_state, con);
 
         self.panels

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -316,6 +316,12 @@ impl App {
                             self.panels.clear_input_invocation(con);
                         }
                     }
+                    Internal::toggle_preview_wrap => {
+                        app_state.wrap_previews ^= true;
+                        if is_input_invocation {
+                            self.panels.clear_input_invocation(con);
+                        }
+                    }
                     _ => {
                         let cmd = self.panels.on_input_internal(internal);
                         if cmd.is_none() {

--- a/src/app/app_context.rs
+++ b/src/app/app_context.rs
@@ -8,7 +8,10 @@ use {
         },
         conf::*,
         content_search,
-        display::LayoutInstructions,
+        display::{
+            LayoutInstructions,
+            Overflow,
+        },
         errors::*,
         file_sum,
         icon::*,
@@ -77,6 +80,9 @@ pub struct AppContext {
 
     /// whether to show a triangle left to selected lines
     pub show_selection_mark: bool,
+
+    /// how to deal with preview lines longer than the panel width
+    pub preview_overflow: Overflow,
 
     /// mapping from file extension to colors (comes from conf)
     pub ext_colors: ExtColorMap,
@@ -260,6 +266,7 @@ impl AppContext {
             special_paths,
             search_modes,
             show_selection_mark: config.show_selection_mark.unwrap_or(false),
+            preview_overflow: config.wrap_previews.map(Overflow::from_wrap_bool).unwrap_or_default(),
             ext_colors,
             syntax_theme: config.syntax_theme,
             standard_status,

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -19,6 +19,9 @@ pub struct AppState {
     /// the selected path in another panel than the currently
     /// active one, if any
     pub other_panel_path: Option<PathBuf>,
+
+    /// Whether long lines are wrapped in previews
+    pub wrap_previews: bool,
 }
 
 impl AppState {
@@ -28,6 +31,7 @@ impl AppState {
             root: root.into(),
             watch_tree: false,
             other_panel_path: None,
+            wrap_previews: true,
         }
     }
 }

--- a/src/app/app_state.rs
+++ b/src/app/app_state.rs
@@ -1,5 +1,8 @@
 use {
-    crate::stage::Stage,
+    crate::{
+        display::Overflow,
+        stage::Stage,
+    },
     std::path::PathBuf,
 };
 
@@ -20,8 +23,8 @@ pub struct AppState {
     /// active one, if any
     pub other_panel_path: Option<PathBuf>,
 
-    /// Whether long lines are wrapped in previews
-    pub wrap_previews: bool,
+    /// How to deal with preview lines longer than the panel width
+    pub preview_overflow: Overflow,
 }
 
 impl AppState {
@@ -31,7 +34,7 @@ impl AppState {
             root: root.into(),
             watch_tree: false,
             other_panel_path: None,
-            wrap_previews: true,
+            preview_overflow: Overflow::Wrap,
         }
     }
 }

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -283,6 +283,7 @@ pub trait PanelState {
                 }
             }
             Internal::open_preview => self.open_preview(None, false, cc),
+            Internal::preview_auto => self.open_preview(None, false, cc),
             Internal::preview_image => self.open_preview(Some(PreviewMode::Image), false, cc),
             Internal::preview_text => self.open_preview(Some(PreviewMode::Text), false, cc),
             Internal::preview_tty => self.open_preview(Some(PreviewMode::Tty), false, cc),

--- a/src/app/panel_state.rs
+++ b/src/app/panel_state.rs
@@ -631,6 +631,9 @@ pub trait PanelState {
             }
             Internal::toggle_second_tree => CmdResult::HandleInApp(Internal::toggle_second_tree),
             Internal::toggle_watch => CmdResult::HandleInApp(Internal::toggle_watch),
+            Internal::toggle_preview_wrap => {
+                CmdResult::HandleInApp(Internal::toggle_preview_wrap)
+            }
             Internal::clear_stage => {
                 app_state.stage.clear();
                 if let Some(panel_id) = cc.app.stage_panel {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,6 +41,7 @@ use {
         event::{
             DisableMouseCapture,
             EnableMouseCapture,
+            PopKeyboardEnhancementFlags,
         },
         terminal::{
             EnterAlternateScreen,
@@ -178,6 +179,7 @@ pub fn run() -> Result<Option<Launchable>, ProgramError> {
 
     let mut w = display::writer();
     let app = App::new(&context)?;
+    install_panic_hook(context.capture_mouse);
     w.queue(EnterAlternateScreen)?;
     w.queue(cursor::Hide)?;
     if context.capture_mouse {
@@ -185,6 +187,11 @@ pub fn run() -> Result<Option<Launchable>, ProgramError> {
     }
     let r = app.run(&mut w, &mut context, &config);
     w.flush()?;
+    if context.keyboard_enhanced {
+        // the event source pushed keyboard enhancement flags and
+        // doesn't pop them itself
+        w.queue(PopKeyboardEnhancementFlags)?;
+    }
     if context.capture_mouse {
         w.queue(DisableMouseCapture)?;
     }
@@ -201,6 +208,31 @@ pub fn run() -> Result<Option<Launchable>, ProgramError> {
 fn clear_resources() {
     info!("clearing resources");
     graphics::manager().lock().unwrap().delete_temp_files();
+}
+
+/// Install a panic hook which restores the terminal to a usable
+/// state before the panic message is printed
+fn install_panic_hook(capture_mouse: bool) {
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        use crokey::crossterm::{
+            event::PopKeyboardEnhancementFlags,
+            terminal,
+        };
+        let mut w = std::io::stderr();
+        let _ = terminal::disable_raw_mode();
+        // popping when nothing was pushed is a no-op for terminals
+        // supporting the keyboard enhancement protocol, and ignored
+        // by the other ones
+        let _ = w.queue(PopKeyboardEnhancementFlags);
+        if capture_mouse {
+            let _ = w.queue(DisableMouseCapture);
+        }
+        let _ = w.queue(cursor::Show);
+        let _ = w.queue(LeaveAlternateScreen);
+        let _ = w.flush();
+        hook(panic_info);
+    }));
 }
 
 /// wait for user input, return `true` if they didn't answer 'n'

--- a/src/conf/conf.rs
+++ b/src/conf/conf.rs
@@ -167,6 +167,9 @@ pub struct Conf {
     #[serde(alias = "update-work-dir")]
     pub update_work_dir: Option<bool>,
 
+    #[serde(alias = "wrap-previews")]
+    pub wrap_previews: Option<bool>,
+
     #[serde(default)]
     pub verbs: Vec<VerbConf>,
 
@@ -263,6 +266,7 @@ impl Conf {
         overwrite!(self, terminal_title, conf);
         overwrite!(self, reset_terminal_title_on_exit, conf);
         overwrite!(self, update_work_dir, conf);
+        overwrite!(self, wrap_previews, conf);
         overwrite!(self, enable_kitty_keyboard, conf);
         overwrite!(self, kitty_graphics_transmission, conf);
         overwrite!(self, kitty_graphics_display, conf);

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -58,6 +58,8 @@ mod luma;
 mod matched_string;
 mod num_format;
 mod screen;
+mod viewport;
+mod wrap;
 pub mod status_line;
 
 #[cfg(not(any(target_family = "windows", target_os = "android")))]
@@ -97,3 +99,7 @@ pub type W = std::io::BufWriter<std::io::Stderr>;
 pub fn writer() -> W {
     std::io::BufWriter::new(std::io::stderr())
 }
+pub use {
+    viewport::*,
+    wrap::*,
+};

--- a/src/display/viewport.rs
+++ b/src/display/viewport.rs
@@ -1,4 +1,5 @@
 use {
+    super::wrap::Overflow,
     crate::command::{
         ScrollCommand,
         move_sel,
@@ -24,33 +25,14 @@ pub trait Rows {
         idx: usize,
         width: usize,
     ) -> usize;
-    /// Return an approximation of the width of the line, in cells,
-    /// used to estimate the scrollbar
+    /// Return a cheap approximation of the width of the line in cells,
+    /// used only to estimate the row count of lines which aren't laid
+    /// out, for the scrollbar. It doesn't have to be exact: scroll
+    /// positions are computed from real row counts.
     fn width_hint(
         &self,
         idx: usize,
     ) -> usize;
-}
-
-/// Lines which are never wrapped
-pub struct UnwrappedRows(pub usize);
-impl Rows for UnwrappedRows {
-    fn len(&self) -> usize {
-        self.0
-    }
-    fn row_count(
-        &self,
-        _idx: usize,
-        _width: usize,
-    ) -> usize {
-        1
-    }
-    fn width_hint(
-        &self,
-        _idx: usize,
-    ) -> usize {
-        1
-    }
 }
 
 /// Scroll and selection state of a view made of lines, some of them
@@ -63,10 +45,31 @@ pub struct Viewport {
     scroll: RowPos,
     page_height: usize,
     width: usize,
-    wrap: bool,
+    overflow: Overflow,
     selection: Option<usize>,
-    /// estimated total number of rows, with the (len, width) it was computed for
-    total_rows: Option<(usize, usize, usize)>,
+    total_rows: Option<TotalRowsEstimate>,
+}
+
+/// Estimated total number of rows of a view, valid only for the
+/// layout it was computed for
+#[derive(Debug, Clone, Copy)]
+struct TotalRowsEstimate {
+    /// number of lines of the view
+    len: usize,
+    /// wrapping width, in cells
+    width: usize,
+    /// estimated total number of rows
+    rows: usize,
+}
+
+impl TotalRowsEstimate {
+    fn is_for(
+        &self,
+        len: usize,
+        width: usize,
+    ) -> bool {
+        self.len == len && self.width == width
+    }
 }
 
 impl Viewport {
@@ -85,9 +88,6 @@ impl Viewport {
     ) -> bool {
         self.selection == Some(idx)
     }
-    pub fn unselect(&mut self) {
-        self.selection = None;
-    }
     /// Select the line and scroll if needed to make it visible
     pub fn select(
         &mut self,
@@ -103,16 +103,16 @@ impl Viewport {
         &mut self,
         page_height: usize,
         width: usize,
-        wrap: bool,
+        overflow: Overflow,
         rows: &impl Rows,
     ) {
         let width = width.max(1);
-        if page_height == self.page_height && width == self.width && wrap == self.wrap {
+        if page_height == self.page_height && width == self.width && overflow == self.overflow {
             return;
         }
         self.page_height = page_height;
         self.width = width;
-        self.wrap = wrap;
+        self.overflow = overflow;
         self.total_rows = None;
         self.scroll.sub = 0;
         self.ensure_selection_is_visible(rows);
@@ -123,7 +123,7 @@ impl Viewport {
         rows: &impl Rows,
         line: usize,
     ) -> usize {
-        if self.wrap && self.width > 0 {
+        if self.overflow == Overflow::Wrap && self.width > 0 {
             rows.row_count(line, self.width).max(1)
         } else {
             1
@@ -254,6 +254,17 @@ impl Viewport {
         }
         self.scroll = self.scroll.min(self.max_scroll(rows));
     }
+    /// Scroll to the top of the view
+    pub fn scroll_to_top(&mut self) {
+        self.scroll = RowPos::default();
+    }
+    /// Scroll to show the last row at the bottom of the page
+    pub fn scroll_to_bottom(
+        &mut self,
+        rows: &impl Rows,
+    ) {
+        self.scroll = self.max_scroll(rows);
+    }
     /// Select the line displayed at the given y in the page, if any
     pub fn try_select_y(
         &mut self,
@@ -333,7 +344,7 @@ impl Viewport {
                 }
             }
         }
-        true
+        self.scroll != old_scroll
     }
     /// Return the positions of the rows of the page, from top to bottom
     pub fn visible_rows(
@@ -359,17 +370,17 @@ impl Viewport {
         rows: &impl Rows,
     ) -> Option<(u16, u16)> {
         let len = rows.len();
-        if !self.wrap || self.width == 0 {
+        if self.overflow == Overflow::NoWrap || self.width == 0 {
             return area.scrollbar(self.scroll.line, len);
         }
         let width = self.width;
         let estimate = |line: usize| rows.width_hint(line).max(1).div_ceil(width);
         let total = match self.total_rows {
-            Some((l, w, total)) if l == len && w == width => total,
+            Some(tre) if tre.is_for(len, width) => tre.rows,
             _ => {
-                let total = (0..len).map(estimate).sum();
-                self.total_rows = Some((len, width, total));
-                total
+                let rows = (0..len).map(estimate).sum();
+                self.total_rows = Some(TotalRowsEstimate { len, width, rows });
+                rows
             }
         };
         let current = (0..self.scroll.line).map(estimate).sum::<usize>() + self.scroll.sub;
@@ -392,6 +403,27 @@ pub fn is_thumb(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// lines which are never wrapped
+    struct UnwrappedRows(usize);
+    impl Rows for UnwrappedRows {
+        fn len(&self) -> usize {
+            self.0
+        }
+        fn row_count(
+            &self,
+            _idx: usize,
+            _width: usize,
+        ) -> usize {
+            1
+        }
+        fn width_hint(
+            &self,
+            _idx: usize,
+        ) -> usize {
+            1
+        }
+    }
 
     /// lines given by their width in cells
     struct Widths(Vec<usize>);
@@ -424,7 +456,7 @@ mod tests {
     fn unwrapped_selection_stays_visible() {
         let rows = UnwrappedRows(100);
         let mut vp = Viewport::default();
-        vp.set_layout(10, 80, false, &rows);
+        vp.set_layout(10, 80, Overflow::NoWrap, &rows);
         vp.select_first(&rows);
         assert_eq!(vp.selection(), Some(0));
         assert_eq!(vp.scroll(), pos(0, 0));
@@ -445,7 +477,7 @@ mod tests {
     fn unwrapped_scroll_moves_visible_selection() {
         let rows = UnwrappedRows(100);
         let mut vp = Viewport::default();
-        vp.set_layout(10, 80, false, &rows);
+        vp.set_layout(10, 80, Overflow::NoWrap, &rows);
         vp.select_first(&rows);
         assert!(vp.try_scroll(ScrollCommand::Lines(3), &rows));
         assert_eq!(vp.scroll(), pos(3, 0));
@@ -473,7 +505,7 @@ mod tests {
     fn empty_view() {
         let rows = UnwrappedRows(0);
         let mut vp = Viewport::default();
-        vp.set_layout(10, 80, true, &rows);
+        vp.set_layout(10, 80, Overflow::Wrap, &rows);
         vp.select_first(&rows);
         vp.select_last(&rows);
         vp.move_selection(1, true, &rows);
@@ -487,7 +519,7 @@ mod tests {
         // rows: 1, 3, 1, 2, 1
         let rows = Widths(vec![5, 25, 5, 15, 5]);
         let mut vp = Viewport::default();
-        vp.set_layout(3, 10, true, &rows);
+        vp.set_layout(3, 10, Overflow::Wrap, &rows);
         vp.select_first(&rows);
         assert_eq!(
             vp.visible_rows(&rows),
@@ -525,7 +557,7 @@ mod tests {
     fn line_taller_than_page_shows_its_start() {
         let rows = Widths(vec![5, 100, 5]);
         let mut vp = Viewport::default();
-        vp.set_layout(3, 10, true, &rows);
+        vp.set_layout(3, 10, Overflow::Wrap, &rows);
         vp.select_first(&rows);
         vp.move_selection(1, false, &rows);
         assert_eq!(vp.scroll(), pos(1, 0));
@@ -537,12 +569,12 @@ mod tests {
     fn layout_change_keeps_selection_visible() {
         let rows = Widths(vec![5, 25, 5, 15, 5]);
         let mut vp = Viewport::default();
-        vp.set_layout(3, 10, false, &rows);
+        vp.set_layout(3, 10, Overflow::NoWrap, &rows);
         vp.select(4, &rows);
         assert_eq!(vp.scroll(), pos(2, 0));
-        vp.set_layout(3, 10, true, &rows);
+        vp.set_layout(3, 10, Overflow::Wrap, &rows);
         assert_eq!(vp.scroll(), pos(3, 0));
-        vp.set_layout(3, 10, false, &rows);
+        vp.set_layout(3, 10, Overflow::NoWrap, &rows);
         assert_eq!(vp.scroll(), pos(2, 0));
     }
 }

--- a/src/display/viewport.rs
+++ b/src/display/viewport.rs
@@ -1,0 +1,548 @@
+use {
+    crate::command::{
+        ScrollCommand,
+        move_sel,
+    },
+    termimad::Area,
+};
+
+/// Position of a screen row: a line of the view, and a row in this
+/// line (always 0 when lines aren't wrapped)
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RowPos {
+    pub line: usize,
+    pub sub: usize,
+}
+
+/// The lines of a view, as needed by the viewport to lay them out
+pub trait Rows {
+    fn len(&self) -> usize;
+    /// Return the number of screen rows the line takes when wrapped
+    /// at this width (at least 1)
+    fn row_count(
+        &self,
+        idx: usize,
+        width: usize,
+    ) -> usize;
+    /// Return an approximation of the width of the line, in cells,
+    /// used to estimate the scrollbar
+    fn width_hint(
+        &self,
+        idx: usize,
+    ) -> usize;
+}
+
+/// Lines which are never wrapped
+pub struct UnwrappedRows(pub usize);
+impl Rows for UnwrappedRows {
+    fn len(&self) -> usize {
+        self.0
+    }
+    fn row_count(
+        &self,
+        _idx: usize,
+        _width: usize,
+    ) -> usize {
+        1
+    }
+    fn width_hint(
+        &self,
+        _idx: usize,
+    ) -> usize {
+        1
+    }
+}
+
+/// Scroll and selection state of a view made of lines, some of them
+/// displayed in a page, possibly wrapped.
+///
+/// Only the lines around the displayed page are ever laid out,
+/// which keeps operations cheap whatever the size of the view.
+#[derive(Debug, Default, Clone)]
+pub struct Viewport {
+    scroll: RowPos,
+    page_height: usize,
+    width: usize,
+    wrap: bool,
+    selection: Option<usize>,
+    /// estimated total number of rows, with the (len, width) it was computed for
+    total_rows: Option<(usize, usize, usize)>,
+}
+
+impl Viewport {
+    pub fn scroll(&self) -> RowPos {
+        self.scroll
+    }
+    pub fn page_height(&self) -> usize {
+        self.page_height
+    }
+    pub fn selection(&self) -> Option<usize> {
+        self.selection
+    }
+    pub fn is_selected(
+        &self,
+        idx: usize,
+    ) -> bool {
+        self.selection == Some(idx)
+    }
+    pub fn unselect(&mut self) {
+        self.selection = None;
+    }
+    /// Select the line and scroll if needed to make it visible
+    pub fn select(
+        &mut self,
+        idx: usize,
+        rows: &impl Rows,
+    ) {
+        self.selection = Some(idx);
+        self.ensure_selection_is_visible(rows);
+    }
+    /// Set the dimensions of the page and whether lines are wrapped,
+    /// keeping the selection visible
+    pub fn set_layout(
+        &mut self,
+        page_height: usize,
+        width: usize,
+        wrap: bool,
+        rows: &impl Rows,
+    ) {
+        let width = width.max(1);
+        if page_height == self.page_height && width == self.width && wrap == self.wrap {
+            return;
+        }
+        self.page_height = page_height;
+        self.width = width;
+        self.wrap = wrap;
+        self.total_rows = None;
+        self.scroll.sub = 0;
+        self.ensure_selection_is_visible(rows);
+    }
+    /// Number of rows of the line, in the current layout
+    fn rc(
+        &self,
+        rows: &impl Rows,
+        line: usize,
+    ) -> usize {
+        if self.wrap && self.width > 0 {
+            rows.row_count(line, self.width).max(1)
+        } else {
+            1
+        }
+    }
+    fn last_pos(
+        &self,
+        rows: &impl Rows,
+    ) -> Option<RowPos> {
+        let len = rows.len();
+        (len > 0).then(|| RowPos {
+            line: len - 1,
+            sub: self.rc(rows, len - 1) - 1,
+        })
+    }
+    /// Move down n rows, returning None when there aren't enough rows
+    fn step_down(
+        &self,
+        rows: &impl Rows,
+        mut pos: RowPos,
+        mut n: usize,
+    ) -> Option<RowPos> {
+        let len = rows.len();
+        loop {
+            if pos.line >= len {
+                return None;
+            }
+            let rc = self.rc(rows, pos.line);
+            if pos.sub + n < rc {
+                pos.sub += n;
+                return Some(pos);
+            }
+            n -= rc - pos.sub;
+            pos = RowPos {
+                line: pos.line + 1,
+                sub: 0,
+            };
+        }
+    }
+    /// Move up n rows, stopping at the first row
+    fn step_up(
+        &self,
+        rows: &impl Rows,
+        mut pos: RowPos,
+        mut n: usize,
+    ) -> RowPos {
+        loop {
+            if n <= pos.sub {
+                pos.sub -= n;
+                return pos;
+            }
+            if pos.line == 0 {
+                return RowPos::default();
+            }
+            n -= pos.sub + 1;
+            pos.line -= 1;
+            pos.sub = self.rc(rows, pos.line) - 1;
+        }
+    }
+    /// Number of rows from `from` to `to`, which must not be before `from`
+    fn distance(
+        &self,
+        rows: &impl Rows,
+        from: RowPos,
+        to: RowPos,
+    ) -> usize {
+        let mut d = 0;
+        for line in from.line..to.line {
+            d += self.rc(rows, line);
+        }
+        d + to.sub - from.sub
+    }
+    fn fits_in_page(
+        &self,
+        rows: &impl Rows,
+    ) -> bool {
+        let mut total = 0;
+        for line in 0..rows.len() {
+            total += self.rc(rows, line);
+            if total > self.page_height {
+                return false;
+            }
+        }
+        true
+    }
+    /// The scroll position showing the last row at the bottom of the page
+    fn max_scroll(
+        &self,
+        rows: &impl Rows,
+    ) -> RowPos {
+        match self.last_pos(rows) {
+            Some(last) => self.step_up(rows, last, self.page_height.saturating_sub(1)),
+            None => RowPos::default(),
+        }
+    }
+    fn padding(&self) -> usize {
+        (self.page_height / 4).min(4)
+    }
+    fn ensure_selection_is_visible(
+        &mut self,
+        rows: &impl Rows,
+    ) {
+        if self.page_height == 0 {
+            return;
+        }
+        if self.fits_in_page(rows) {
+            self.scroll = RowPos::default();
+            return;
+        }
+        let Some(sel) = self.selection else {
+            self.scroll = self.scroll.min(self.max_scroll(rows));
+            return;
+        };
+        let padding = self.padding();
+        let start = RowPos { line: sel, sub: 0 };
+        let end = RowPos {
+            line: sel,
+            sub: self.rc(rows, sel) - 1,
+        };
+        if start < self.scroll || self.distance(rows, self.scroll, start) < padding {
+            self.scroll = self.step_up(rows, start, padding);
+        } else if self.distance(rows, self.scroll, end) + padding >= self.page_height {
+            self.scroll = self.step_up(rows, end, self.page_height - 1 - padding);
+            if start < self.scroll {
+                // the line is taller than the page: show its start
+                self.scroll = start;
+            }
+        }
+        self.scroll = self.scroll.min(self.max_scroll(rows));
+    }
+    /// Select the line displayed at the given y in the page, if any
+    pub fn try_select_y(
+        &mut self,
+        y: u16,
+        rows: &impl Rows,
+    ) -> bool {
+        match self.step_down(rows, self.scroll, y as usize) {
+            Some(pos) => {
+                self.selection = Some(pos.line);
+                true
+            }
+            None => false,
+        }
+    }
+    pub fn select_first(
+        &mut self,
+        rows: &impl Rows,
+    ) {
+        if rows.len() > 0 {
+            self.selection = Some(0);
+            self.scroll = RowPos::default();
+        }
+    }
+    pub fn select_last(
+        &mut self,
+        rows: &impl Rows,
+    ) {
+        if rows.len() > 0 {
+            self.select(rows.len() - 1, rows);
+        }
+    }
+    pub fn move_selection(
+        &mut self,
+        dy: i32,
+        cycle: bool,
+        rows: &impl Rows,
+    ) {
+        if let Some(idx) = self.selection {
+            self.selection = Some(move_sel(idx, rows.len(), dy, cycle));
+        } else if rows.len() > 0 {
+            self.selection = Some(0);
+        }
+        self.ensure_selection_is_visible(rows);
+    }
+    /// Scroll, moving the selection along when it was visible,
+    /// and return whether something changed
+    pub fn try_scroll(
+        &mut self,
+        cmd: ScrollCommand,
+        rows: &impl Rows,
+    ) -> bool {
+        let n = cmd.to_lines(self.page_height);
+        let old_scroll = self.scroll;
+        let max_scroll = self.max_scroll(rows);
+        self.scroll = if n < 0 {
+            self.step_up(rows, self.scroll, n.unsigned_abs() as usize)
+        } else {
+            self.step_down(rows, self.scroll, n as usize)
+                .unwrap_or(max_scroll)
+                .min(max_scroll)
+        };
+        if let Some(idx) = self.selection {
+            if self.scroll == old_scroll {
+                let old_selection = self.selection;
+                self.selection = Some(if cmd.is_up() { 0 } else { rows.len() - 1 });
+                return self.selection != old_selection;
+            }
+            let sel_start = RowPos { line: idx, sub: 0 };
+            if old_scroll <= sel_start {
+                let y = self.distance(rows, old_scroll, sel_start);
+                if y < self.page_height {
+                    // the selection was visible: we keep it at the same y
+                    self.selection = Some(
+                        self.step_down(rows, self.scroll, y)
+                            .map_or(rows.len() - 1, |pos| pos.line),
+                    );
+                }
+            }
+        }
+        true
+    }
+    /// Return the positions of the rows of the page, from top to bottom
+    pub fn visible_rows(
+        &self,
+        rows: &impl Rows,
+    ) -> Vec<RowPos> {
+        let mut positions = Vec::with_capacity(self.page_height);
+        let mut pos = self.scroll;
+        while positions.len() < self.page_height && pos.line < rows.len() {
+            positions.push(pos);
+            match self.step_down(rows, pos, 1) {
+                Some(next) => pos = next,
+                None => break,
+            }
+        }
+        positions
+    }
+    /// Return the scrollbar of the page, based on an estimate of
+    /// the row counts when lines are wrapped
+    pub fn scrollbar(
+        &mut self,
+        area: &Area,
+        rows: &impl Rows,
+    ) -> Option<(u16, u16)> {
+        let len = rows.len();
+        if !self.wrap || self.width == 0 {
+            return area.scrollbar(self.scroll.line, len);
+        }
+        let width = self.width;
+        let estimate = |line: usize| rows.width_hint(line).max(1).div_ceil(width);
+        let total = match self.total_rows {
+            Some((l, w, total)) if l == len && w == width => total,
+            _ => {
+                let total = (0..len).map(estimate).sum();
+                self.total_rows = Some((len, width, total));
+                total
+            }
+        };
+        let current = (0..self.scroll.line).map(estimate).sum::<usize>() + self.scroll.sub;
+        area.scrollbar(current, total)
+    }
+}
+
+/// Tell whether the row at this y (from the top of the screen)
+/// is part of the scrollbar thumb
+pub fn is_thumb(
+    y: usize,
+    scrollbar: Option<(u16, u16)>,
+) -> bool {
+    scrollbar.is_some_and(|(top, bottom)| {
+        let y = y as u16;
+        top <= y && y <= bottom
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// lines given by their width in cells
+    struct Widths(Vec<usize>);
+    impl Rows for Widths {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+        fn row_count(
+            &self,
+            idx: usize,
+            width: usize,
+        ) -> usize {
+            self.0[idx].max(1).div_ceil(width)
+        }
+        fn width_hint(
+            &self,
+            idx: usize,
+        ) -> usize {
+            self.0[idx]
+        }
+    }
+    fn pos(
+        line: usize,
+        sub: usize,
+    ) -> RowPos {
+        RowPos { line, sub }
+    }
+
+    #[test]
+    fn unwrapped_selection_stays_visible() {
+        let rows = UnwrappedRows(100);
+        let mut vp = Viewport::default();
+        vp.set_layout(10, 80, false, &rows);
+        vp.select_first(&rows);
+        assert_eq!(vp.selection(), Some(0));
+        assert_eq!(vp.scroll(), pos(0, 0));
+        vp.select(50, &rows);
+        let scroll = vp.scroll().line;
+        assert!(scroll <= 50 && 50 < scroll + 10);
+        vp.select_last(&rows);
+        assert_eq!(vp.selection(), Some(99));
+        assert_eq!(vp.scroll(), pos(90, 0));
+        vp.move_selection(1, true, &rows);
+        assert_eq!(vp.selection(), Some(0));
+        assert_eq!(vp.scroll(), pos(0, 0));
+        vp.move_selection(-1, false, &rows);
+        assert_eq!(vp.selection(), Some(0));
+    }
+
+    #[test]
+    fn unwrapped_scroll_moves_visible_selection() {
+        let rows = UnwrappedRows(100);
+        let mut vp = Viewport::default();
+        vp.set_layout(10, 80, false, &rows);
+        vp.select_first(&rows);
+        assert!(vp.try_scroll(ScrollCommand::Lines(3), &rows));
+        assert_eq!(vp.scroll(), pos(3, 0));
+        assert_eq!(vp.selection(), Some(3));
+        assert!(vp.try_scroll(ScrollCommand::Pages(1), &rows));
+        assert_eq!(vp.scroll(), pos(13, 0));
+        assert_eq!(vp.selection(), Some(13));
+        // the selection keeps its y while scrolling
+        vp.select(85, &rows);
+        assert_eq!(vp.scroll(), pos(78, 0));
+        assert!(vp.try_scroll(ScrollCommand::Pages(1), &rows));
+        assert_eq!(vp.scroll(), pos(88, 0));
+        assert_eq!(vp.selection(), Some(95));
+        // the last row stays at the bottom, then scrolling selects the last line
+        assert!(vp.try_scroll(ScrollCommand::Pages(1), &rows));
+        assert_eq!(vp.scroll(), pos(90, 0));
+        assert_eq!(vp.selection(), Some(97));
+        assert!(vp.try_scroll(ScrollCommand::Lines(1), &rows));
+        assert_eq!(vp.scroll(), pos(90, 0));
+        assert_eq!(vp.selection(), Some(99));
+        assert!(!vp.try_scroll(ScrollCommand::Lines(1), &rows));
+    }
+
+    #[test]
+    fn empty_view() {
+        let rows = UnwrappedRows(0);
+        let mut vp = Viewport::default();
+        vp.set_layout(10, 80, true, &rows);
+        vp.select_first(&rows);
+        vp.select_last(&rows);
+        vp.move_selection(1, true, &rows);
+        assert_eq!(vp.selection(), None);
+        assert!(!vp.try_select_y(0, &rows));
+        assert!(vp.visible_rows(&rows).is_empty());
+    }
+
+    #[test]
+    fn wrapped_rows() {
+        // rows: 1, 3, 1, 2, 1
+        let rows = Widths(vec![5, 25, 5, 15, 5]);
+        let mut vp = Viewport::default();
+        vp.set_layout(3, 10, true, &rows);
+        vp.select_first(&rows);
+        assert_eq!(
+            vp.visible_rows(&rows),
+            vec![pos(0, 0), pos(1, 0), pos(1, 1)]
+        );
+        assert!(vp.try_select_y(2, &rows));
+        assert_eq!(vp.selection(), Some(1));
+        assert!(!vp.try_select_y(3, &rows) || vp.selection() == Some(1));
+        // selecting line 2 brings its row into view
+        vp.select(2, &rows);
+        assert_eq!(vp.scroll(), pos(1, 1));
+        assert_eq!(
+            vp.visible_rows(&rows),
+            vec![pos(1, 1), pos(1, 2), pos(2, 0)]
+        );
+        // scrolling one row up keeps the selection at the same y
+        assert!(vp.try_scroll(ScrollCommand::Lines(-1), &rows));
+        assert_eq!(vp.scroll(), pos(1, 0));
+        assert_eq!(vp.selection(), Some(1));
+        // the last row of the view ends at the bottom of the page
+        vp.select_last(&rows);
+        assert_eq!(vp.scroll(), pos(3, 0));
+        assert_eq!(
+            vp.visible_rows(&rows),
+            vec![pos(3, 0), pos(3, 1), pos(4, 0)]
+        );
+        // page down from the start
+        vp.select_first(&rows);
+        vp.try_scroll(ScrollCommand::Pages(1), &rows);
+        assert_eq!(vp.scroll(), pos(1, 2));
+        assert_eq!(vp.selection(), Some(1));
+    }
+
+    #[test]
+    fn line_taller_than_page_shows_its_start() {
+        let rows = Widths(vec![5, 100, 5]);
+        let mut vp = Viewport::default();
+        vp.set_layout(3, 10, true, &rows);
+        vp.select_first(&rows);
+        vp.move_selection(1, false, &rows);
+        assert_eq!(vp.scroll(), pos(1, 0));
+        vp.move_selection(1, false, &rows);
+        assert_eq!(vp.scroll(), pos(1, 8));
+    }
+
+    #[test]
+    fn layout_change_keeps_selection_visible() {
+        let rows = Widths(vec![5, 25, 5, 15, 5]);
+        let mut vp = Viewport::default();
+        vp.set_layout(3, 10, false, &rows);
+        vp.select(4, &rows);
+        assert_eq!(vp.scroll(), pos(2, 0));
+        vp.set_layout(3, 10, true, &rows);
+        assert_eq!(vp.scroll(), pos(3, 0));
+        vp.set_layout(3, 10, false, &rows);
+        assert_eq!(vp.scroll(), pos(2, 0));
+    }
+}

--- a/src/display/wrap.rs
+++ b/src/display/wrap.rs
@@ -1,0 +1,109 @@
+//! Line wrapping of previews: hard wrap at cell boundaries.
+
+use unicode_width::UnicodeWidthChar;
+
+/// Number of cells a tab takes in previews
+pub const TAB_WIDTH: usize = 2;
+
+/// Width in cells of a char displayed in a preview: tabs are expanded,
+/// control chars (including end of line ones) take no room.
+pub fn char_width(c: char) -> usize {
+    if c == '\t' {
+        TAB_WIDTH
+    } else {
+        c.width().unwrap_or(0)
+    }
+}
+
+/// Return the indexes, in chars, at which start the rows after the
+/// first one when the text is wrapped at `width` cells.
+///
+/// A wide char never straddles two rows (unless wider than the row).
+/// Zero width chars stay on the row of the previous char.
+pub fn row_starts(
+    chars: impl Iterator<Item = char>,
+    width: usize,
+) -> Vec<usize> {
+    let width = width.max(1);
+    let mut starts = Vec::new();
+    let mut x = 0;
+    for (i, c) in chars.enumerate() {
+        let w = char_width(c);
+        if w > 0 && x > 0 && x + w > width {
+            starts.push(i);
+            x = 0;
+        }
+        x += w;
+    }
+    starts
+}
+
+/// Return the number of rows the text takes when wrapped at `width` cells
+/// (at least 1)
+pub fn row_count(
+    chars: impl Iterator<Item = char>,
+    width: usize,
+) -> usize {
+    let width = width.max(1);
+    let mut count = 1;
+    let mut x = 0;
+    for c in chars {
+        let w = char_width(c);
+        if w > 0 && x > 0 && x + w > width {
+            count += 1;
+            x = 0;
+        }
+        x += w;
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii() {
+        assert_eq!(row_starts("".chars(), 5), Vec::<usize>::new());
+        assert_eq!(row_starts("abcde".chars(), 5), Vec::<usize>::new());
+        assert_eq!(row_starts("abcdef".chars(), 5), vec![5]);
+        assert_eq!(row_starts("abcdefghijk".chars(), 5), vec![5, 10]);
+        assert_eq!(row_count("abcdefghijk".chars(), 5), 3);
+        assert_eq!(row_count("".chars(), 5), 1);
+    }
+
+    #[test]
+    fn end_of_line_takes_no_room() {
+        assert_eq!(row_starts("abcde\n".chars(), 5), Vec::<usize>::new());
+        assert_eq!(row_starts("abcde\r\n".chars(), 5), Vec::<usize>::new());
+        assert_eq!(row_count("abcde\n".chars(), 5), 1);
+    }
+
+    #[test]
+    fn tabs() {
+        // a tab takes TAB_WIDTH cells
+        assert_eq!(row_starts("\tab".chars(), 4), Vec::<usize>::new());
+        assert_eq!(row_starts("\tabc".chars(), 4), vec![3]);
+    }
+
+    #[test]
+    fn wide_chars() {
+        // 日 and 本 are 2 cells wide: a wide char doesn't straddle rows
+        assert_eq!(row_starts("a日本".chars(), 4), vec![2]);
+        assert_eq!(row_starts("日本語".chars(), 4), vec![2]);
+        assert_eq!(row_count("日本語".chars(), 4), 2);
+    }
+
+    #[test]
+    fn combining_marks_stay_with_base() {
+        // e + combining acute accent (zero width)
+        let s = "abcde\u{301}f";
+        assert_eq!(row_starts(s.chars(), 5), vec![6]);
+    }
+
+    #[test]
+    fn tiny_width() {
+        assert_eq!(row_starts("abc".chars(), 0), vec![1, 2]);
+        assert_eq!(row_starts("日本".chars(), 1), vec![1]);
+    }
+}

--- a/src/display/wrap.rs
+++ b/src/display/wrap.rs
@@ -3,7 +3,28 @@
 use unicode_width::UnicodeWidthChar;
 
 /// Number of cells a tab takes in previews
-pub const TAB_WIDTH: usize = 2;
+pub const TAB_WIDTH: usize = 4;
+
+/// What to do with the part of a line not fitting the width of the view
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Overflow {
+    /// long lines continue on following rows
+    #[default]
+    Wrap,
+    /// long lines are truncated
+    NoWrap,
+}
+impl Overflow {
+    pub fn toggle(&mut self) {
+        *self = match self {
+            Self::Wrap => Self::NoWrap,
+            Self::NoWrap => Self::Wrap,
+        };
+    }
+    pub fn from_wrap_bool(wrap: bool) -> Self {
+        if wrap { Self::Wrap } else { Self::NoWrap }
+    }
+}
 
 /// Width in cells of a char displayed in a preview: tabs are expanded,
 /// control chars (including end of line ones) take no room.
@@ -82,8 +103,8 @@ mod tests {
     #[test]
     fn tabs() {
         // a tab takes TAB_WIDTH cells
-        assert_eq!(row_starts("\tab".chars(), 4), Vec::<usize>::new());
-        assert_eq!(row_starts("\tabc".chars(), 4), vec![3]);
+        assert_eq!(row_starts("\tab".chars(), TAB_WIDTH + 2), Vec::<usize>::new());
+        assert_eq!(row_starts("\tabc".chars(), TAB_WIDTH + 2), vec![3]);
     }
 
     #[test]

--- a/src/hex/hex_view.rs
+++ b/src/hex/hex_view.rs
@@ -64,10 +64,10 @@ impl HexView {
         self.scroll = cmd.apply(self.scroll, self.line_count(), self.page_height);
         self.scroll != old_scroll
     }
-    pub fn select_first(&mut self) {
+    pub fn go_to_top(&mut self) {
         self.scroll = 0;
     }
-    pub fn select_last(&mut self) {
+    pub fn go_to_bottom(&mut self) {
         if self.page_height < self.line_count() {
             self.scroll = self.line_count() - self.page_height;
         }

--- a/src/preview/preview.rs
+++ b/src/preview/preview.rs
@@ -403,7 +403,7 @@ impl Preview {
         match self {
             Self::Dir(dv) => dv.display(w, disc, area),
             Self::Image(iv) => time!(iv.display(w, disc, area)),
-            Self::Text(sv) => sv.display(w, screen, panel_skin, area, con),
+            Self::Text(sv) => sv.display(w, screen, panel_skin, area, con, disc.app_state.wrap_previews),
             Self::ZeroLen(zlv) => zlv.display(w, screen, panel_skin, area),
             Self::Hex(hv) => hv.display(w, screen, panel_skin, area),
             Self::Tty(v) => v.display(w, screen, panel_skin, area),

--- a/src/preview/preview.rs
+++ b/src/preview/preview.rs
@@ -321,13 +321,6 @@ impl Preview {
             _ => false,
         }
     }
-    pub fn unselect(&mut self) {
-        match self {
-            Self::Text(sv) => sv.unselect(),
-            Self::Tty(tv) => tv.unselect(),
-            _ => {}
-        }
-    }
     pub fn try_select_y(
         &mut self,
         y: u16,
@@ -335,7 +328,6 @@ impl Preview {
         match self {
             Self::Dir(dv) => dv.try_select_y(y),
             Self::Text(sv) => sv.try_select_y(y),
-            Self::Tty(v) => v.try_select_y(y),
             Self::Diff(v) => v.try_select_y(y),
             _ => false,
         }
@@ -348,8 +340,11 @@ impl Preview {
         match self {
             Self::Dir(dv) => dv.move_selection(dy, cycle),
             Self::Text(sv) => sv.move_selection(dy, cycle),
-            Self::Tty(v) => v.move_selection(dy, cycle),
             Self::Diff(v) => v.move_selection(dy, cycle),
+            // views without a selection scroll instead
+            Self::Tty(v) => {
+                v.try_scroll(ScrollCommand::Lines(dy));
+            }
             Self::Hex(hv) => {
                 hv.try_scroll(ScrollCommand::Lines(dy));
             }
@@ -376,17 +371,18 @@ impl Preview {
         match self {
             Self::Dir(dv) => dv.select_first(),
             Self::Text(sv) => sv.select_first(),
-            Self::Hex(hv) => hv.select_first(),
-            Self::Tty(v) => v.select_first(),
+            Self::Hex(hv) => hv.go_to_top(),
+            Self::Tty(v) => v.go_to_top(),
             Self::Diff(v) => v.select_first(),
             _ => {}
         }
     }
     pub fn select_last(&mut self) {
         match self {
+            Self::Dir(dv) => dv.select_last(),
             Self::Text(sv) => sv.select_last(),
-            Self::Hex(hv) => hv.select_last(),
-            Self::Tty(v) => v.select_last(),
+            Self::Hex(hv) => hv.go_to_bottom(),
+            Self::Tty(v) => v.go_to_bottom(),
             Self::Diff(v) => v.select_last(),
             _ => {}
         }
@@ -403,11 +399,11 @@ impl Preview {
         match self {
             Self::Dir(dv) => dv.display(w, disc, area),
             Self::Image(iv) => time!(iv.display(w, disc, area)),
-            Self::Text(sv) => sv.display(w, screen, panel_skin, area, con, disc.app_state.wrap_previews),
+            Self::Text(sv) => sv.display(w, screen, panel_skin, area, con, disc.app_state.preview_overflow),
             Self::ZeroLen(zlv) => zlv.display(w, screen, panel_skin, area),
             Self::Hex(hv) => hv.display(w, screen, panel_skin, area),
-            Self::Tty(v) => v.display(w, screen, panel_skin, area),
-            Self::Diff(v) => v.display(w, screen, panel_skin, area, con),
+            Self::Tty(v) => v.display(w, screen, panel_skin, area, disc.app_state.preview_overflow),
+            Self::Diff(v) => v.display(w, screen, panel_skin, area, con, disc.app_state.preview_overflow),
             Self::IoError(err) => {
                 let mut y = area.top;
                 w.queue(cursor::MoveTo(area.left, y))?;
@@ -442,6 +438,7 @@ impl Preview {
             Self::Image(iv) => iv.display_info(w, screen, panel_skin, area),
             Self::Text(sv) => sv.display_info(w, screen, panel_skin, area),
             Self::Hex(hv) => hv.display_info(w, screen, panel_skin, area),
+            Self::Tty(v) => v.display_info(w, screen, panel_skin, area),
             Self::Diff(v) => v.display_info(w, screen, panel_skin, area),
             _ => Ok(()),
         }

--- a/src/preview/preview_state.rs
+++ b/src/preview/preview_state.rs
@@ -118,6 +118,23 @@ impl PreviewState {
             Err(e) => CmdResult::DisplayError(format!("Can't display as {mode:?} : {e:?}")),
         })
     }
+    /// Go back to automatically choosing the preview mode
+    fn set_auto_mode(
+        &mut self,
+        con: &AppContext,
+    ) -> CmdResult {
+        if self.preferred_mode.is_none() {
+            return CmdResult::Keep;
+        }
+        self.preferred_mode = None;
+        self.transform = con.preview_transformers.transform(&self.source_path, None);
+        self.preview = match &self.transform {
+            // the git status doesn't apply to the transformed file
+            Some(transform) => Preview::new(&transform.output_path, None, None, con),
+            None => Preview::new(&self.source_path, self.source_git_status, None, con),
+        };
+        CmdResult::Keep
+    }
 
     fn no_opt_selection(&self) -> Selection<'_> {
         match self.transform.as_ref() {
@@ -495,6 +512,7 @@ impl PanelState for PreviewState {
                 self.mut_preview().next_match();
                 Ok(CmdResult::Keep)
             }
+            Internal::preview_auto => Ok(self.set_auto_mode(con)),
             Internal::preview_image => self.set_mode(PreviewMode::Image, con),
             Internal::preview_text => self.set_mode(PreviewMode::Text, con),
             Internal::preview_tty => self.set_mode(PreviewMode::Tty, con),

--- a/src/preview/unified_diff_view.rs
+++ b/src/preview/unified_diff_view.rs
@@ -4,13 +4,13 @@ use {
             AppContext,
             LineNumber,
         },
-        command::{
-            ScrollCommand,
-            move_sel,
-        },
+        command::ScrollCommand,
         display::{
             Screen,
+            UnwrappedRows,
+            Viewport,
             W,
+            is_thumb,
         },
         errors::ProgramError,
         git::{
@@ -54,9 +54,7 @@ enum Row {
 pub struct UnifiedDiffView {
     diff: FileDiff,
     rows: Vec<Row>,
-    scroll: usize,
-    page_height: usize,
-    selection_idx: Option<usize>,
+    viewport: Viewport,
 }
 
 impl UnifiedDiffView {
@@ -82,9 +80,7 @@ impl UnifiedDiffView {
         Self {
             diff,
             rows,
-            scroll: 0,
-            page_height: 0,
-            selection_idx: None,
+            viewport: Viewport::default(),
         }
     }
     fn line(
@@ -109,37 +105,17 @@ impl UnifiedDiffView {
             _ => 0,
         }
     }
-    fn ensure_selection_is_visible(&mut self) {
-        if self.page_height >= self.rows.len() {
-            self.scroll = 0;
-        } else if let Some(idx) = self.selection_idx {
-            let padding = self.padding();
-            if idx < self.scroll + padding || idx + padding > self.scroll + self.page_height {
-                if idx <= padding {
-                    self.scroll = 0;
-                } else if idx + padding > self.rows.len() {
-                    self.scroll = self.rows.len() - self.page_height;
-                } else if idx < self.scroll + self.page_height / 2 {
-                    self.scroll = idx - padding;
-                } else {
-                    self.scroll = idx + padding - self.page_height;
-                }
-            }
-        }
-    }
-    fn padding(&self) -> usize {
-        (self.page_height / 4).min(4)
-    }
     /// Return the number, in the current version of the file, of the
     /// selected line or of the closest following one
     pub fn get_selected_line_number(&self) -> Option<LineNumber> {
-        let idx = self.selection_idx?;
+        let idx = self.viewport.selection()?;
         self.rows[idx..]
             .iter()
             .find_map(|&row| self.line(row).and_then(|line| line.new_number))
     }
     pub fn get_selected_line(&self) -> Option<String> {
-        self.selection_idx
+        self.viewport
+            .selection()
             .and_then(|idx| self.line(self.rows[idx]))
             .map(|line| line.content.clone())
     }
@@ -155,8 +131,7 @@ impl UnifiedDiffView {
                 .is_some_and(|n| n >= number)
         });
         if let Some(idx) = idx {
-            self.selection_idx = Some(idx);
-            self.ensure_selection_is_visible();
+            self.viewport.select(idx, &UnwrappedRows(self.rows.len()));
         }
         idx.is_some()
     }
@@ -179,24 +154,25 @@ impl UnifiedDiffView {
     }
     /// Select the first line of the next block of changes
     pub fn next_change(&mut self) {
-        let s = self.selection_idx.unwrap_or(self.rows.len().saturating_sub(1));
+        let s = self
+            .viewport
+            .selection()
+            .unwrap_or(self.rows.len().saturating_sub(1));
         for d in 1..=self.rows.len() {
             let idx = (s + d) % self.rows.len();
             if self.is_change_start(idx) {
-                self.selection_idx = Some(idx);
-                self.ensure_selection_is_visible();
+                self.viewport.select(idx, &UnwrappedRows(self.rows.len()));
                 return;
             }
         }
     }
     /// Select the first line of the previous block of changes
     pub fn previous_change(&mut self) {
-        let s = self.selection_idx.unwrap_or(0);
+        let s = self.viewport.selection().unwrap_or(0);
         for d in 1..=self.rows.len() {
             let idx = (self.rows.len() + s - d) % self.rows.len();
             if self.is_change_start(idx) {
-                self.selection_idx = Some(idx);
-                self.ensure_selection_is_visible();
+                self.viewport.select(idx, &UnwrappedRows(self.rows.len()));
                 return;
             }
         }
@@ -205,64 +181,26 @@ impl UnifiedDiffView {
         &mut self,
         y: u16,
     ) -> bool {
-        let idx = y as usize + self.scroll;
-        if idx < self.rows.len() {
-            self.selection_idx = Some(idx);
-            true
-        } else {
-            false
-        }
+        self.viewport.try_select_y(y, &UnwrappedRows(self.rows.len()))
     }
     pub fn select_first(&mut self) {
-        if !self.rows.is_empty() {
-            self.selection_idx = Some(0);
-            self.scroll = 0;
-        }
+        self.viewport.select_first(&UnwrappedRows(self.rows.len()));
     }
     pub fn select_last(&mut self) {
-        if !self.rows.is_empty() {
-            self.selection_idx = Some(self.rows.len() - 1);
-            self.ensure_selection_is_visible();
-        }
+        self.viewport.select_last(&UnwrappedRows(self.rows.len()));
     }
     pub fn move_selection(
         &mut self,
         dy: i32,
         cycle: bool,
     ) {
-        if let Some(idx) = self.selection_idx {
-            self.selection_idx = Some(move_sel(idx, self.rows.len(), dy, cycle));
-        } else if !self.rows.is_empty() {
-            self.selection_idx = Some(0);
-        }
-        self.ensure_selection_is_visible();
+        self.viewport.move_selection(dy, cycle, &UnwrappedRows(self.rows.len()));
     }
     pub fn try_scroll(
         &mut self,
         cmd: ScrollCommand,
     ) -> bool {
-        let old_scroll = self.scroll;
-        self.scroll = cmd.apply(self.scroll, self.rows.len(), self.page_height);
-        if let Some(idx) = self.selection_idx {
-            if self.scroll == old_scroll {
-                let old_selection = self.selection_idx;
-                if cmd.is_up() {
-                    self.selection_idx = Some(0);
-                } else {
-                    self.selection_idx = Some(self.rows.len() - 1);
-                }
-                return self.selection_idx == old_selection;
-            } else if idx >= old_scroll && idx < old_scroll + self.page_height {
-                if idx + self.scroll < old_scroll {
-                    self.selection_idx = Some(0);
-                } else if idx + self.scroll - old_scroll >= self.rows.len() {
-                    self.selection_idx = Some(self.rows.len() - 1);
-                } else {
-                    self.selection_idx = Some(idx + self.scroll - old_scroll);
-                }
-            }
-        }
-        self.scroll != old_scroll
+        self.viewport.try_scroll(cmd, &UnwrappedRows(self.rows.len()))
     }
     pub fn display(
         &mut self,
@@ -272,15 +210,14 @@ impl UnifiedDiffView {
         area: &Area,
         con: &AppContext,
     ) -> Result<(), ProgramError> {
-        if area.height as usize != self.page_height {
-            self.page_height = area.height as usize;
-            self.ensure_selection_is_visible();
-        }
+        let rows = UnwrappedRows(self.rows.len());
+        self.viewport
+            .set_layout(area.height as usize, area.width as usize, false, &rows);
         let styles = &panel_skin.styles;
         let number_len = self.max_line_number().to_string().len();
         let show_line_numbers = area.width as usize > 2 * number_len + 30;
         let code_width = area.width as usize - 1; // 1 char left for scrollbar
-        let scrollbar = area.scrollbar(self.scroll, self.rows.len());
+        let scrollbar = self.viewport.scrollbar(area, &rows);
         let scrollbar_fg = styles
             .scrollbar_thumb
             .get_fg()
@@ -289,8 +226,8 @@ impl UnifiedDiffView {
         for y in 0..area.height as usize {
             w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
             let mut cw = CropWriter::new(w, code_width);
-            let row_idx = self.scroll + y;
-            let selected = self.selection_idx == Some(row_idx);
+            let row_idx = self.viewport.scroll().line + y;
+            let selected = self.viewport.is_selected(row_idx);
             match self.rows.get(row_idx) {
                 Some(Row::Separator) => {
                     cw.queue_unstyled_str(" ")?;
@@ -389,16 +326,6 @@ impl UnifiedDiffView {
     }
 }
 
-fn is_thumb(
-    y: usize,
-    scrollbar: Option<(u16, u16)>,
-) -> bool {
-    scrollbar.is_some_and(|(top, bottom)| {
-        let y = y as u16;
-        top <= y && y <= bottom
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -440,23 +367,23 @@ mod tests {
             deletions: 0,
         };
         let mut view = UnifiedDiffView::from_diff(diff);
-        view.page_height = 10;
+        view.viewport.set_layout(10, 80, false, &UnwrappedRows(view.rows.len()));
         // rows: h0 = 0..4, sep 4, h1 = 5..8, sep 8, h2 = 9..17
         let starts: Vec<usize> = (0..view.rows.len()).filter(|&i| view.is_change_start(i)).collect();
         assert_eq!(starts, vec![1, 6, 10, 15]);
         view.next_change();
-        assert_eq!(view.selection_idx, Some(1));
+        assert_eq!(view.viewport.selection(), Some(1));
         view.next_change();
-        assert_eq!(view.selection_idx, Some(6));
+        assert_eq!(view.viewport.selection(), Some(6));
         view.next_change();
-        assert_eq!(view.selection_idx, Some(10));
+        assert_eq!(view.viewport.selection(), Some(10));
         view.next_change();
-        assert_eq!(view.selection_idx, Some(15));
+        assert_eq!(view.viewport.selection(), Some(15));
         view.next_change();
-        assert_eq!(view.selection_idx, Some(1));
+        assert_eq!(view.viewport.selection(), Some(1));
         view.previous_change();
-        assert_eq!(view.selection_idx, Some(15));
+        assert_eq!(view.viewport.selection(), Some(15));
         view.previous_change();
-        assert_eq!(view.selection_idx, Some(10));
+        assert_eq!(view.viewport.selection(), Some(10));
     }
 }

--- a/src/preview/unified_diff_view.rs
+++ b/src/preview/unified_diff_view.rs
@@ -6,14 +6,18 @@ use {
         },
         command::ScrollCommand,
         display::{
+            Overflow,
+            Rows,
             Screen,
-            UnwrappedRows,
+            TAB_WIDTH,
             Viewport,
             W,
             is_thumb,
+            row_starts,
         },
         errors::ProgramError,
         git::{
+            DiffLine,
             DiffLineKind,
             FileDiff,
             FileDiffContent,
@@ -57,6 +61,48 @@ pub struct UnifiedDiffView {
     viewport: Viewport,
 }
 
+/// The rows of a diff view, for layout by the viewport
+struct DiffRows<'v> {
+    rows: &'v [Row],
+    diff: &'v FileDiff,
+}
+impl<'v> DiffRows<'v> {
+    fn line(
+        &self,
+        row: Row,
+    ) -> Option<&'v DiffLine> {
+        match (row, &self.diff.content) {
+            (Row::Line(hunk_idx, line_idx), FileDiffContent::Text(hunks)) => {
+                hunks.get(hunk_idx).and_then(|hunk| hunk.lines.get(line_idx))
+            }
+            _ => None,
+        }
+    }
+}
+impl Rows for DiffRows<'_> {
+    fn len(&self) -> usize {
+        self.rows.len()
+    }
+    fn row_count(
+        &self,
+        idx: usize,
+        width: usize,
+    ) -> usize {
+        match self.line(self.rows[idx]) {
+            Some(line) => crate::display::row_count(line.content.chars(), width),
+            None => 1, // separator
+        }
+    }
+    fn width_hint(
+        &self,
+        idx: usize,
+    ) -> usize {
+        // the length in bytes overestimates the width in cells,
+        // exactly for ASCII
+        self.line(self.rows[idx]).map_or(1, |line| line.content.len())
+    }
+}
+
 impl UnifiedDiffView {
     pub fn new(
         path: &Path,
@@ -86,13 +132,12 @@ impl UnifiedDiffView {
     fn line(
         &self,
         row: Row,
-    ) -> Option<&crate::git::DiffLine> {
-        match (row, &self.diff.content) {
-            (Row::Line(hunk_idx, line_idx), FileDiffContent::Text(hunks)) => {
-                hunks.get(hunk_idx).and_then(|hunk| hunk.lines.get(line_idx))
-            }
-            _ => None,
+    ) -> Option<&DiffLine> {
+        DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
         }
+        .line(row)
     }
     fn max_line_number(&self) -> usize {
         match &self.diff.content {
@@ -131,7 +176,11 @@ impl UnifiedDiffView {
                 .is_some_and(|n| n >= number)
         });
         if let Some(idx) = idx {
-            self.viewport.select(idx, &UnwrappedRows(self.rows.len()));
+            let rows = DiffRows {
+                rows: &self.rows,
+                diff: &self.diff,
+            };
+            self.viewport.select(idx, &rows);
         }
         idx.is_some()
     }
@@ -161,7 +210,11 @@ impl UnifiedDiffView {
         for d in 1..=self.rows.len() {
             let idx = (s + d) % self.rows.len();
             if self.is_change_start(idx) {
-                self.viewport.select(idx, &UnwrappedRows(self.rows.len()));
+                let rows = DiffRows {
+                    rows: &self.rows,
+                    diff: &self.diff,
+                };
+                self.viewport.select(idx, &rows);
                 return;
             }
         }
@@ -172,7 +225,11 @@ impl UnifiedDiffView {
         for d in 1..=self.rows.len() {
             let idx = (self.rows.len() + s - d) % self.rows.len();
             if self.is_change_start(idx) {
-                self.viewport.select(idx, &UnwrappedRows(self.rows.len()));
+                let rows = DiffRows {
+                    rows: &self.rows,
+                    diff: &self.diff,
+                };
+                self.viewport.select(idx, &rows);
                 return;
             }
         }
@@ -181,26 +238,46 @@ impl UnifiedDiffView {
         &mut self,
         y: u16,
     ) -> bool {
-        self.viewport.try_select_y(y, &UnwrappedRows(self.rows.len()))
+        let rows = DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
+        };
+        self.viewport.try_select_y(y, &rows)
     }
     pub fn select_first(&mut self) {
-        self.viewport.select_first(&UnwrappedRows(self.rows.len()));
+        let rows = DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
+        };
+        self.viewport.select_first(&rows);
     }
     pub fn select_last(&mut self) {
-        self.viewport.select_last(&UnwrappedRows(self.rows.len()));
+        let rows = DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
+        };
+        self.viewport.select_last(&rows);
     }
     pub fn move_selection(
         &mut self,
         dy: i32,
         cycle: bool,
     ) {
-        self.viewport.move_selection(dy, cycle, &UnwrappedRows(self.rows.len()));
+        let rows = DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
+        };
+        self.viewport.move_selection(dy, cycle, &rows);
     }
     pub fn try_scroll(
         &mut self,
         cmd: ScrollCommand,
     ) -> bool {
-        self.viewport.try_scroll(cmd, &UnwrappedRows(self.rows.len()))
+        let rows = DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
+        };
+        self.viewport.try_scroll(cmd, &rows)
     }
     pub fn display(
         &mut self,
@@ -209,32 +286,43 @@ impl UnifiedDiffView {
         panel_skin: &PanelSkin,
         area: &Area,
         con: &AppContext,
+        overflow: Overflow,
     ) -> Result<(), ProgramError> {
-        let rows = UnwrappedRows(self.rows.len());
-        self.viewport
-            .set_layout(area.height as usize, area.width as usize, false, &rows);
+        let rows = DiffRows {
+            rows: &self.rows,
+            diff: &self.diff,
+        };
         let styles = &panel_skin.styles;
         let number_len = self.max_line_number().to_string().len();
         let show_line_numbers = area.width as usize > 2 * number_len + 30;
         let code_width = area.width as usize - 1; // 1 char left for scrollbar
+        let gutter_width = if show_line_numbers { 2 * number_len + 3 } else { 0 }
+            + usize::from(con.show_selection_mark)
+            + 2; // the sign and the space after it
+        let text_width = code_width.saturating_sub(gutter_width).max(1);
+        self.viewport
+            .set_layout(area.height as usize, text_width, overflow, &rows);
+        let positions = self.viewport.visible_rows(&rows);
         let scrollbar = self.viewport.scrollbar(area, &rows);
         let scrollbar_fg = styles
             .scrollbar_thumb
             .get_fg()
             .or_else(|| styles.preview.get_fg())
             .unwrap_or(Color::White);
+        // row starts of the line being drawn, computed once per line
+        let mut laid_out: Option<(usize, Vec<usize>)> = None;
         for y in 0..area.height as usize {
             w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
             let mut cw = CropWriter::new(w, code_width);
-            let row_idx = self.viewport.scroll().line + y;
-            let selected = self.viewport.is_selected(row_idx);
-            match self.rows.get(row_idx) {
-                Some(Row::Separator) => {
+            let pos = positions.get(y).copied();
+            let selected = pos.is_some_and(|pos| self.viewport.is_selected(pos.line));
+            match pos.map(|pos| (pos, self.rows[pos.line])) {
+                Some((_, Row::Separator)) => {
                     cw.queue_unstyled_str(" ")?;
                     cw.fill(&styles.preview_separator, &SEPARATOR_FILLING)?;
                 }
-                Some(&row @ Row::Line(..)) => {
-                    let Some(line) = self.line(row) else {
+                Some((pos, row @ Row::Line(..))) => {
+                    let Some(line) = rows.line(row) else {
                         continue;
                     };
                     let (line_style, sign) = match line.kind {
@@ -248,25 +336,57 @@ impl UnifiedDiffView {
                         line_style
                     };
                     if show_line_numbers {
-                        let number = |n: Option<usize>| match n {
-                            Some(n) => format!("{n:>number_len$}"),
-                            None => " ".repeat(number_len),
-                        };
-                        cw.queue_g_string(
-                            &styles.diff_line_number,
-                            format!(
-                                " {} {} ",
-                                number(line.old_number),
-                                number(line.new_number),
-                            ),
-                        )?;
+                        if pos.sub == 0 {
+                            let number = |n: Option<usize>| match n {
+                                Some(n) => format!("{n:>number_len$}"),
+                                None => " ".repeat(number_len),
+                            };
+                            cw.queue_g_string(
+                                &styles.diff_line_number,
+                                format!(
+                                    " {} {} ",
+                                    number(line.old_number),
+                                    number(line.new_number),
+                                ),
+                            )?;
+                        } else {
+                            cw.queue_g_string(
+                                &styles.diff_line_number,
+                                " ".repeat(2 * number_len + 3),
+                            )?;
+                        }
                     }
                     if con.show_selection_mark {
-                        cw.queue_char(style, if selected { '▶' } else { ' ' })?;
+                        cw.queue_char(style, if selected && pos.sub == 0 { '▶' } else { ' ' })?;
                     }
-                    cw.queue_char(style, sign)?;
+                    cw.queue_char(style, if pos.sub == 0 { sign } else { ' ' })?;
                     cw.queue_char(style, ' ')?;
-                    cw.queue_str(style, &line.content)?;
+                    let starts: &[usize] = if overflow == Overflow::Wrap {
+                        if laid_out.as_ref().is_none_or(|(idx, _)| *idx != pos.line) {
+                            laid_out = Some((pos.line, row_starts(line.content.chars(), text_width)));
+                        }
+                        &laid_out.as_ref().unwrap().1
+                    } else {
+                        &[]
+                    };
+                    // chars of the line displayed on this row
+                    let from = if pos.sub == 0 { 0 } else { starts[pos.sub - 1] };
+                    let to = starts.get(pos.sub).copied().unwrap_or(usize::MAX);
+                    let mut s = String::new();
+                    for (ci, c) in line.content.chars().enumerate() {
+                        if ci >= to {
+                            break;
+                        }
+                        if ci < from || c == '\n' || c == '\r' {
+                            continue;
+                        }
+                        if c == '\t' {
+                            s.extend(std::iter::repeat_n(' ', TAB_WIDTH));
+                        } else {
+                            s.push(c);
+                        }
+                    }
+                    cw.queue_str(style, &s)?;
                     cw.fill(style, &SPACE_FILLING)?;
                 }
                 None => {
@@ -367,7 +487,11 @@ mod tests {
             deletions: 0,
         };
         let mut view = UnifiedDiffView::from_diff(diff);
-        view.viewport.set_layout(10, 80, false, &UnwrappedRows(view.rows.len()));
+        let rows = DiffRows {
+            rows: &view.rows,
+            diff: &view.diff,
+        };
+        view.viewport.set_layout(10, 80, Overflow::NoWrap, &rows);
         // rows: h0 = 0..4, sep 4, h1 = 5..8, sep 8, h2 = 9..17
         let starts: Vec<usize> = (0..view.rows.len()).filter(|&i| view.is_change_start(i)).collect();
         assert_eq!(starts, vec![1, 6, 10, 15]);
@@ -385,5 +509,32 @@ mod tests {
         assert_eq!(view.viewport.selection(), Some(15));
         view.previous_change();
         assert_eq!(view.viewport.selection(), Some(10));
+    }
+
+    #[test]
+    fn wrapped_row_counts() {
+        let mut h = hunk(1, " + ");
+        h.lines[0].content = "abcdefghijkl".to_string(); // 12 cells
+        h.lines[1].content = "日本語日本語".to_string(); // 6 wide chars, 12 cells
+        h.lines[2].content = "ab\tcd".to_string(); // 4 + TAB_WIDTH cells
+        let diff = FileDiff {
+            path: std::path::PathBuf::from("f"),
+            content: FileDiffContent::Text(vec![h]),
+            insertions: 1,
+            deletions: 0,
+        };
+        let view = UnifiedDiffView::from_diff(diff);
+        let rows = DiffRows {
+            rows: &view.rows,
+            diff: &view.diff,
+        };
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.row_count(0, 5), 3);
+        // wide chars don't straddle rows: 2 per 5 cells row
+        assert_eq!(rows.row_count(1, 5), 3);
+        assert_eq!(rows.row_count(1, 12), 1);
+        // the tab takes TAB_WIDTH cells
+        assert_eq!(rows.row_count(2, TAB_WIDTH + 2), 2);
+        assert_eq!(rows.row_count(2, TAB_WIDTH + 4), 1);
     }
 }

--- a/src/syntactic/text_view.rs
+++ b/src/syntactic/text_view.rs
@@ -7,6 +7,7 @@ use {
         },
         command::ScrollCommand,
         display::{
+            Overflow,
             Rows,
             Screen,
             TAB_WIDTH,
@@ -147,6 +148,7 @@ impl TextRows<'_> {
             .and_then(|mmap| mmap.get(line.start..line.start + line.len))
             // we copy the slice, as the file may change
             .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok())
+            .map(|s| printable_line(&s).into_owned())
     }
 }
 impl Rows for TextRows<'_> {
@@ -175,6 +177,8 @@ impl Rows for TextRows<'_> {
     ) -> usize {
         match &self.lines[idx] {
             DisplayLine::Separator => 1,
+            // the length in bytes overestimates the width in cells,
+            // exactly for ASCII, without reading the line
             DisplayLine::Content(line) => line.len,
         }
     }
@@ -246,7 +250,6 @@ impl TextView {
             return Err(ProgramError::ZeroLenFile);
         }
         let with_style = !no_style && md.len() < MAX_SIZE_FOR_STYLING;
-        self.mmap = if with_style { None } else { Some(mmap) };
         let mut reader = BufReader::new(f);
         let mut content_lines = Vec::new();
         let mut line = String::new();
@@ -259,6 +262,8 @@ impl TextView {
         } else {
             None
         };
+        // lines are read back from the file when they aren't stored styled
+        self.mmap = if highlighter.is_some() { None } else { Some(mmap) };
         let pattern = &self.pattern.pattern;
         while reader.read_line(&mut line)? > 0 {
             number += 1;
@@ -286,7 +291,7 @@ impl TextView {
             content_lines.push(Line {
                 regions,
                 start,
-                len: clean_line.len(),
+                len: line.len(),
                 name_match,
                 number,
             });
@@ -381,9 +386,6 @@ impl TextView {
             .selection()
             .and_then(|idx| self.lines[idx].line_number())
     }
-    pub fn unselect(&mut self) {
-        self.viewport.unselect();
-    }
     pub fn try_select_y(
         &mut self,
         y: u16,
@@ -414,10 +416,11 @@ impl TextView {
         // this could obviously be optimized
         for (idx, line) in self.lines.iter().enumerate() {
             if line.line_number() == Some(number) {
-                self.viewport.select(idx, &TextRows {
-            lines: &self.lines,
-            mmap: self.mmap.as_ref(),
-        });
+                let rows = TextRows {
+                    lines: &self.lines,
+                    mmap: self.mmap.as_ref(),
+                };
+                self.viewport.select(idx, &rows);
                 return true;
             }
         }
@@ -440,10 +443,11 @@ impl TextView {
         for d in 1..self.lines.len() {
             let idx = (self.lines.len() + s - d) % self.lines.len();
             if self.lines[idx].is_match() {
-                self.viewport.select(idx, &TextRows {
-            lines: &self.lines,
-            mmap: self.mmap.as_ref(),
-        });
+                let rows = TextRows {
+                    lines: &self.lines,
+                    mmap: self.mmap.as_ref(),
+                };
+                self.viewport.select(idx, &rows);
                 return;
             }
         }
@@ -453,10 +457,11 @@ impl TextView {
         for d in 1..self.lines.len() {
             let idx = (s + d) % self.lines.len();
             if self.lines[idx].is_match() {
-                self.viewport.select(idx, &TextRows {
-            lines: &self.lines,
-            mmap: self.mmap.as_ref(),
-        });
+                let rows = TextRows {
+                    lines: &self.lines,
+                    mmap: self.mmap.as_ref(),
+                };
+                self.viewport.select(idx, &rows);
                 return;
             }
         }
@@ -498,7 +503,7 @@ impl TextView {
         panel_skin: &PanelSkin,
         area: &Area,
         con: &AppContext,
-        wrap: bool,
+        overflow: Overflow,
     ) -> Result<(), ProgramError> {
         let rows = TextRows {
             lines: &self.lines,
@@ -511,7 +516,7 @@ impl TextView {
             + usize::from(con.show_selection_mark);
         let text_width = code_width.saturating_sub(gutter_width).max(1);
         self.viewport
-            .set_layout(area.height as usize, text_width, wrap, &rows);
+            .set_layout(area.height as usize, text_width, overflow, &rows);
         let positions = self.viewport.visible_rows(&rows);
         let scrollbar = self.viewport.scrollbar(area, &rows);
         let styles = &panel_skin.styles;
@@ -573,7 +578,7 @@ impl TextView {
                         } else {
                             Cow::Borrowed(line.regions.as_slice())
                         };
-                        let starts = if wrap {
+                        let starts = if overflow == Overflow::Wrap {
                             row_starts(regions.iter().flat_map(|r| r.string.chars()), text_width)
                         } else {
                             Vec::new()
@@ -606,7 +611,7 @@ impl TextView {
                     let from = if pos.sub == 0 { 0 } else { starts[pos.sub - 1] };
                     let to = starts.get(pos.sub).copied().unwrap_or(usize::MAX);
                     let pos_list = line.name_match.as_ref().map(|nm| &nm.pos);
-                    if !wrap && pos_list.is_none() {
+                    if overflow == Overflow::NoWrap && pos_list.is_none() {
                         for region in regions {
                             cw.w.queue(SetForegroundColor(region.fg))?;
                             let s = region.string.trim_end_matches(is_char_end_of_line);

--- a/src/syntactic/text_view.rs
+++ b/src/syntactic/text_view.rs
@@ -5,13 +5,15 @@ use {
             AppContext,
             LineNumber,
         },
-        command::{
-            ScrollCommand,
-            move_sel,
-        },
+        command::ScrollCommand,
         display::{
+            Rows,
             Screen,
+            TAB_WIDTH,
+            Viewport,
             W,
+            is_thumb,
+            row_starts,
         },
         errors::*,
         pattern::{
@@ -58,7 +60,7 @@ use {
 pub static SEPARATOR_FILLING: Lazy<Filling> = Lazy::new(|| Filling::from_char('─'));
 
 /// Homogeneously colored piece of a line
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Region {
     pub fg: Color,
     pub string: String,
@@ -107,9 +109,9 @@ pub struct TextView {
     pub path: PathBuf,
     pub pattern: InputPattern,
     lines: Vec<DisplayLine>,
-    scroll: usize,
-    page_height: usize,
-    selection_idx: Option<usize>, // index in lines of the selection, if any
+    /// the file, when lines aren't kept in memory
+    mmap: Option<Mmap>,
+    viewport: Viewport,
     content_lines_count: usize,   // number of lines excluding separators
     total_lines_count: usize,     // including lines not filtered out
     partial: bool,
@@ -130,6 +132,54 @@ impl DisplayLine {
     }
 }
 
+/// The lines of a text view, for layout by the viewport
+struct TextRows<'v> {
+    lines: &'v [DisplayLine],
+    mmap: Option<&'v Mmap>,
+}
+impl TextRows<'_> {
+    /// Return the content of a line not kept in memory
+    fn read(
+        &self,
+        line: &Line,
+    ) -> Option<String> {
+        self.mmap
+            .and_then(|mmap| mmap.get(line.start..line.start + line.len))
+            // we copy the slice, as the file may change
+            .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok())
+    }
+}
+impl Rows for TextRows<'_> {
+    fn len(&self) -> usize {
+        self.lines.len()
+    }
+    fn row_count(
+        &self,
+        idx: usize,
+        width: usize,
+    ) -> usize {
+        match &self.lines[idx] {
+            DisplayLine::Separator => 1,
+            DisplayLine::Content(line) if !line.regions.is_empty() => crate::display::row_count(
+                line.regions.iter().flat_map(|r| r.string.chars()),
+                width,
+            ),
+            DisplayLine::Content(line) => self
+                .read(line)
+                .map_or(1, |s| crate::display::row_count(s.chars(), width)),
+        }
+    }
+    fn width_hint(
+        &self,
+        idx: usize,
+    ) -> usize {
+        match &self.lines[idx] {
+            DisplayLine::Separator => 1,
+            DisplayLine::Content(line) => line.len,
+        }
+    }
+}
+
 impl TextView {
     /// Return a prepared text view with syntax coloring if possible.
     /// May return Ok(None) only when a pattern is given and there
@@ -146,15 +196,17 @@ impl TextView {
             path: path.to_path_buf(),
             pattern,
             lines: Vec::new(),
-            scroll: 0,
-            page_height: 0,
-            selection_idx: None,
+            mmap: None,
+            viewport: Viewport::default(),
             content_lines_count: 0,
             total_lines_count: 0,
             partial: false,
         };
         if sv.read_lines(dam, con, no_style, allow_partial)? {
-            sv.select_first();
+            sv.viewport.select_first(&TextRows {
+                lines: &sv.lines,
+                mmap: sv.mmap.as_ref(),
+            });
             Ok(Some(sv))
         } else {
             Ok(None)
@@ -186,19 +238,15 @@ impl TextView {
         initial_load: bool,
     ) -> Result<bool, ProgramError> {
         let f = File::open(&self.path)?;
-        {
-            // if we detect the file isn't mappable, we'll
-            // let the ZeroLenFilePreview try to read it
-            let mmap = unsafe { Mmap::map(&f) };
-            if mmap.is_err() {
-                return Err(ProgramError::UnmappableFile);
-            }
-        }
+        // if we detect the file isn't mappable, we'll
+        // let the ZeroLenFilePreview try to read it
+        let mmap = unsafe { Mmap::map(&f) }.map_err(|_| ProgramError::UnmappableFile)?;
         let md = f.metadata()?;
         if md.len() == 0 {
             return Err(ProgramError::ZeroLenFile);
         }
         let with_style = !no_style && md.len() < MAX_SIZE_FOR_STYLING;
+        self.mmap = if with_style { None } else { Some(mmap) };
         let mut reader = BufReader::new(f);
         let mut content_lines = Vec::new();
         let mut line = String::new();
@@ -301,78 +349,62 @@ impl TextView {
         (self.lines.len(), self.total_lines_count)
     }
 
-    fn ensure_selection_is_visible(&mut self) {
-        if self.page_height >= self.lines.len() {
-            self.scroll = 0;
-        } else if let Some(idx) = self.selection_idx {
-            let padding = self.padding();
-            if idx < self.scroll + padding || idx + padding > self.scroll + self.page_height {
-                if idx <= padding {
-                    self.scroll = 0;
-                } else if idx + padding > self.lines.len() {
-                    self.scroll = self.lines.len() - self.page_height;
-                } else if idx < self.scroll + self.page_height / 2 {
-                    self.scroll = idx - padding;
-                } else {
-                    self.scroll = idx + padding - self.page_height;
-                }
-            }
-        }
-    }
-
-    fn padding(&self) -> usize {
-        (self.page_height / 4).min(4)
-    }
-
     pub fn get_selected_line(&self) -> Option<String> {
-        self.selection_idx
+        self.viewport
+            .selection()
             .and_then(|idx| self.lines.get(idx))
             .and_then(|line| match line {
                 DisplayLine::Content(line) => Some(line),
                 DisplayLine::Separator => None,
             })
             .and_then(|line| {
-                File::open(&self.path)
-                    .and_then(|file| unsafe { Mmap::map(&file) })
-                    .ok()
-                    .filter(|mmap| mmap.len() >= line.start + line.len)
-                    .and_then(|mmap| {
-                        String::from_utf8((mmap[line.start..line.start + line.len]).to_vec()).ok()
-                    })
+                let mapped;
+                let mmap = match &self.mmap {
+                    Some(mmap) => mmap,
+                    None => {
+                        mapped = File::open(&self.path)
+                            .and_then(|file| unsafe { Mmap::map(&file) })
+                            .ok()?;
+                        &mapped
+                    }
+                };
+                TextRows {
+                    lines: &self.lines,
+                    mmap: Some(mmap),
+                }
+                .read(line)
             })
     }
 
     pub fn get_selected_line_number(&self) -> Option<LineNumber> {
-        self.selection_idx
+        self.viewport
+            .selection()
             .and_then(|idx| self.lines[idx].line_number())
     }
     pub fn unselect(&mut self) {
-        self.selection_idx = None;
+        self.viewport.unselect();
     }
     pub fn try_select_y(
         &mut self,
         y: u16,
     ) -> bool {
-        let idx = y as usize + self.scroll;
-        if idx < self.lines.len() {
-            self.selection_idx = Some(idx);
-            true
-        } else {
-            false
-        }
+        self.viewport.try_select_y(y, &TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        })
     }
 
     pub fn select_first(&mut self) {
-        if !self.lines.is_empty() {
-            self.selection_idx = Some(0);
-            self.scroll = 0;
-        }
+        self.viewport.select_first(&TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        });
     }
     pub fn select_last(&mut self) {
-        self.selection_idx = Some(self.lines.len() - 1);
-        if self.page_height < self.lines.len() {
-            self.scroll = self.lines.len() - self.page_height;
-        }
+        self.viewport.select_last(&TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        });
     }
 
     pub fn try_select_line_number(
@@ -382,8 +414,10 @@ impl TextView {
         // this could obviously be optimized
         for (idx, line) in self.lines.iter().enumerate() {
             if line.line_number() == Some(number) {
-                self.selection_idx = Some(idx);
-                self.ensure_selection_is_visible();
+                self.viewport.select(idx, &TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        });
                 return true;
             }
         }
@@ -395,32 +429,34 @@ impl TextView {
         dy: i32,
         cycle: bool,
     ) {
-        if let Some(idx) = self.selection_idx {
-            self.selection_idx = Some(move_sel(idx, self.lines.len(), dy, cycle));
-        } else if !self.lines.is_empty() {
-            self.selection_idx = Some(0)
-        }
-        self.ensure_selection_is_visible();
+        self.viewport.move_selection(dy, cycle, &TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        });
     }
 
     pub fn previous_match(&mut self) {
-        let s = self.selection_idx.unwrap_or(0);
+        let s = self.viewport.selection().unwrap_or(0);
         for d in 1..self.lines.len() {
             let idx = (self.lines.len() + s - d) % self.lines.len();
             if self.lines[idx].is_match() {
-                self.selection_idx = Some(idx);
-                self.ensure_selection_is_visible();
+                self.viewport.select(idx, &TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        });
                 return;
             }
         }
     }
     pub fn next_match(&mut self) {
-        let s = self.selection_idx.unwrap_or(0);
+        let s = self.viewport.selection().unwrap_or(0);
         for d in 1..self.lines.len() {
             let idx = (s + d) % self.lines.len();
             if self.lines[idx].is_match() {
-                self.selection_idx = Some(idx);
-                self.ensure_selection_is_visible();
+                self.viewport.select(idx, &TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        });
                 return;
             }
         }
@@ -430,28 +466,10 @@ impl TextView {
         &mut self,
         cmd: ScrollCommand,
     ) -> bool {
-        let old_scroll = self.scroll;
-        self.scroll = cmd.apply(self.scroll, self.lines.len(), self.page_height);
-        if let Some(idx) = self.selection_idx {
-            if self.scroll == old_scroll {
-                let old_selection = self.selection_idx;
-                if cmd.is_up() {
-                    self.selection_idx = Some(0);
-                } else {
-                    self.selection_idx = Some(self.lines.len() - 1);
-                }
-                return self.selection_idx == old_selection;
-            } else if idx >= old_scroll && idx < old_scroll + self.page_height {
-                if idx + self.scroll < old_scroll {
-                    self.selection_idx = Some(0);
-                } else if idx + self.scroll - old_scroll >= self.lines.len() {
-                    self.selection_idx = Some(self.lines.len() - 1);
-                } else {
-                    self.selection_idx = Some(idx + self.scroll - old_scroll);
-                }
-            }
-        }
-        self.scroll != old_scroll
+        self.viewport.try_scroll(cmd, &TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        })
     }
 
     pub fn max_line_number(&self) -> Option<LineNumber> {
@@ -480,14 +498,22 @@ impl TextView {
         panel_skin: &PanelSkin,
         area: &Area,
         con: &AppContext,
+        wrap: bool,
     ) -> Result<(), ProgramError> {
-        if area.height as usize != self.page_height {
-            self.page_height = area.height as usize;
-            self.ensure_selection_is_visible();
-        }
+        let rows = TextRows {
+            lines: &self.lines,
+            mmap: self.mmap.as_ref(),
+        };
         let max_number_len = self.max_line_number().unwrap_or(0).to_string().len();
         let show_line_number = area.width > 55 || (self.pattern.is_some() && area.width > 8);
-        let line_count = area.height as usize;
+        let code_width = area.width as usize - 1; // 1 char left for scrollbar
+        let gutter_width = if show_line_number { max_number_len + 2 } else { 1 }
+            + usize::from(con.show_selection_mark);
+        let text_width = code_width.saturating_sub(gutter_width).max(1);
+        self.viewport
+            .set_layout(area.height as usize, text_width, wrap, &rows);
+        let positions = self.viewport.visible_rows(&rows);
+        let scrollbar = self.viewport.scrollbar(area, &rows);
         let styles = &panel_skin.styles;
         let normal_fg = styles
             .preview
@@ -507,97 +533,125 @@ impl TextView {
             .preview_match
             .get_bg()
             .unwrap_or(Color::AnsiValue(28));
-        let code_width = area.width as usize - 1; // 1 char left for scrollbar
-        let scrollbar = area.scrollbar(self.scroll, self.lines.len());
         let scrollbar_fg = styles
             .scrollbar_thumb
             .get_fg()
             .or_else(|| styles.preview.get_fg())
             .unwrap_or(Color::White);
-        for y in 0..line_count {
+        // regions and row starts of the line being drawn, computed once per line
+        let mut laid_out: Option<(usize, Cow<'_, [Region]>, Vec<usize>)> = None;
+        for y in 0..area.height as usize {
             w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
             let mut cw = CropWriter::new(w, code_width);
-            let line_idx = self.scroll + y;
-            let selected = self.selection_idx == Some(line_idx);
+            let Some(&pos) = positions.get(y) else {
+                cw.fill(&styles.preview, &SPACE_FILLING)?;
+                w.queue(SetBackgroundColor(normal_bg))?;
+                w.queue(Print(' '))?;
+                continue;
+            };
+            let selected = self.viewport.is_selected(pos.line);
             let bg = if selected { selection_bg } else { normal_bg };
-            let mut op_mmap: Option<Mmap> = None;
-            match self.lines.get(line_idx) {
-                Some(DisplayLine::Separator) => {
+            match &self.lines[pos.line] {
+                DisplayLine::Separator => {
                     cw.w.queue(SetBackgroundColor(bg))?;
                     cw.queue_unstyled_str(" ")?;
                     cw.fill(&styles.preview_separator, &SEPARATOR_FILLING)?;
                 }
-                Some(DisplayLine::Content(line)) => {
-                    let mut regions = &line.regions;
-                    let regions_ur;
-                    if regions.is_empty() && line.len > 0 {
-                        if op_mmap.is_none() {
-                            let file = File::open(&self.path)?;
-                            let mmap = unsafe { Mmap::map(&file)? };
-                            op_mmap = Some(mmap);
-                        }
-                        if op_mmap.as_ref().unwrap().len() < line.start + line.len {
-                            warn!("file truncated since parsing");
+                DisplayLine::Content(line) => {
+                    if laid_out.as_ref().is_none_or(|(idx, _, _)| *idx != pos.line) {
+                        let regions = if line.regions.is_empty() && line.len > 0 {
+                            match rows.read(line) {
+                                Some(string) => Cow::Owned(vec![Region {
+                                    fg: normal_fg,
+                                    string,
+                                }]),
+                                None => {
+                                    warn!("file truncated since parsing");
+                                    Cow::Owned(Vec::new())
+                                }
+                            }
                         } else {
-                            // an UTF8 error can only happen if file modified during display
-                            let string = String::from_utf8(
-                                // we copy the memmap slice, as it's not immutable
-                                (op_mmap.unwrap()[line.start..line.start + line.len]).to_vec(),
-                            )
-                            .unwrap_or_else(|_| "Bad UTF8".to_string());
-                            regions_ur = vec![Region {
-                                fg: normal_fg,
-                                string,
-                            }];
-                            regions = &regions_ur;
-                        }
+                            Cow::Borrowed(line.regions.as_slice())
+                        };
+                        let starts = if wrap {
+                            row_starts(regions.iter().flat_map(|r| r.string.chars()), text_width)
+                        } else {
+                            Vec::new()
+                        };
+                        laid_out = Some((pos.line, regions, starts));
                     }
+                    let (_, regions, starts) = laid_out.as_ref().unwrap();
+                    let regions: &[Region] = regions;
                     cw.w.queue(SetBackgroundColor(bg))?;
                     if show_line_number {
-                        cw.queue_g_string(
-                            &styles.preview_line_number,
-                            format!(" {:w$} ", line.number, w = max_number_len),
-                        )?;
+                        if pos.sub == 0 {
+                            cw.queue_g_string(
+                                &styles.preview_line_number,
+                                format!(" {:w$} ", line.number, w = max_number_len),
+                            )?;
+                        } else {
+                            cw.queue_g_string(
+                                &styles.preview_line_number,
+                                " ".repeat(max_number_len + 2),
+                            )?;
+                        }
                     } else {
                         cw.queue_unstyled_str(" ")?;
                     }
                     cw.w.queue(SetBackgroundColor(bg))?;
                     if con.show_selection_mark {
-                        cw.queue_unstyled_char(if selected { '▶' } else { ' ' })?;
+                        cw.queue_unstyled_char(if selected && pos.sub == 0 { '▶' } else { ' ' })?;
                     }
-                    if let Some(nm) = &line.name_match {
-                        let mut dec = 0;
-                        let pos = &nm.pos;
-                        let mut pos_idx: usize = 0;
-                        for content in regions {
-                            let s = content.string.trim_end_matches(is_char_end_of_line);
-                            cw.w.queue(SetForegroundColor(content.fg))?;
-                            if pos_idx < pos.len() {
-                                for (cand_idx, cand_char) in s.chars().enumerate() {
-                                    if pos_idx < pos.len() && pos[pos_idx] == cand_idx + dec {
-                                        cw.w.queue(SetBackgroundColor(match_bg))?;
-                                        cw.queue_unstyled_char(cand_char)?;
-                                        cw.w.queue(SetBackgroundColor(bg))?;
-                                        pos_idx += 1;
-                                    } else {
-                                        cw.queue_unstyled_char(cand_char)?;
-                                    }
-                                }
-                                dec += s.chars().count();
+                    // chars of the line displayed on this row
+                    let from = if pos.sub == 0 { 0 } else { starts[pos.sub - 1] };
+                    let to = starts.get(pos.sub).copied().unwrap_or(usize::MAX);
+                    let pos_list = line.name_match.as_ref().map(|nm| &nm.pos);
+                    if !wrap && pos_list.is_none() {
+                        for region in regions {
+                            cw.w.queue(SetForegroundColor(region.fg))?;
+                            let s = region.string.trim_end_matches(is_char_end_of_line);
+                            if s.contains('\t') {
+                                cw.queue_unstyled_str(&s.replace('\t', &" ".repeat(TAB_WIDTH)))?;
                             } else {
                                 cw.queue_unstyled_str(s)?;
                             }
                         }
                     } else {
-                        for content in regions {
-                            cw.w.queue(SetForegroundColor(content.fg))?;
-                            cw.queue_unstyled_str(
-                                content.string.trim_end_matches(is_char_end_of_line),
-                            )?;
+                        // chars are buffered into runs of same style
+                        let pos_list = pos_list.map(|v| v.as_slice()).unwrap_or(&[]);
+                        let mut pos_idx = pos_list.partition_point(|&p| p < from);
+                        let mut ci = 0; // index of the char in the line
+                        let mut run = String::new();
+                        'regions: for region in regions {
+                            flush(&mut cw, &mut run)?;
+                            cw.w.queue(SetForegroundColor(region.fg))?;
+                            for c in region.string.chars() {
+                                if ci >= to {
+                                    break 'regions;
+                                }
+                                if ci >= from && !is_char_end_of_line(c) {
+                                    let matched = pos_list.get(pos_idx) == Some(&ci);
+                                    if matched {
+                                        flush(&mut cw, &mut run)?;
+                                        cw.w.queue(SetBackgroundColor(match_bg))?;
+                                        pos_idx += 1;
+                                    }
+                                    if c == '\t' {
+                                        run.extend(std::iter::repeat_n(' ', TAB_WIDTH));
+                                    } else {
+                                        run.push(c);
+                                    }
+                                    if matched {
+                                        flush(&mut cw, &mut run)?;
+                                        cw.w.queue(SetBackgroundColor(bg))?;
+                                    }
+                                }
+                                ci += 1;
+                            }
                         }
+                        flush(&mut cw, &mut run)?;
                     }
                 }
-                None => {}
             }
             cw.fill(
                 if selected {
@@ -663,16 +717,6 @@ impl TextView {
     }
 }
 
-fn is_thumb(
-    y: usize,
-    scrollbar: Option<(u16, u16)>,
-) -> bool {
-    scrollbar.is_some_and(|(sctop, scbottom)| {
-        let y = y as u16;
-        sctop <= y && y <= scbottom
-    })
-}
-
 /// Tell whether the character must be replaced to prevent rendering from being broken
 pub fn is_char_unprintable(c: char) -> bool {
     match c {
@@ -692,6 +736,18 @@ fn printable_line(line: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(line)
     }
+}
+
+/// Write the buffered run of chars, if any
+fn flush(
+    cw: &mut CropWriter<'_, W>,
+    run: &mut String,
+) -> Result<(), ProgramError> {
+    if !run.is_empty() {
+        cw.queue_unstyled_str(run)?;
+        run.clear();
+    }
+    Ok(())
 }
 
 fn is_char_end_of_line(c: char) -> bool {

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -8,8 +8,6 @@ pub const CSI_RESET: &str = "\u{1b}[0m";
 pub const CSI_BOLD: &str = "\u{1b}[1m";
 pub const CSI_ITALIC: &str = "\u{1b}[3m";
 
-static TAB_REPLACEMENT: &str = "    ";
-
 use {
     crate::{
         display::W,

--- a/src/tty/tline.rs
+++ b/src/tty/tline.rs
@@ -1,4 +1,5 @@
 use {
+    crate::display::TAB_WIDTH,
     super::*,
     crate::display::W,
     serde::{
@@ -68,7 +69,7 @@ impl TLine {
     pub fn from_tty(tty: &str) -> Self {
         let tty_str: String;
         let tty = if tty.contains('\t') {
-            tty_str = tty.replace('\t', TAB_REPLACEMENT);
+            tty_str = tty.replace('\t', &" ".repeat(TAB_WIDTH));
             &tty_str
         } else {
             tty

--- a/src/tty/tline.rs
+++ b/src/tty/tline.rs
@@ -6,6 +6,8 @@ use {
         Deserialize,
         Serialize,
     },
+    std::io::Write,
+    unicode_width::UnicodeWidthChar,
 };
 
 /// a simple representation of a line made of homogeneous parts.
@@ -141,6 +143,53 @@ impl TLine {
                 break;
             }
             cols += ts.draw_in(w, cols_max - cols)?;
+        }
+        Ok(cols)
+    }
+    /// Draw the chars of the line whose indexes are in `from..to`,
+    /// without taking more than cols_max cols, and return the number
+    /// of cols written.
+    /// Control chars are skipped, as they would break the column
+    /// accounting.
+    pub fn draw_range_in(
+        &self,
+        w: &mut W,
+        cols_max: usize,
+        from: usize,
+        to: usize,
+    ) -> Result<usize, ProgramError> {
+        let mut cols = 0;
+        let mut ci = 0; // index of the char in the line
+        for ts in &self.strings {
+            let mut run = String::new();
+            let mut full = false;
+            for c in ts.raw.chars() {
+                if ci >= to {
+                    full = true;
+                    break;
+                }
+                if ci >= from {
+                    if let Some(width) = c.width() {
+                        if cols + width > cols_max {
+                            full = true;
+                            break;
+                        }
+                        run.push(c);
+                        cols += width;
+                    }
+                }
+                ci += 1;
+            }
+            if !run.is_empty() {
+                if ts.csi.is_empty() {
+                    write!(w, "{run}")?;
+                } else {
+                    write!(w, "{}{}{}", ts.csi, run, CSI_RESET)?;
+                }
+            }
+            if full {
+                break;
+            }
         }
         Ok(cols)
     }

--- a/src/tty/tty_view.rs
+++ b/src/tty/tty_view.rs
@@ -1,13 +1,13 @@
 use {
     super::*,
     crate::{
-        command::{
-            ScrollCommand,
-            move_sel,
-        },
+        command::ScrollCommand,
         display::{
             Screen,
+            UnwrappedRows,
+            Viewport,
             W,
+            is_thumb,
         },
         errors::*,
         skin::PanelSkin,
@@ -41,9 +41,7 @@ use {
 pub struct TtyView {
     pub path: PathBuf,
     lines: Vec<TLine>,
-    scroll: usize,
-    page_height: usize,
-    selection_idx: Option<usize>, // index in lines of the selection, if any
+    viewport: Viewport,
     total_lines_count: usize,
 }
 
@@ -52,9 +50,7 @@ impl TtyView {
         let mut sv = Self {
             path: path.to_path_buf(),
             lines: Vec::new(),
-            scroll: 0,
-            page_height: 0,
-            selection_idx: None,
+            viewport: Viewport::default(),
             total_lines_count: 0,
         };
         sv.read_lines()?;
@@ -89,56 +85,21 @@ impl TtyView {
         Ok(())
     }
 
-    fn ensure_selection_is_visible(&mut self) {
-        if self.page_height >= self.lines.len() {
-            self.scroll = 0;
-        } else if let Some(idx) = self.selection_idx {
-            let padding = self.padding();
-            if idx < self.scroll + padding || idx + padding > self.scroll + self.page_height {
-                if idx <= padding {
-                    self.scroll = 0;
-                } else if idx + padding > self.lines.len() {
-                    self.scroll = self.lines.len() - self.page_height;
-                } else if idx < self.scroll + self.page_height / 2 {
-                    self.scroll = idx - padding;
-                } else {
-                    self.scroll = idx + padding - self.page_height;
-                }
-            }
-        }
-    }
-
-    fn padding(&self) -> usize {
-        (self.page_height / 4).min(4)
-    }
-
     pub fn unselect(&mut self) {
-        self.selection_idx = None;
+        self.viewport.unselect();
     }
     pub fn try_select_y(
         &mut self,
         y: u16,
     ) -> bool {
-        let idx = y as usize + self.scroll;
-        if idx < self.lines.len() {
-            self.selection_idx = Some(idx);
-            true
-        } else {
-            false
-        }
+        self.viewport.try_select_y(y, &UnwrappedRows(self.lines.len()))
     }
 
     pub fn select_first(&mut self) {
-        if !self.lines.is_empty() {
-            self.selection_idx = Some(0);
-            self.scroll = 0;
-        }
+        self.viewport.select_first(&UnwrappedRows(self.lines.len()));
     }
     pub fn select_last(&mut self) {
-        self.selection_idx = Some(self.lines.len() - 1);
-        if self.page_height < self.lines.len() {
-            self.scroll = self.lines.len() - self.page_height;
-        }
+        self.viewport.select_last(&UnwrappedRows(self.lines.len()));
     }
 
     pub fn move_selection(
@@ -146,40 +107,14 @@ impl TtyView {
         dy: i32,
         cycle: bool,
     ) {
-        if let Some(idx) = self.selection_idx {
-            self.selection_idx = Some(move_sel(idx, self.lines.len(), dy, cycle));
-        } else if !self.lines.is_empty() {
-            self.selection_idx = Some(0)
-        }
-        self.ensure_selection_is_visible();
+        self.viewport.move_selection(dy, cycle, &UnwrappedRows(self.lines.len()));
     }
 
     pub fn try_scroll(
         &mut self,
         cmd: ScrollCommand,
     ) -> bool {
-        let old_scroll = self.scroll;
-        self.scroll = cmd.apply(self.scroll, self.lines.len(), self.page_height);
-        if let Some(idx) = self.selection_idx {
-            if self.scroll == old_scroll {
-                let old_selection = self.selection_idx;
-                if cmd.is_up() {
-                    self.selection_idx = Some(0);
-                } else {
-                    self.selection_idx = Some(self.lines.len() - 1);
-                }
-                return self.selection_idx == old_selection;
-            } else if idx >= old_scroll && idx < old_scroll + self.page_height {
-                if idx + self.scroll < old_scroll {
-                    self.selection_idx = Some(0);
-                } else if idx + self.scroll - old_scroll >= self.lines.len() {
-                    self.selection_idx = Some(self.lines.len() - 1);
-                } else {
-                    self.selection_idx = Some(idx + self.scroll - old_scroll);
-                }
-            }
-        }
-        self.scroll != old_scroll
+        self.viewport.try_scroll(cmd, &UnwrappedRows(self.lines.len()))
     }
 
     pub fn display(
@@ -189,10 +124,9 @@ impl TtyView {
         panel_skin: &PanelSkin,
         area: &Area,
     ) -> Result<(), ProgramError> {
-        if area.height as usize != self.page_height {
-            self.page_height = area.height as usize;
-            self.ensure_selection_is_visible();
-        }
+        let rows = UnwrappedRows(self.lines.len());
+        self.viewport
+            .set_layout(area.height as usize, area.width as usize, false, &rows);
         let line_count = area.height as usize;
         let styles = &panel_skin.styles;
         let bg = styles
@@ -201,14 +135,14 @@ impl TtyView {
             .or_else(|| styles.default.get_bg())
             .unwrap_or(Color::AnsiValue(238));
         let content_width = area.width as usize - 1; // 1 char left for scrollbar
-        let scrollbar = area.scrollbar(self.scroll, self.lines.len());
+        let scrollbar = self.viewport.scrollbar(area, &rows);
         let scrollbar_fg = styles
             .scrollbar_thumb
             .get_fg()
             .or_else(|| styles.preview.get_fg())
             .unwrap_or(Color::White);
         for y in 0..line_count {
-            let line_idx = self.scroll + y;
+            let line_idx = self.viewport.scroll().line + y;
             let mut allowed = content_width;
             w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
             if let Some(tline) = self.lines.get(line_idx) {
@@ -251,14 +185,4 @@ impl TtyView {
         panel_skin.styles.default.queue(w, s)?;
         Ok(())
     }
-}
-
-fn is_thumb(
-    y: usize,
-    scrollbar: Option<(u16, u16)>,
-) -> bool {
-    scrollbar.is_some_and(|(sctop, scbottom)| {
-        let y = y as u16;
-        sctop <= y && y <= scbottom
-    })
 }

--- a/src/tty/tty_view.rs
+++ b/src/tty/tty_view.rs
@@ -3,11 +3,13 @@ use {
     crate::{
         command::ScrollCommand,
         display::{
+            Overflow,
+            Rows,
             Screen,
-            UnwrappedRows,
             Viewport,
             W,
             is_thumb,
+            row_starts,
         },
         errors::*,
         skin::PanelSkin,
@@ -45,6 +47,34 @@ pub struct TtyView {
     total_lines_count: usize,
 }
 
+/// The lines of a tty view, for layout by the viewport
+struct TtyRows<'v> {
+    lines: &'v [TLine],
+}
+impl Rows for TtyRows<'_> {
+    fn len(&self) -> usize {
+        self.lines.len()
+    }
+    fn row_count(
+        &self,
+        idx: usize,
+        width: usize,
+    ) -> usize {
+        crate::display::row_count(
+            self.lines[idx].strings.iter().flat_map(|ts| ts.raw.chars()),
+            width,
+        )
+    }
+    fn width_hint(
+        &self,
+        idx: usize,
+    ) -> usize {
+        // the length in bytes overestimates the width in cells,
+        // exactly for ASCII
+        self.lines[idx].strings.iter().map(|ts| ts.raw.len()).sum()
+    }
+}
+
 impl TtyView {
     pub fn new(path: &Path) -> Result<Self, io::Error> {
         let mut sv = Self {
@@ -54,7 +84,6 @@ impl TtyView {
             total_lines_count: 0,
         };
         sv.read_lines()?;
-        sv.select_first();
         Ok(sv)
     }
 
@@ -85,36 +114,20 @@ impl TtyView {
         Ok(())
     }
 
-    pub fn unselect(&mut self) {
-        self.viewport.unselect();
+    pub fn go_to_top(&mut self) {
+        self.viewport.scroll_to_top();
     }
-    pub fn try_select_y(
-        &mut self,
-        y: u16,
-    ) -> bool {
-        self.viewport.try_select_y(y, &UnwrappedRows(self.lines.len()))
-    }
-
-    pub fn select_first(&mut self) {
-        self.viewport.select_first(&UnwrappedRows(self.lines.len()));
-    }
-    pub fn select_last(&mut self) {
-        self.viewport.select_last(&UnwrappedRows(self.lines.len()));
-    }
-
-    pub fn move_selection(
-        &mut self,
-        dy: i32,
-        cycle: bool,
-    ) {
-        self.viewport.move_selection(dy, cycle, &UnwrappedRows(self.lines.len()));
+    pub fn go_to_bottom(&mut self) {
+        let rows = TtyRows { lines: &self.lines };
+        self.viewport.scroll_to_bottom(&rows);
     }
 
     pub fn try_scroll(
         &mut self,
         cmd: ScrollCommand,
     ) -> bool {
-        self.viewport.try_scroll(cmd, &UnwrappedRows(self.lines.len()))
+        let rows = TtyRows { lines: &self.lines };
+        self.viewport.try_scroll(cmd, &rows)
     }
 
     pub fn display(
@@ -123,31 +136,45 @@ impl TtyView {
         _screen: Screen,
         panel_skin: &PanelSkin,
         area: &Area,
+        overflow: Overflow,
     ) -> Result<(), ProgramError> {
-        let rows = UnwrappedRows(self.lines.len());
+        let rows = TtyRows { lines: &self.lines };
+        let content_width = area.width as usize - 1; // 1 char left for scrollbar
         self.viewport
-            .set_layout(area.height as usize, area.width as usize, false, &rows);
-        let line_count = area.height as usize;
+            .set_layout(area.height as usize, content_width, overflow, &rows);
+        let positions = self.viewport.visible_rows(&rows);
         let styles = &panel_skin.styles;
         let bg = styles
             .preview
             .get_bg()
             .or_else(|| styles.default.get_bg())
-            .unwrap_or(Color::AnsiValue(238));
-        let content_width = area.width as usize - 1; // 1 char left for scrollbar
+            .unwrap_or(Color::Reset);
         let scrollbar = self.viewport.scrollbar(area, &rows);
         let scrollbar_fg = styles
             .scrollbar_thumb
             .get_fg()
             .or_else(|| styles.preview.get_fg())
             .unwrap_or(Color::White);
-        for y in 0..line_count {
-            let line_idx = self.viewport.scroll().line + y;
+        // row starts of the line being drawn, computed once per line
+        let mut laid_out: Option<(usize, Vec<usize>)> = None;
+        for y in 0..area.height as usize {
             let mut allowed = content_width;
             w.queue(cursor::MoveTo(area.left, y as u16 + area.top))?;
-            if let Some(tline) = self.lines.get(line_idx) {
+            if let Some(&pos) = positions.get(y) {
+                let tline = &self.lines[pos.line];
                 w.queue(SetBackgroundColor(bg))?;
-                allowed -= tline.draw_in(w, allowed)?;
+                allowed -= if overflow == Overflow::Wrap {
+                    if laid_out.as_ref().is_none_or(|(idx, _)| *idx != pos.line) {
+                        let chars = tline.strings.iter().flat_map(|ts| ts.raw.chars());
+                        laid_out = Some((pos.line, row_starts(chars, content_width)));
+                    }
+                    let starts = &laid_out.as_ref().unwrap().1;
+                    let from = if pos.sub == 0 { 0 } else { starts[pos.sub - 1] };
+                    let to = starts.get(pos.sub).copied().unwrap_or(usize::MAX);
+                    tline.draw_range_in(w, allowed, from, to)?
+                } else {
+                    tline.draw_in(w, allowed)?
+                };
             }
             w.queue(SetBackgroundColor(bg))?;
             for _ in 0..allowed {
@@ -184,5 +211,33 @@ impl TtyView {
         ))?;
         panel_skin.styles.default.queue(w, s)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tty_row_counts() {
+        let mut lines = Vec::new();
+        let mut l = TLine::default();
+        l.add_tstring("\u{1b}[31m", "abcde");
+        l.add_tstring("\u{1b}[32m", "fghij");
+        lines.push(l); // 10 cells
+        let mut l = TLine::default();
+        l.add_tstring("\u{1b}[36m", "日本");
+        l.add_tstring("\u{1b}[35m", "語間");
+        lines.push(l); // 4 wide chars, 8 cells
+        let rows = TtyRows { lines: &lines };
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.row_count(0, 10), 1);
+        assert_eq!(rows.row_count(0, 5), 2);
+        assert_eq!(rows.row_count(0, 4), 3);
+        // a wide char doesn't straddle rows: 5 cells hold only 2 wide chars
+        assert_eq!(rows.row_count(1, 8), 1);
+        assert_eq!(rows.row_count(1, 5), 2);
+        assert_eq!(rows.row_count(1, 3), 4);
+        assert_eq!(rows.width_hint(0), 10);
     }
 }

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -152,6 +152,7 @@ Internals! {
     toggle_ignore: "toggle use of .gitignore and .ignore" false,
     toggle_perm: "toggle showing file permissions" false,
     toggle_preview: "open/close the preview panel" false,
+    toggle_preview_wrap: "toggle line wrapping in previews" false,
     toggle_root_fs: "toggle showing filesystem info on top" false,
     set_max_depth: "set the maximum directory depth shown" false,
     unset_max_depth: "clear the max_depth" false,

--- a/src/verb/internal.rs
+++ b/src/verb/internal.rs
@@ -107,6 +107,7 @@ Internals! {
     panel_right: "focus or open panel on right" false,
     panel_right_no_open: "either focus panel on right or close left one" false,
     parent: "move to the parent directory" false,
+    preview_auto: "preview the selection in the default mode" true,
     preview_binary: "preview the selection as binary" true,
     preview_diff: "preview the changes of the selection since the last commit" true,
     preview_image: "preview the selection as image" true,

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -143,6 +143,7 @@ impl VerbStore {
         self.add_internal(open_preview);
         self.add_internal(close_preview);
         self.add_internal(toggle_preview);
+        self.add_internal(toggle_preview_wrap);
         self.add_internal(preview_image).with_shortcut("img");
         self.add_internal(preview_text).with_shortcut("txt");
         self.add_internal(preview_binary).with_shortcut("hex");

--- a/src/verb/verb_store.rs
+++ b/src/verb/verb_store.rs
@@ -143,7 +143,8 @@ impl VerbStore {
         self.add_internal(open_preview);
         self.add_internal(close_preview);
         self.add_internal(toggle_preview);
-        self.add_internal(toggle_preview_wrap);
+        self.add_internal(toggle_preview_wrap).with_shortcut("wrap");
+        self.add_internal(preview_auto);
         self.add_internal(preview_image).with_shortcut("img");
         self.add_internal(preview_text).with_shortcut("txt");
         self.add_internal(preview_binary).with_shortcut("hex");

--- a/website/src/conf_file.md
+++ b/website/src/conf_file.md
@@ -282,6 +282,19 @@ terminal_title = "{file} 🐄"
 
 # Preview
 
+## Wrap
+
+Long lines of text, diff, and tty previews are wrapped by default.
+
+You can toggle wrapping at any time with the `:toggle_preview_wrap` verb (shortcut `:wrap`), and change the initial behavior in the conf:
+
+```Hjson
+wrap_previews: false
+```
+```TOML
+wrap_previews = false
+```
+
 ## Graphics Display
 
 `graphics_display` selects which terminal-graphics protocol broot uses for

--- a/website/src/conf_verbs.md
+++ b/website/src/conf_verbs.md
@@ -501,6 +501,7 @@ invocation | default key | default shortcut | behavior / details
 :panel_right | <kbd>ctrl</kbd><kbd>→</kbd> or <kbd>alt</kbd><kbd>→</kbd> | - | move to or open a panel to the right
 :panel_right_no_open | -  | - | move to panel to the right
 :parent | - | - | focus the parent directory
+:preview_auto | - | - | preview the selection in the default mode
 :preview_binary | - | - | preview the selection as binary
 :preview_diff | - | - | preview the changes of the selection since the last commit
 :preview_image | - | - | preview the selection as image
@@ -543,6 +544,7 @@ invocation | default key | default shortcut | behavior / details
 :toggle_ignore | - | - | toggle display of files in .gitignore and .ignore
 :toggle_perm | - | - | toggle display of permissions (not available on Windows)
 :toggle_preview | - | - | toggle display of the preview panel
+:toggle_preview_wrap | - | wrap | toggle line wrapping in previews
 :toggle_root_fs | - | - | toggle showing filesystem info on top
 :toggle_watch | - | - | toggle watching for changes and keeping the tree up to date
 :set_max_depth | - | - | set the maximum directory depth shown

--- a/website/src/panels.md
+++ b/website/src/panels.md
@@ -35,6 +35,8 @@ It's not immediately focused on creation, because most often you'll want to prev
 
 To focus it, for example to scroll it or to do a search, do <kbd>ctrl</kbd><kbd>→</kbd> again.
 
+Long lines are wrapped to the panel's width. If you prefer them truncated, use the `:toggle_preview_wrap` verb (shortcut `:wrap`) or set `wrap_previews: false` in [the conf](../conf_file/#wrap).
+
 Files that can't be interpreted as text or image are shown as binary:
 
 ![binary](img/2020081609-preview-binary.png)


### PR DESCRIPTION
By default, long lines in preview are now wrapped.
This impacts text previews, with or without syntactic coloring, unified diffs, and TTY previews
This can be toogled with `:toggle_preview_wrap` (shortcut `:wrap`), and `wrap_previews: false` in the conf disables it on start
